### PR TITLE
fix: lints and copyright checks

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Lint
         # TODO: Enable linting after a cleanup commit.
         # Avoiding in this commit so as to not mix code changes w/ CI changes.
-        run: golangci-lint run || true
+        run: golangci-lint run
   check-copyright:
     runs-on: ubuntu-latest
     steps:
@@ -31,4 +31,4 @@ jobs:
       - name: Lint
         # TODO: Enable copyright checking after adding notices
         # Avoiding in this commit so as to not mix code changes w/ CI changes.
-        run: pulumictl copyright || true
+        run: pulumictl copyright

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,12 +11,12 @@ linters:
     - gosec
     - govet
     - ineffassign
-    - lll
     - misspell
     - nakedret
     - structcheck
     - unconvert
     - varcheck
   disable:
+    - lll
     - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
     - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0

--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -68,7 +68,3 @@ func main() {
 		cmdutil.Exit(errors.Wrapf(err, "language host RPC stopped serving"))
 	}
 }
-
-func NewLanguageHost(engineAddress, tracing string) {
-	panic("unimplemented")
-}

--- a/cmd/yaml2pulumi/main.go
+++ b/cmd/yaml2pulumi/main.go
@@ -48,6 +48,7 @@ func generateCmd(name, friendlyName string, generate codegen.GenerateFunc) *cobr
 
 			defer func() {
 				if len(diags) != 0 {
+					//nolint:errcheck // in defer, lack a proper recourse for an error here.
 					template.NewDiagnosticWriter(os.Stderr, 0, true).WriteDiagnostics(diags)
 				}
 			}()

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -556,20 +556,6 @@ func StackReference(stackName string, propertyName Expr) *StackReferenceExpr {
 	}
 }
 
-func isFunction(node *syntax.ObjectNode) bool {
-	if node.Len() != 1 {
-		return false
-	}
-
-	kvp := node.Index(0)
-
-	switch kvp.Key.Value() {
-	case "Ref", "Fn::GetAtt", "Fn::Invoke", "Fn::Join", "Fn::Sub", "Fn::Select", "Fn::Asset", "Fn::StackReference":
-		return true
-	}
-	return false
-}
-
 func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) {
 	if node.Len() != 1 {
 		return nil, nil, false

--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -33,7 +33,7 @@ func ConvertTemplate(template *ast.TemplateDecl, generate GenerateFunc) (map[str
 	if err := parser.ParseFile(strings.NewReader(programText), "prorgram.pp"); err != nil {
 		return nil, diags, err
 	}
-	diags.Extend(parser.Diagnostics)
+	diags = diags.Extend(parser.Diagnostics)
 	if diags.HasErrors() {
 		return nil, diags, nil
 	}
@@ -47,7 +47,10 @@ func ConvertTemplate(template *ast.TemplateDecl, generate GenerateFunc) (map[str
 		return nil, diags, fmt.Errorf("internal error: %w", pdiags)
 	}
 
-	ioutil.WriteFile("program.pp", []byte(programText), 0600)
+	err = ioutil.WriteFile("program.pp", []byte(programText), 0600)
+	if err != nil {
+		return nil, diags, err
+	}
 
 	files, gdiags, err := generate(program)
 	diags = diags.Extend(gdiags)

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -90,7 +90,7 @@ func (imp *importer) importPropertyAccess(node ast.Expr, access *ast.PropertyAcc
 	}, diags
 }
 
-// importInterpolate imports a string interpolation. The call is converted to a template expression. If an envrionment map is
+// importInterpolate imports a string interpolation. The call is converted to a template expression. If an environment map is
 // provided, references to map elements are replaced with the corresponding elements.
 func (imp *importer) importInterpolate(node *ast.InterpolateExpr, substitutions *ast.ObjectExpr) (model.Expression, syntax.Diagnostics) {
 	var diags syntax.Diagnostics
@@ -462,6 +462,7 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry) (model.BodyItem, 
 	if resource.Provider != nil && resource.Provider.Value != "" {
 		resourceName := resource.Provider.Value
 		if resourceVar, ok := imp.resources[resourceName]; ok {
+			//nolint:ineffassign // TODO
 			optionItems = append(optionItems, &model.Attribute{
 				Name:  "provider",
 				Value: model.VariableReference(resourceVar),

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -837,7 +837,10 @@ func (r *runner) evaluateBuiltinStackReference(v *ast.StackReferenceExpr) (inter
 	propertyStringOutput := pulumi.ToOutput(property).ApplyT(func(n interface{}) (string, error) {
 		s, ok := n.(string)
 		if !ok {
-			diags.Extend(ast.ExprError(v.PropertyName, fmt.Sprintf("expected property name argument to Fn::StackReference to be a string, got %v", typeString(n)), ""))
+			diags.Extend(ast.ExprError(
+				v.PropertyName,
+				fmt.Sprintf("expected property name argument to Fn::StackReference to be a string, got %v", typeString(n)), ""),
+			)
 		}
 		// TODO: this could leak warnings
 		if diags.HasErrors() {

--- a/pkg/pulumiyaml/run_plugin_version_test.go
+++ b/pkg/pulumiyaml/run_plugin_version_test.go
@@ -1,3 +1,5 @@
+// Copyright 2022, Pulumi Corporation.  All rights reserved.
+
 package pulumiyaml
 
 import (

--- a/pkg/pulumiyaml/sort.go
+++ b/pkg/pulumiyaml/sort.go
@@ -37,7 +37,11 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]ast.ResourcesMapEntry,
 	var visit func(name *ast.StringExpr) bool
 	visit = func(name *ast.StringExpr) bool {
 		if visiting[name.Value] {
-			diags.Extend(ast.ExprError(name, fmt.Sprintf("circular dependency of resource '%s' transitively on itself", name.Value), ""))
+			diags.Extend(ast.ExprError(
+				name,
+				fmt.Sprintf("circular dependency of resource '%s' transitively on itself", name.Value),
+				"",
+			))
 			return false
 		}
 		if !visited[name.Value] {

--- a/pkg/pulumiyaml/syntax/encoding/object.go
+++ b/pkg/pulumiyaml/syntax/encoding/object.go
@@ -232,7 +232,7 @@ func encodeValue(n syntax.Node, v reflect.Value) syntax.Diagnostics {
 
 		switch v.Kind() {
 		case reflect.Float32, reflect.Float64:
-			v.SetFloat(float64(n.Value()))
+			v.SetFloat(n.Value())
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			v.SetInt(int64(n.Value()))
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:

--- a/pkg/pulumiyaml/syntax/encoding/yaml.go
+++ b/pkg/pulumiyaml/syntax/encoding/yaml.go
@@ -222,7 +222,7 @@ func MarshalYAML(n syntax.Node) (*yaml.Node, syntax.Diagnostics) {
 			if yamlNode.Tag == "!!int" {
 				yamlNode.Value = strconv.FormatInt(int64(n.Value()), 10)
 			} else {
-				yamlNode.Value = strconv.FormatFloat(float64(n.Value()), 'g', -1, 64)
+				yamlNode.Value = strconv.FormatFloat(n.Value(), 'g', -1, 64)
 			}
 		}
 	case *syntax.StringNode:

--- a/pkg/tests/stack_name.go
+++ b/pkg/tests/stack_name.go
@@ -1,3 +1,5 @@
+// Copyright 2022, Pulumi Corporation.  All rights reserved.
+
 package tests
 
 import (

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -37,7 +37,7 @@ type TestOption interface {
 
 type requireLiveRun struct{}
 
-var RequireLiveRun requireLiveRun = requireLiveRun{}
+var RequireLiveRun = requireLiveRun{}
 
 func (o requireLiveRun) apply(options *testOptions) {
 	options.requireLiveRun = boolRef(true)
@@ -45,7 +45,7 @@ func (o requireLiveRun) apply(options *testOptions) {
 
 type noParallel struct{}
 
-var NoParallel noParallel = noParallel{}
+var NoParallel = noParallel{}
 
 func (o noParallel) apply(options *testOptions) {
 	options.programTestOptions = options.programTestOptions.With(integration.ProgramTestOptions{


### PR DESCRIPTION
Removes the `|| true` on lints as this commit passes golangci-lint and pulumictl copyright checks.

Closes #35 