### PR TITLE
[ast] Parse integer subscripts as int.

### DIFF
--- a/pkg/pulumiyaml/ast/property.go
+++ b/pkg/pulumiyaml/ast/property.go
@@ -134,7 +134,7 @@ func parsePropertyAccess(node syntax.Node, access string) (string, *PropertyAcce
 					return "", nil, syntax.Diagnostics{syntax.NodeError(node, "the root property must be a string subscript or a name", "")}
 				}
 
-				indexNode, access = float64(index), access[rbracket:]
+				indexNode, access = int(index), access[rbracket:]
 			}
 			accessors, access = append(accessors, &PropertySubscript{Index: indexNode}), access[1:]
 		default:


### PR DESCRIPTION
The current parser was parsing integer subscripts as `float64` values
where the downstream code expected `int` values. Replace the use of
`float64` with `int` in the parser.

Fixes #58.