### PR TITLE
feat: reserved `pulumi` variable

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,12 +4,15 @@
 
 - [feature] Resources may specify "pluginDownloadURL" to exercise the common API signature used
   across providers for dynamic plugin acquisition.
-  
+
 - [features] Fn::Invoke arguments may contain outputs from other resources
 
 - [features] Fn::Asset supports FileArchive, RemoteArchive modes
 
 - [features] variables top level item implemented, can use variables to store intermediates to
   simplify invokes or re-use values
+
+- [features] built-in variable "pulumi", which is a map with a "cwd", "stack", and "project" to
+  obtain the current working directory, stack name, and project name respectively.
 
 ### Bug Fixes

--- a/examples/pulumi-variable/Pulumi.yaml
+++ b/examples/pulumi-variable/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-reserved-variable
+runtime: yaml
+main: ./working-dir

--- a/examples/pulumi-variable/working-dir/Main.yaml
+++ b/examples/pulumi-variable/working-dir/Main.yaml
@@ -1,0 +1,4 @@
+outputs:
+  cwd: "${pulumi.cwd}"
+  stack: "${pulumi.stack}"
+  project: "${pulumi.project}"

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -243,6 +243,16 @@ func newRunner(ctx *pulumi.Context, t *ast.TemplateDecl) *runner {
 func (r *runner) Evaluate() syntax.Diagnostics {
 	var diags syntax.Diagnostics
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		return syntax.Diagnostics{syntax.Error(nil, err.Error(), "")}
+	}
+	r.variables["pulumi"] = map[string]interface{}{
+		"cwd":     cwd,
+		"project": r.ctx.Project(),
+		"stack":   r.ctx.Stack(),
+	}
+
 	// Topologically sort the intermediates based on implicit and explicit dependencies
 	intermediates, rdiags := topologicallySortedResources(r.t)
 	if rdiags.HasErrors() {

--- a/pkg/pulumiyaml/sort.go
+++ b/pkg/pulumiyaml/sort.go
@@ -166,6 +166,10 @@ func checkUniqueNode(intermediates map[string]graphNode, node graphNode) syntax.
 
 	key := node.key()
 	name := key.Value
+	if name == "pulumi" {
+		return syntax.Diagnostics{ast.ExprError(key, fmt.Sprintf("%s %s uses the reserved name pulumi", node.valueKind(), name), "")}
+	}
+
 	if other, found := intermediates[name]; found {
 		if node.valueKind() == other.valueKind() {
 			diags.Extend(ast.ExprError(key, fmt.Sprintf("found duplicate %s %s", node.valueKind(), name), ""))

--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -133,3 +133,22 @@ func TestExampleWebserver(t *testing.T) {
 func TestExampleWebserverJson(t *testing.T) {
 	testWrapper(t, exampleDir("webserver-json"), ExpectRefreshChanges, RequireLiveRun, awsConfig)
 }
+
+func TestExamplePulumiVariable(t *testing.T) {
+	testWrapper(t, exampleDir("pulumi-variable"),
+		RequireLiveRun,
+		Validator{func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			cwdOutput, isString := stack.Outputs["cwd"].(string)
+			assert.True(t, isString)
+			assert.True(t, strings.HasSuffix(cwdOutput, "working-dir"))
+
+			stackOutput, isString := stack.Outputs["stack"].(string)
+			assert.True(t, isString)
+			assert.Equal(t, string(stack.StackName), stackOutput)
+
+			projectOutput, isString := stack.Outputs["project"].(string)
+			assert.True(t, isString)
+			assert.Equal(t, "pulumi-reserved-variable", projectOutput)
+		}},
+	)
+}


### PR DESCRIPTION
Implements #76.

Allows stacks to reference and interpolate in the current working directory, the stack name, and project name.