### PR TITLE
fix: allowing arbitrary expressions in Default of a configuration key

### DIFF
--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -247,7 +247,7 @@ type ConfigParamDecl struct {
 	declNode
 
 	Type    *StringExpr
-	Default Expr
+	Default *StringExpr
 	Secret  *BooleanExpr
 }
 
@@ -255,7 +255,7 @@ func (d *ConfigParamDecl) recordSyntax() *syntax.Node {
 	return &d.syntax
 }
 
-func ConfigParamSyntax(node *syntax.ObjectNode, typ *StringExpr, defaultValue Expr,
+func ConfigParamSyntax(node *syntax.ObjectNode, typ *StringExpr, defaultValue *StringExpr,
 	secret *BooleanExpr) *ConfigParamDecl {
 
 	return &ConfigParamDecl{
@@ -266,7 +266,7 @@ func ConfigParamSyntax(node *syntax.ObjectNode, typ *StringExpr, defaultValue Ex
 	}
 }
 
-func ConfigParam(typ *StringExpr, defaultValue Expr, secret *BooleanExpr) *ConfigParamDecl {
+func ConfigParam(typ *StringExpr, defaultValue *StringExpr, secret *BooleanExpr) *ConfigParamDecl {
 	return ConfigParamSyntax(nil, typ, defaultValue, secret)
 }
 


### PR DESCRIPTION
This was an undocumented feature, more or less, and we remove it in favor of requiring the `configuration` key to be statically known at the start of evaluation. Interestingly, we don't parse the default value, so this does mean (right now) we can't represent a number or list of numbers with a default, but that's out of scope.

@pgavlin for your review, this just walls off this mis-feature for now so we don't depend on it writing examples. I'd like to later build support for our standard config types such as a map, list, and to also allow "type" to be more expressive. Related to that:

Related:
- pulumi/pulumi#2307
- pulumi/pulumi#1052

