### PR TITLE
[feature] Add support for Fn::Split.

### DIFF
--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -16,6 +16,11 @@ import (
 const example = `
 name: simple-yaml
 runtime: yaml
+variables:
+  join:
+    Fn::Join: [ ",", [ "a", "b", "c" ] ]
+  split:
+    Fn::Split: [ ",", "${join}" ]
 resources:
   my-bucket:
     type: aws:s3/bucket:Bucket

--- a/pkg/pulumiyaml/expr.go
+++ b/pkg/pulumiyaml/expr.go
@@ -62,6 +62,5 @@ func getExpressionDependencies(deps *[]*ast.StringExpr, x ast.Expr) {
 		*deps = append(*deps, x.ResourceName)
 	case ast.BuiltinExpr:
 		getExpressionDependencies(deps, x.Args())
-
 	}
 }


### PR DESCRIPTION
Like its CloudFormation counterpart, Fn::Split accepts a delimiter and a
value to split. Both arguments must evaluate to strings.