### PR TITLE
Deduplicate plugin listings

### DIFF
--- a/pkg/pulumiyaml/run_plugin_version_test.go
+++ b/pkg/pulumiyaml/run_plugin_version_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionValueComplex(t *testing.T) {
@@ -22,7 +23,8 @@ resources:
 `
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
-	plugins := GetReferencedPlugins(tmpl)
+	plugins, diags := GetReferencedPlugins(tmpl)
+	assert.False(t, diags.HasErrors())
 
 	got := plugins
 	want := autogold.Want("test-plugins", []Plugin{{
@@ -31,7 +33,7 @@ resources:
 	}})
 	want.Equal(t, got)
 
-	diags := testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
+	diags = testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
 	requireNoErrors(t, tmpl, diags)
 }
 
@@ -48,7 +50,8 @@ resources:
 `
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
-	plugins := GetReferencedPlugins(tmpl)
+	plugins, diags := GetReferencedPlugins(tmpl)
+	assert.False(t, diags.HasErrors())
 
 	got := plugins
 	want := autogold.Want("test-plugins", []Plugin{{
@@ -57,7 +60,7 @@ resources:
 	}})
 	want.Equal(t, got)
 
-	diags := testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
+	diags = testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
 	requireNoErrors(t, tmpl, diags)
 }
 
@@ -74,7 +77,8 @@ resources:
 `
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
-	plugins := GetReferencedPlugins(tmpl)
+	plugins, diags := GetReferencedPlugins(tmpl)
+	assert.False(t, diags.HasErrors())
 
 	got := plugins
 	want := autogold.Want("test-plugins", []Plugin{{
@@ -83,7 +87,7 @@ resources:
 	}})
 	want.Equal(t, got)
 
-	diags := testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
+	diags = testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
 	requireNoErrors(t, tmpl, diags)
 }
 
@@ -145,7 +149,8 @@ outputs:
   `
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
-	plugins := GetReferencedPlugins(tmpl)
+	plugins, diags := GetReferencedPlugins(tmpl)
+	assert.False(t, diags.HasErrors())
 
 	gotPlugins := plugins
 	wantPlugins := autogold.Want("test-plugins", []Plugin{
@@ -153,12 +158,70 @@ outputs:
 			Package: "aws",
 			Version: "4.37.1",
 		},
-		{Package: "aws"},
-		{Package: "aws"},
-		{Package: "aws"},
 	})
 	wantPlugins.Equal(t, gotPlugins)
 
-	_, diags := topologicallySortedResources(tmpl)
+	_, diags = topologicallySortedResources(tmpl)
 	requireNoErrors(t, tmpl, diags)
+}
+
+func TestVersionDuplicate(t *testing.T) {
+	const text = `
+name: test-yaml
+runtime: yaml
+resources:
+  res-a:
+    type: test:resource:type
+    options:
+      version: 1.23.425-beta.6
+      pluginDownloadURL: https://example.com
+    properties: {}
+  res-b:
+    type: test:resource:type
+    options:
+      version: 1.23.425-beta.6
+      pluginDownloadURL: https://example.com
+    properties: {}
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	plugins, diags := GetReferencedPlugins(tmpl)
+	assert.False(t, diags.HasErrors())
+
+	got := plugins
+	want := autogold.Want("test-plugins", []Plugin{{
+		Package:           "test",
+		Version:           "1.23.425-beta.6",
+		PluginDownloadURL: "https://example.com",
+	}})
+	want.Equal(t, got)
+
+	diags = testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
+	requireNoErrors(t, tmpl, diags)
+}
+
+func TestVersionConflicts(t *testing.T) {
+	const text = `
+name: test-yaml
+runtime: yaml
+resources:
+  res-a:
+    type: test:resource:type
+    options:
+      version: 1.23.425-beta.6
+      pluginDownloadURL: https://example.com
+    properties: {}
+  res-b:
+    type: test:resource:type
+    options:
+      version: '2.0'
+      pluginDownloadURL: https://example.com/v2
+    properties: {}
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	plugins, diags := GetReferencedPlugins(tmpl)
+	assert.Contains(t, diagString(diags[0]), "<stdin>:13:16: Provider test already declared with a conflicting version: 1.23.425-beta.6")
+	assert.Contains(t, diagString(diags[1]), "<stdin>:14:26: Provider test already declared with a conflicting plugin download URL: https://example.com")
+	assert.Empty(t, plugins)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,7 +55,10 @@ func (host *yamlLanguageHost) GetRequiredPlugins(ctx context.Context,
 		return nil, diags
 	}
 
-	pkgs := pulumiyaml.GetReferencedPlugins(tmpl)
+	pkgs, diags := pulumiyaml.GetReferencedPlugins(tmpl)
+	if diags.HasErrors() {
+		return nil, diags
+	}
 	var plugins []*pulumirpc.PluginDependency
 	for _, pkg := range pkgs {
 		plugins = append(plugins, &pulumirpc.PluginDependency{


### PR DESCRIPTION
This also adds diagnostic errors when a single provider is provided with mutually incompatible version information.

Technically, that's not an issue for our engine, but it could be confusing in YAML and we'll prevent it for now. It seems more likely that it's user error if two different versions are specified.

We'll use this de-duplicated plugin list to determine which plugins to host and get schema from.

Based off of #106, only top commit needs to be reviewed.