### PR TITLE
Translate `Fn::GetAtt [ foo, bar ]` as `foo.bar`

### DIFF
--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -236,7 +236,6 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 		return &model.ScopeTraversalExpression{
 			Traversal: hcl.Traversal{
 				hcl.TraverseRoot{Name: resourceVar.Name},
-				hcl.TraverseAttr{Name: "attributes"},
 				hcl.TraverseAttr{Name: propertyName},
 			},
 			Parts: []model.Traversable{

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -40,7 +40,6 @@ var (
 	failingExamples = []string{
 		"azure-container-apps",
 		"azure-app-service",
-		"webserver-json",
 		"stackreference-consumer",
 	}
 
@@ -54,6 +53,7 @@ var (
 		"azure-static-website":    AllLanguages(),
 		"aws-static-website":      AllLanguages(),
 		"webserver":               AllLanguages().Except(Nodejs),
+		"webserver-json":          AllLanguages().Except(Nodejs),
 		"aws-eks":                 AllLanguages().Except(Python),
 	}
 

--- a/pkg/tests/transpiled_examples/webserver-json/nodejs/index.ts
+++ b/pkg/tests/transpiled_examples/webserver-json/nodejs/index.ts
@@ -1,0 +1,31 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+const instanceType = config.get("instanceType") || "t3.micro";
+const webSecGrp = new aws.ec2.SecurityGroup("webSecGrp", {ingress: [{
+    protocol: "tcp",
+    fromPort: 80,
+    toPort: 80,
+    cidrBlocks: ["0.0.0.0/0"],
+}]});
+const webServer = new aws.ec2.Instance("webServer", {
+    instanceType: instanceType,
+    ami: aws.getAmi({
+        filters: [{
+            name: "name",
+            values: ["amzn-ami-hvm-*-x86_64-ebs"],
+        }],
+        owners: ["137112412989"],
+        mostRecent: true,
+    }).then(invoke => invoke.id),
+    userData: webSecGrp.arn.apply(arn => [
+        "#!/bin/bash",
+        `echo 'Hello, World from ${arn}!' > index.html`,
+        "nohup python -m SimpleHTTPServer 80 &",
+    ].join("\n")),
+    vpcSecurityGroupIds: [webSecGrp.id],
+});
+export const instanceId = webServer.id;
+export const publicIp = webServer.publicIp;
+export const publicHostName = webServer.publicDns;

--- a/pkg/tests/transpiled_examples/webserver-json/program.pp
+++ b/pkg/tests/transpiled_examples/webserver-json/program.pp
@@ -34,9 +34,9 @@ output instanceId {
 }
 
 output publicIp {
-	value = webServer.attributes.publicIp
+	value = webServer.publicIp
 }
 
 output publicHostName {
-	value = webServer.attributes.publicDns
+	value = webServer.publicDns
 }


### PR DESCRIPTION
This enables the `webserver-json` example to emit valid PCL. 

I want to confirm that the YAML -> PCL translation is correct. Right now it seems to me that we could remove `Fn::GetAtt` without loosing expressive power. 