### PR TITLE
Add *good* error messages for extra fields on resources. 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
-* Update pulumi/pulumi to v3.32.1
+- Update pulumi/pulumi to v3.32.1
+
+- Add errors when hanging invalid fields off of resources.  
+  [#203](https://github.com/pulumi/pulumi-yaml/pull/203)
 
 ### Bug Fixes

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -66,14 +66,14 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 	}
 	if s := v.Syntax(); s != nil {
 		if o, ok := s.(*syntax.ObjectNode); ok {
-			valid := []string{"type", "properties", "options", "condition", "metadata"}
+			validKeys := []string{"type", "properties", "options", "condition", "metadata"}
 			fmtr := yamldiags.InvalidFieldBagFormatter{
 				ParentLabel: fmt.Sprintf("Resource %s", typ.String()),
 				MaxListed:   5,
 				Bags: []yamldiags.TypeBag{
 					{Name: "properties", Properties: allProperties},
 					{Name: "options", Properties: allOptions},
-					{Name: k, Properties: valid},
+					{Name: k, Properties: validKeys},
 				},
 				DistanceLimit: 3,
 			}
@@ -81,14 +81,14 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 				prop := o.Index(i)
 				key := prop.Key.Value()
 				keyLower := strings.ToLower(key)
-				isValid := false
-				for _, k := range valid {
+				valid := false
+				for _, k := range validKeys {
 					if k == keyLower {
-						isValid = true
+						valid = true
 						break
 					}
 				}
-				if isValid {
+				if valid {
 					// This is a valid option, so we don't error
 					continue
 				}

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -78,7 +78,8 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 				prop := o.Index(i)
 				key := prop.Key.Value()
 				keyLower := strings.ToLower(key)
-				if keyLower == "type" || keyLower == "properties" || keyLower == "options" {
+				if keyLower == "type" || keyLower == "properties" || keyLower == "options" ||
+					keyLower == "condition" || keyLower == "metadata" {
 					// This is a valid option, so we don't error
 					continue
 				}

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -4,6 +4,8 @@ package pulumiyaml
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/ast"
@@ -25,9 +27,9 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 		return true
 	}
 	hint := pkg.ResourceTypeHint(typ)
-	fields := hint.InputProperties()
+	properties := hint.InputProperties()
 	var allProperties []string
-	for k := range fields {
+	for k := range properties {
 		allProperties = append(allProperties, k)
 	}
 	fmtr := yamldiags.NonExistantFieldFormatter{
@@ -38,7 +40,7 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 	}
 
 	for _, kvp := range v.Properties.Entries {
-		if typ, hasField := fields[kvp.Key.Value]; !hasField {
+		if typ, hasField := properties[kvp.Key.Value]; !hasField {
 			summary, detail := fmtr.MessageWithDetail(kvp.Key.Value, fmt.Sprintf("Property %s", kvp.Key.Value))
 			subject := kvp.Key.Syntax().Syntax().Range()
 			valueRange := kvp.Value.Syntax().Syntax().Range()
@@ -49,7 +51,6 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 				Detail:      detail,
 				Subject:     subject,
 				Context:     &context,
-				Expression:  nil,
 				EvalContext: &hcl.EvalContext{},
 			})
 		} else {
@@ -57,6 +58,45 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 		}
 	}
 	tc.resources[node.Value] = hint.Fields()
+
+	options := ResourceOptionsTypeHint()
+	allOptions := make([]string, 0, len(options))
+	for k := range options {
+		allOptions = append(allOptions, k)
+	}
+	if s := v.Syntax(); s != nil {
+		if o, ok := s.(*syntax.ObjectNode); ok {
+			fmtr := yamldiags.InvalidFieldBagFormatter{
+				ParentLabel: fmt.Sprintf("Resource %s", typ.String()),
+				MaxListed:   5,
+				Bags: []yamldiags.TypeBag{
+					{Name: "properties", Properties: allProperties},
+					{Name: "options", Properties: allOptions},
+				},
+			}
+			for i := 0; i < o.Len(); i++ {
+				prop := o.Index(i)
+				key := prop.Key.Value()
+				keyLower := strings.ToLower(key)
+				if keyLower == "type" || keyLower == "properties" || keyLower == "options" {
+					// This is a valid option, so we don't error
+					continue
+				}
+				summary, detail := fmtr.MessageWithDetail(key)
+				if match := fmtr.ExactMatching(key); len(match) == 1 {
+					detail += fmt.Sprintf(", e.g.\n\n%s:\n  # ...\n  %s:\n    %s: %s",
+						k, match[0], key, prop.Value)
+				}
+
+				ctx.addDiag(&syntax.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  summary,
+					Detail:   detail,
+					Subject:  prop.Key.Syntax().Range(),
+				})
+			}
+		}
+	}
 	return true
 }
 
@@ -322,4 +362,18 @@ func (e walker) walkStringList(ctx *evalContext, l *ast.StringListDecl) bool {
 		}
 	}
 	return true
+}
+
+// Compute the set of fields valid for the resource options.
+func ResourceOptionsTypeHint() FieldsTypeHint {
+	typ := reflect.TypeOf(ast.ResourceOptionsDecl{})
+	m := FieldsTypeHint{}
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		m[f.Name] = nil
+	}
+	return m
 }

--- a/pkg/pulumiyaml/diags/diags.go
+++ b/pkg/pulumiyaml/diags/diags.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // A formatter for when a field or property is used that does not exist.
@@ -136,9 +134,8 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 		addBag(bags[0])
 	} else {
 		detail += "one of the following:\n"
-		contract.Assertf(len(bags) <= 26, "You need to letter more items then exist letters")
-		for i, bag := range bags {
-			detail += fmt.Sprintf("  %c) ", i+'a')
+		for _, bag := range bags {
+			detail += fmt.Sprintf("  * ")
 			addBag(bag)
 			detail += "\n"
 		}

--- a/pkg/pulumiyaml/diags/diags.go
+++ b/pkg/pulumiyaml/diags/diags.go
@@ -104,13 +104,29 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 	// We have an exact match, so only show exact matches.
 	if bags[0].rank == 0 {
 		names := e.ExactMatching(field)
-		detail := fmt.Sprintf("'%s' exists under %s", field, HumanList(names))
+		detail := fmt.Sprintf("'%s' exists under %s", field, AndList(names))
 		return summary, detail
 	}
 
 	// We have matches but none are exact
-	// TODO
 	detail := fmt.Sprintf("Did you mean ")
+	addBag := func(bag BagOrdering) {
+		if len(bag.BagName) == 1 {
+			detail += fmt.Sprintf("%s under %s", bag.Property, bag.BagName[0])
+		} else {
+			detail += fmt.Sprintf("%s under either %s", bag.Property, OrList(bag.BagName))
+		}
+	}
+	if len(bags) == 1 {
+		addBag(bags[0])
+	} else {
+		detail += "any of:\n"
+		for _, bag := range bags {
+			detail += "  - "
+			addBag(bag)
+			detail += "\n"
+		}
+	}
 	return summary, detail
 }
 

--- a/pkg/pulumiyaml/diags/diags.go
+++ b/pkg/pulumiyaml/diags/diags.go
@@ -122,7 +122,7 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 	}
 
 	// We have matches but none are exact
-	detail := fmt.Sprintf("You may have meant ")
+	detail := fmt.Sprintf("Did you mean ")
 	addBag := func(bag BagOrdering) {
 		if len(bag.BagName) == 1 {
 			detail += fmt.Sprintf("%s under %s", bag.Property, bag.BagName[0])

--- a/pkg/pulumiyaml/diags/diags.go
+++ b/pkg/pulumiyaml/diags/diags.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // A formatter for when a field or property is used that does not exist.
@@ -122,7 +124,7 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 	}
 
 	// We have matches but none are exact
-	detail := fmt.Sprintf("Did you mean ")
+	detail := fmt.Sprintf("You may have meant ")
 	addBag := func(bag BagOrdering) {
 		if len(bag.BagName) == 1 {
 			detail += fmt.Sprintf("%s under %s", bag.Property, bag.BagName[0])
@@ -133,9 +135,10 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 	if len(bags) == 1 {
 		addBag(bags[0])
 	} else {
-		detail += "any of:\n"
-		for _, bag := range bags {
-			detail += "  - "
+		detail += "one of the following:\n"
+		contract.Assertf(len(bags) <= 26, "You need to letter more items then exist letters")
+		for i, bag := range bags {
+			detail += fmt.Sprintf("  %c) ", i+'a')
 			addBag(bag)
 			detail += "\n"
 		}

--- a/pkg/pulumiyaml/diags/diags.go
+++ b/pkg/pulumiyaml/diags/diags.go
@@ -4,6 +4,7 @@ package diags
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -46,4 +47,105 @@ func (e NonExistantFieldFormatter) messageBody(field string) string {
 		list = fmt.Sprintf("%s and %d others", strings.Join(existing[:5], ", "), len(existing)-e.MaxElements)
 	}
 	return fmt.Sprintf("Existing %s are: %s", e.fieldsName(), list)
+}
+
+// A formatter for missing fields that may be valid in other places.
+type InvalidFieldBagFormatter struct {
+	ParentLabel string
+	Bags        []TypeBag
+	// The maximum number of fields to return. `MaxListed` <= 0 implies return all fields.
+	MaxListed int
+}
+
+type TypeBag struct {
+	Name       string
+	Properties []string
+}
+
+func (e InvalidFieldBagFormatter) BagList(field string) []BagOrdering {
+	bags := suggestBag(field, e.Bags)
+
+	if e.MaxListed > 0 {
+		b := []BagOrdering{}
+		for i := 0; i < e.MaxListed && i < len(bags); i++ {
+			b = append(b, bags[i])
+		}
+		bags = b
+	}
+	return bags
+}
+
+// The list of bags that exactly match `field`.
+func (e InvalidFieldBagFormatter) ExactMatching(field string) []string {
+	m := map[string]struct{}{}
+	for _, bag := range e.BagList(field) {
+		if bag.rank == 0 {
+			for _, name := range bag.BagName {
+				m[name] = struct{}{}
+			}
+		}
+	}
+	names := make([]string, 0, len(m))
+	for bag := range m {
+		names = append(names, bag)
+	}
+	return names
+}
+
+func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, string) {
+	bags := e.BagList(field)
+	summary := fmt.Sprintf("%s has invalid key '%s'", e.ParentLabel, field)
+
+	// No matches, so say nothing
+	if len(bags) == 0 {
+		return summary, ""
+	}
+
+	// We have an exact match, so only show exact matches.
+	if bags[0].rank == 0 {
+		names := e.ExactMatching(field)
+		detail := fmt.Sprintf("'%s' exists under %s", field, HumanList(names))
+		return summary, detail
+	}
+
+	// We have matches but none are exact
+	// TODO
+	detail := fmt.Sprintf("Did you mean ")
+	return summary, detail
+}
+
+type BagOrdering struct {
+	// Which bags `Property` belongs in.
+	BagName []string
+	// The name of the property
+	Property string
+
+	// Computed edit distance from the `field` that this was created from.
+	rank int
+}
+
+// Infer which of several property bags a value is most likely to be in.
+func suggestBag(field string, bags []TypeBag) []BagOrdering {
+	places := map[string]BagOrdering{}
+	for _, bag := range bags {
+		for _, prop := range bag.Properties {
+			existing, ok := places[prop]
+			if !ok {
+				existing = BagOrdering{
+					Property: prop,
+				}
+			}
+			existing.BagName = append(existing.BagName, bag.Name)
+			places[prop] = existing
+		}
+	}
+	orderedPlaces := make([]BagOrdering, 0, len(places))
+	for _, p := range places {
+		p.rank = editDistance(field, p.Property)
+		orderedPlaces = append(orderedPlaces, p)
+	}
+	sort.Slice(orderedPlaces, func(i, j int) bool {
+		return orderedPlaces[i].rank < orderedPlaces[j].rank
+	})
+	return orderedPlaces
 }

--- a/pkg/pulumiyaml/diags/diags.go
+++ b/pkg/pulumiyaml/diags/diags.go
@@ -55,6 +55,8 @@ type InvalidFieldBagFormatter struct {
 	Bags        []TypeBag
 	// The maximum number of fields to return. `MaxListed` <= 0 implies return all fields.
 	MaxListed int
+	// The degree of (edit) distance between the field typed and suggested.
+	DistanceLimit int
 }
 
 type TypeBag struct {
@@ -64,6 +66,17 @@ type TypeBag struct {
 
 func (e InvalidFieldBagFormatter) BagList(field string) []BagOrdering {
 	bags := suggestBag(field, e.Bags)
+
+	if e.DistanceLimit != 0 {
+		b := []BagOrdering{}
+		for _, bag := range bags {
+			if bag.rank > e.DistanceLimit {
+				break
+			}
+			b = append(b, bag)
+		}
+		bags = b
+	}
 
 	if e.MaxListed > 0 {
 		b := []BagOrdering{}
@@ -114,7 +127,7 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 		if len(bag.BagName) == 1 {
 			detail += fmt.Sprintf("%s under %s", bag.Property, bag.BagName[0])
 		} else {
-			detail += fmt.Sprintf("%s under either %s", bag.Property, OrList(bag.BagName))
+			detail += fmt.Sprintf("%s under keys %s", bag.Property, AndList(bag.BagName))
 		}
 	}
 	if len(bags) == 1 {

--- a/pkg/pulumiyaml/diags/utils.go
+++ b/pkg/pulumiyaml/diags/utils.go
@@ -63,18 +63,29 @@ func sortByEditDistance(words []string, comparedTo string) []string {
 	return w
 }
 
-// A list that displays in a human readable format.
-type HumanList []string
+// A list that displays in the human readable format: "a, b and c".
+type AndList []string
 
-func (h HumanList) String() string {
+func (h AndList) String() string {
+	return displayList(h, "and")
+}
+
+// A list that displays in the human readable format: "a, b or c".
+type OrList []string
+
+func (h OrList) String() string {
+	return displayList(h, "or")
+}
+
+func displayList(h []string, conjuctor string) string {
 	switch len(h) {
 	case 0:
 		return ""
 	case 1:
 		return h[0]
 	case 2:
-		return fmt.Sprintf("%s and %s", h[0], h[1])
+		return fmt.Sprintf("%s %s %s", h[0], conjuctor, h[1])
 	default:
-		return fmt.Sprintf("%s, %s", h[0], HumanList(h[1:]))
+		return fmt.Sprintf("%s, %s", h[0], displayList(h[1:], conjuctor))
 	}
 }

--- a/pkg/pulumiyaml/diags/utils.go
+++ b/pkg/pulumiyaml/diags/utils.go
@@ -2,7 +2,10 @@
 
 package diags
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // editDistance calculates the Levenshtein distance between words a and b.
 func editDistance(a, b string) int {
@@ -58,4 +61,20 @@ func sortByEditDistance(words []string, comparedTo string) []string {
 		return v(w[i]) < v(w[j])
 	})
 	return w
+}
+
+// A list that displays in a human readable format.
+type HumanList []string
+
+func (h HumanList) String() string {
+	switch len(h) {
+	case 0:
+		return ""
+	case 1:
+		return h[0]
+	case 2:
+		return fmt.Sprintf("%s and %s", h[0], h[1])
+	default:
+		return fmt.Sprintf("%s, %s", h[0], HumanList(h[1:]))
+	}
 }

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -291,7 +291,6 @@ resources:
       foo: oof
   comp-a:
     type: test:component:type
-    component: true
     properties:
       foo: ${res-a.bar}
 outputs:
@@ -584,7 +583,6 @@ func TestJSON(t *testing.T) {
 		},
 		"comp-a": {
 			"type": "test:component:type",
-			"component": true,
 			"properties": {
 				"foo": "${res-a.bar}"
 			}


### PR DESCRIPTION
Fixes #197

Since this adds a hard error, this change is a breaking change. We are in since we haven't hit 1.0, I think this is ok.

The generated error looks like:
```
❯ pulumi preview
Previewing update (dev)

View Live: https://app.pulumi.com/iwahbe/yaml-example/dev/previews/7e608ff4-33dc-41b8-ad8e-c8561a4198a4

     Type                 Name              Plan       Info
 +   pulumi:pulumi:Stack  yaml-example-dev  create     2 errors; 8 messages
 
Diagnostics:
  pulumi:pulumi:Stack (yaml-example-dev):
    error: Error: Resource aws:s3/bucket:Bucket has invalid key 'bucket'
    
      on Pulumi.yaml line 8:
       8:     bucket: "my-bucket-name"
    
    'bucket' exists under properties, e.g.
    
    myBucket:
      # ...
      properties:
        bucket: my-bucket-name
    error: an unhandled error occurred: failed to evaluate template
 
    Error: Resource aws:s3/bucket:Bucket has invalid key 'bucket'
      on Pulumi.yaml line 8:
       8:     bucket: "my-bucket-name"
    'bucket' exists under properties, e.g.
    myBucket:
      # ...
      properties:
        bucket: my-bucket-name
```

If there isn't an exact match, we provide up to 5 suggestions. We ensure that all suggestions are within a certain (3) edit distance. This is a hyper parameter we should experiment with tuning.

```
X pulumi preview
Previewing update (dev)

View Live: https://app.pulumi.com/iwahbe/yaml-example/dev/previews/37736e47-5651-4aa1-a009-bbc3e3339424

     Type                 Name              Plan       Info
 +   pulumi:pulumi:Stack  yaml-example-dev  create     2 errors; 6 messages
 
Diagnostics:
  pulumi:pulumi:Stack (yaml-example-dev):
    error: Error: Resource aws:s3/bucket:Bucket has invalid key 'version'
    
      on Pulumi.yaml line 8:
       8:     version: 1.2.3
    
    Did you mean any of:
      - Version under options
      - versioning under properties
    error: an unhandled error occurred: failed to evaluate template
 
    Error: Resource aws:s3/bucket:Bucket has invalid key 'version'
      on Pulumi.yaml line 8:
       8:     version: 1.2.3
    Did you mean any of:
      - Version under options
      - versioning under properties
 ```