### PR TITLE
De-duplicate errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
-* Update pulumi/pulumi to v3.32.1
+- Update pulumi/pulumi to v3.32.1
 
 ### Bug Fixes
+
+- De-duplicate error message added during pre-eval checking.  
+  [#207](https://github.com/pulumi/pulumi-yaml/pull/207)

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -43,15 +43,7 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 			subject := kvp.Key.Syntax().Syntax().Range()
 			valueRange := kvp.Value.Syntax().Syntax().Range()
 			context := hcl.RangeOver(*subject, *valueRange)
-			ctx.addDiag(&syntax.Diagnostic{
-				Severity:    hcl.DiagError,
-				Summary:     summary,
-				Detail:      detail,
-				Subject:     subject,
-				Context:     &context,
-				Expression:  nil,
-				EvalContext: &hcl.EvalContext{},
-			})
+			ctx.addDiag(syntax.Error(subject, summary, detail).WithContext(&context))
 		} else {
 			tc.exprs[kvp.Value] = typ
 		}
@@ -80,14 +72,10 @@ func (tc *typeCache) typeInvoke(ctx *evalContext, t *ast.InvokeExpr) bool {
 	for _, prop := range t.CallArgs.Entries {
 		k := prop.Key.(*ast.StringExpr).Value
 		if typ, ok := inputs[k]; !ok {
-			msg, detail := fmtr.MessageWithDetail(k, k)
-			ctx.addDiag(&syntax.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  msg,
-				Detail:   detail,
-				Subject:  prop.Key.Syntax().Syntax().Range(),
-				Context:  t.Syntax().Syntax().Range(),
-			})
+			summary, detail := fmtr.MessageWithDetail(k, k)
+			subject := prop.Key.Syntax().Syntax().Range()
+			context := t.Syntax().Syntax().Range()
+			ctx.addDiag(syntax.Error(subject, summary, detail).WithContext(context))
 		} else {
 			tc.exprs[prop.Value] = typ
 		}

--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -50,7 +50,7 @@ func ConvertTemplateIL(template *ast.TemplateDecl, loader schema.Loader) (string
 	}
 
 	templateBody, tdiags := ImportTemplate(template, pulumiyaml.NewPackageLoaderFromSchemaLoader(loader))
-	diags = diags.Extend(hcl.Diagnostics(tdiags))
+	diags = diags.Extend(tdiags.HCL())
 	if diags.HasErrors() {
 		return "", diags, nil
 	}

--- a/pkg/pulumiyaml/codegen/eject.go
+++ b/pkg/pulumiyaml/codegen/eject.go
@@ -110,5 +110,5 @@ func LoadTemplate(dir string) (*workspace.Project, *ast.TemplateDecl, hcl.Diagno
 
 	// unset this, as we've already parsed the YAML program in "main" and it won't be valid for convert
 	proj.Main = ""
-	return proj, t, hcl.Diagnostics(diags), err
+	return proj, t, diags.HCL(), err
 }

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -255,7 +255,6 @@ func (ctx *evalContext) addDiag(diag *syntax.Diagnostic) {
 	if err != nil {
 		err = ctx.ctx.Log.Error(fmt.Sprintf("internal error: %v", err), &pulumi.LogArgs{})
 	} else {
-		diag.Shown = true
 		s := buf.String()
 		// We strip off the appropriate HCL error message, since it will be
 		// added back on via the pulumi.Log framework.
@@ -270,6 +269,8 @@ func (ctx *evalContext) addDiag(diag *syntax.Diagnostic) {
 	}
 	if err != nil {
 		os.Stderr.Write([]byte(err.Error()))
+	} else {
+		diag.Shown = true
 	}
 }
 

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
@@ -243,16 +244,29 @@ func (ctx *evalContext) error(expr ast.Expr, summary string) (interface{}, bool)
 }
 
 func (ctx *evalContext) addDiag(diag *syntax.Diagnostic) {
-	ctx.sdiags.Extend(diag)
-	ctx.runner.sdiags.Extend(diag)
+	defer func() {
+		ctx.sdiags.Extend(diag)
+		ctx.runner.sdiags.Extend(diag)
+	}()
 
 	var buf bytes.Buffer
 	w := ctx.t.NewDiagnosticWriter(&buf, 0, false)
-	err := w.WriteDiagnostic(diag)
+	err := w.WriteDiagnostic(diag.HCL())
 	if err != nil {
 		err = ctx.ctx.Log.Error(fmt.Sprintf("internal error: %v", err), &pulumi.LogArgs{})
 	} else {
-		err = ctx.ctx.Log.Error(buf.String(), &pulumi.LogArgs{})
+		diag.Shown = true
+		s := buf.String()
+		// We strip off the appropriate HCL error message, since it will be
+		// added back on via the pulumi.Log framework.
+		switch diag.Severity {
+		case hcl.DiagWarning:
+			s = strings.TrimPrefix(s, "Warning: ")
+			err = ctx.ctx.Log.Warn(s, &pulumi.LogArgs{})
+		default:
+			s = strings.TrimPrefix(s, "Error: ")
+			err = ctx.ctx.Log.Error(s, &pulumi.LogArgs{})
+		}
 	}
 	if err != nil {
 		os.Stderr.Write([]byte(err.Error()))

--- a/pkg/pulumiyaml/run_async_diags_test.go
+++ b/pkg/pulumiyaml/run_async_diags_test.go
@@ -92,7 +92,7 @@ resources:
 	assert.Equal(t, "<stdin>:9:12: list index 1 out-of-bounds for list of length 1", diagString(hoistedRunner.sdiags.diags[0]))
 
 	// 4. We have rich logs sent to Pulumi:
-	richError := `Error: list index 1 out-of-bounds for list of length 1
+	richError := `list index 1 out-of-bounds for list of length 1
 
   on <stdin> line 9:
    1: name: test-yaml

--- a/pkg/pulumiyaml/sort_test.go
+++ b/pkg/pulumiyaml/sort_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,7 +14,7 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 )
 
-func diagString(d *hcl.Diagnostic) string {
+func diagString(d *syntax.Diagnostic) string {
 	if d.Subject != nil {
 		return fmt.Sprintf("%v:%v:%v: %s", d.Subject.Filename, d.Subject.Start.Line, d.Subject.Start.Column, d.Summary)
 	} else if d.Context != nil {
@@ -31,7 +30,7 @@ func requireNoErrors(t *testing.T, tmpl *ast.TemplateDecl, diags syntax.Diagnost
 			if tmpl != nil {
 				var buf bytes.Buffer
 				w := tmpl.NewDiagnosticWriter(&buf, 0, true)
-				err := w.WriteDiagnostic(d)
+				err := w.WriteDiagnostic(d.HCL())
 				assert.NoError(t, err)
 				t.Log(buf.String())
 			} else {

--- a/pkg/pulumiyaml/syntax/diags.go
+++ b/pkg/pulumiyaml/syntax/diags.go
@@ -76,14 +76,13 @@ func (d Diagnostics) HasErrors() bool {
 
 // Error implements the error interface so that Diagnostics values may interoperate with APIs that use errors.
 func (d Diagnostics) Error() string {
-	count := len(d)
-	switch {
-	case count == 0:
+	switch len(d) {
+	case 0:
 		return "no diagnostics"
-	case count == 1:
+	case 1:
 		return d[0].Error()
 	default:
-		return fmt.Sprintf("%s, and %d other diagnostic(s)", d[0].Error(), count-1)
+		return fmt.Sprintf("%s, and %d other diagnostic(s)", d[0].Error(), len(d)-1)
 	}
 }
 

--- a/pkg/pulumiyaml/syntax/diags.go
+++ b/pkg/pulumiyaml/syntax/diags.go
@@ -3,18 +3,42 @@
 package syntax
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 )
 
 // A Diagnostic represents a warning or an error to be presented to the user.
-type Diagnostic = hcl.Diagnostic
+type Diagnostic struct {
+	hcl.Diagnostic
+
+	// Whether the diagnostic has been shown to the user
+	Shown bool
+}
+
+// WithContext adds context without mutating the receiver.
+func (d Diagnostic) WithContext(rng *hcl.Range) *Diagnostic {
+	d.Context = rng
+	return &d
+}
+
+func (d Diagnostic) HCL() *hcl.Diagnostic {
+	return &d.Diagnostic
+}
 
 // Warning creates a new warning-level diagnostic from the given subject, summary, and detail.
 func Warning(rng *hcl.Range, summary, detail string) *Diagnostic {
 	if detail == "" {
 		detail = summary
 	}
-	return &Diagnostic{Severity: hcl.DiagWarning, Subject: rng, Summary: summary, Detail: detail}
+	return &Diagnostic{
+		Diagnostic: hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Subject:  rng,
+			Summary:  summary,
+			Detail:   detail,
+		},
+	}
 }
 
 // Error creates a new error-level diagnostic from the given subject, summary, and detail.
@@ -22,7 +46,9 @@ func Error(rng *hcl.Range, summary, detail string) *Diagnostic {
 	if detail == "" {
 		detail = summary
 	}
-	return &Diagnostic{Severity: hcl.DiagError, Subject: rng, Summary: summary, Detail: detail}
+	return &Diagnostic{
+		Diagnostic: hcl.Diagnostic{Severity: hcl.DiagError, Subject: rng, Summary: summary, Detail: detail},
+	}
 }
 
 // NodeError creates a new error-level diagnostic from the given node, summary, and detail. If the node is non-nil,
@@ -36,16 +62,29 @@ func NodeError(node Node, summary, detail string) *Diagnostic {
 }
 
 // Diagnostics is a list of diagnostics.
-type Diagnostics hcl.Diagnostics
+type Diagnostics []*Diagnostic
 
 // HasErrors returns true if the list of diagnostics contains any error-level diagnostics.
 func (d Diagnostics) HasErrors() bool {
-	return hcl.Diagnostics(d).HasErrors()
+	for _, diag := range d {
+		if diag.Severity == hcl.DiagError {
+			return true
+		}
+	}
+	return false
 }
 
 // Error implements the error interface so that Diagnostics values may interoperate with APIs that use errors.
 func (d Diagnostics) Error() string {
-	return hcl.Diagnostics(d).Error()
+	count := len(d)
+	switch {
+	case count == 0:
+		return "no diagnostics"
+	case count == 1:
+		return d[0].Error()
+	default:
+		return fmt.Sprintf("%s, and %d other diagnostic(s)", d[0].Error(), count-1)
+	}
 }
 
 // Extend appends the given list of diagnostics to the list.
@@ -53,4 +92,25 @@ func (d *Diagnostics) Extend(diags ...*Diagnostic) {
 	if len(diags) != 0 {
 		*d = append(*d, diags...)
 	}
+}
+
+func (d *Diagnostics) HCL() hcl.Diagnostics {
+	if d == nil {
+		return nil
+	}
+	a := make(hcl.Diagnostics, 0, len(*d))
+	for _, diag := range *d {
+		a = append(a, diag.HCL())
+	}
+	return a
+}
+
+func (d Diagnostics) Unshown() *Diagnostics {
+	diags := Diagnostics{}
+	for _, diag := range d {
+		if !diag.Shown {
+			diags = append(diags, diag)
+		}
+	}
+	return &diags
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	pbempty "github.com/golang/protobuf/ptypes/empty"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -118,7 +117,7 @@ func (host *yamlLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 
 	diagWriter := template.NewDiagnosticWriter(os.Stderr, 0, true)
 	if len(diags) != 0 {
-		err := diagWriter.WriteDiagnostics(hcl.Diagnostics(diags))
+		err := diagWriter.WriteDiagnostics(diags.HCL())
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +154,7 @@ func (host *yamlLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 		return pulumiyaml.RunTemplate(ctx, template, loader)
 	}); err != nil {
 		if diags, ok := pulumiyaml.HasDiagnostics(err); ok {
-			err := diagWriter.WriteDiagnostics(hcl.Diagnostics(diags))
+			err := diagWriter.WriteDiagnostics(diags.Unshown().HCL())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -207,7 +207,7 @@ func (l mockPackageLoader) Close() {}
 
 func getValidPCLFile(t *testing.T, file *ast.TemplateDecl) ([]byte, hcl.Diagnostics, error) {
 	templateBody, tdiags := codegen.ImportTemplate(file, rootPluginLoader)
-	diags := hcl.Diagnostics(tdiags)
+	diags := tdiags.HCL()
 	if tdiags.HasErrors() {
 		return nil, diags, nil
 	}


### PR DESCRIPTION
This PR fixes 2 problems with the following output:
```
X pulumi preview
Previewing update (dev)

View Live: https://app.pulumi.com/iwahbe/yaml-example/dev/previews/e73fea04-e958-4545-ac1e-a7be525b40e2

     Type                 Name              Plan       Info
 +   pulumi:pulumi:Stack  yaml-example-dev  create     2 errors; 4 messages
 
Diagnostics:
  pulumi:pulumi:Stack (yaml-example-dev):
    error: Error: Property myBucket does not exist on Resource aws:s3/bucket:Bucket
    
      on Pulumi.yaml line 5:
       5:       myBucket: myBucket
    
    Existing properties are: bucket, acl, policy, website, arn and 16 others
    error: an unhandled error occurred: failed to evaluate template
 
    Error: Property myBucket does not exist on Resource aws:s3/bucket:Bucket
      on Pulumi.yaml line 5:
       5:       myBucket: myBucket
    Existing properties are: bucket, acl, policy, website, arn and 16 others
 ```

1. The error message is displayed twice.
2. One of the displays is `error: Error`. The first error is added by `pulumi.Log`, while the second is added by `hcl.WriteDiagnostic`. We don't want both.