### PR TITLE
feature: Fn::ReadFile to read file from disk, support Stack README functionality

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,9 @@
 - Add `Fn::FromBase64`
   [#218](https://github.com/pulumi/pulumi-yaml/pull/218)
 
+- Add support for Fn::ReadFile, enabling [Stack README](https://www.pulumi.com/blog/stack-readme/) support.
+  [#217](https://github.com/pulumi/pulumi-yaml/pull/217)
+
 ### Bug Fixes
 
 - De-duplicate error message added during pre-eval checking.

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ variables:
 
 The expression `${reference}` will have the value of the `outputName` output from the stack `org/project/stack`.
 
-#### `Fn::Secret`
+##### `Fn::Secret`
 
 Constructs a [Secret](https://www.pulumi.com/docs/intro/concepts/secrets/) from an existing value.
 
@@ -402,3 +402,34 @@ variables:
       Fn::Invoke:
         Function: my:pkg:GetSecretValue
 ```
+
+##### `Fn::ReadFile`
+
+Reads a file from disk and returns the contents as a string, must be utf-8. This function has
+special rules for its behavior.
+
+``` yaml
+variables:
+  someText:
+    Fn::ReadFile: ./README.md
+```
+
+Any subpath of the Pulumi project directory is allowed, whether it is absolute, relative, constant,
+or an expression:
+
+ * `Fn::ReadFile: ./README.md`, a relative subpath
+ * `Fn::ReadFile: ${pulumi.cwd}/example.txt`, an absolute subpath
+ * `Fn::ReadFile: /opt/project-dir/example.json`, an absolute subpath if the program is in /opt/project-dir
+
+Absolute paths to any location are allowed if they are constants:
+
+ * `Fn::ReadFile: /etc/lsb-release`
+ * `Fn::ReadFile: /usr/share/nginx/html`
+ * `Fn::ReadFile: /var/run/secrets/kubernetes.io/serviceaccount/token`
+
+Relative paths that escape the project directory and absolute paths that are non-constant are
+forbidden to prevent path traversals.
+
+ * `Fn::ReadFile: ../../etc/shadow`, a relative path that escapes the project
+ * `Fn::ReadFile: ${pulumi.cwd}/../../.ssh/id_rsa.pub`, an expression that returns an absolute path
+   that escapes the project

--- a/examples/readme/Pulumi.README.md
+++ b/examples/readme/Pulumi.README.md
@@ -1,0 +1,6 @@
+# Stack README
+
+Full markdown support! Substitute stack outputs dynamically so that links can depend on your infrastructure! Link to dashboards, logs, metrics, and more.
+
+1. Reference a string stack output: ${outputs.strVar}
+2. Reference an array stack output: ${outputs.arrVar[1]}

--- a/examples/readme/Pulumi.yaml
+++ b/examples/readme/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: random
+runtime: yaml
+outputs:
+  strVar: "foo"
+  arrVar:
+  - fizz
+  - buzz
+  readme:
+    Fn::ReadFile: ./Pulumi.README.md

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -718,36 +718,31 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 	kvp := node.Index(0)
 
 	var parse func(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics)
-
-	key := kvp.Key.Value()
-
-	if strings.HasPrefix(key, "Fn::") {
-		switch key {
-		case "Fn::Invoke":
-			parse = parseInvoke
-		case "Fn::Join":
-			parse = parseJoin
-		case "Fn::ToJSON":
-			parse = parseToJSON
-		case "Fn::ToBase64":
-			parse = parseToBase64
-		case "Fn::FromBase64":
-			parse = parseFromBase64
-		case "Fn::Select":
-			parse = parseSelect
-		case "Fn::Split":
-			parse = parseSplit
-		case "Fn::StackReference":
-			parse = parseStackReference
-		case "Fn::AssetArchive":
-			parse = parseAssetArchive
-		case "Fn::Secret":
-			parse = parseSecret
-		case "Fn::ReadFile":
-			parse = parseReadFile
-		default:
-			return nil, nil, false
-		}
+	switch kvp.Key.Value() {
+	case "Fn::Invoke":
+		parse = parseInvoke
+	case "Fn::Join":
+		parse = parseJoin
+	case "Fn::ToJSON":
+		parse = parseToJSON
+	case "Fn::ToBase64":
+		parse = parseToBase64
+	case "Fn::FromBase64":
+		parse = parseFromBase64
+	case "Fn::Select":
+		parse = parseSelect
+	case "Fn::Split":
+		parse = parseSplit
+	case "Fn::StackReference":
+		parse = parseStackReference
+	case "Fn::AssetArchive":
+		parse = parseAssetArchive
+	case "Fn::Secret":
+		parse = parseSecret
+	case "Fn::ReadFile":
+		parse = parseReadFile
+	default:
+		return nil, nil, false
 	}
 
 	var diags syntax.Diagnostics

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -322,6 +322,16 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 			},
 			Key: propertyName,
 		}, diags
+	case *ast.ReadFileExpr:
+		var diags syntax.Diagnostics
+
+		path, pdiags := imp.importExpr(node.Path, nil)
+		diags.Extend(pdiags...)
+
+		return &model.FunctionCallExpression{
+			Name: "readFile",
+			Args: []model.Expression{path},
+		}, pdiags
 	default:
 		contract.Failf("unexpected builtin type %T", node)
 		return nil, nil

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -3,6 +3,10 @@
 package pulumiyaml
 
 import (
+	_ "embed"
+	"os"
+	"path/filepath"
+
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -17,6 +21,9 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/ast"
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 )
+
+//go:embed README.md
+var packageReadmeFile string
 
 const testComponentToken = "test:component:type"
 const testResourceToken = "test:resource:type"
@@ -1450,6 +1457,78 @@ variables:
 		r.ctx.Export("out", out)
 	})
 	assert.True(t, hasRun)
+}
+
+func TestReadFile(t *testing.T) {
+	t.Parallel()
+
+	repoReadmePath, err := filepath.Abs("../../README.md")
+	assert.NoError(t, err)
+
+	repoReadmeText, err := os.ReadFile(repoReadmePath)
+	assert.NoError(t, err)
+
+	text := fmt.Sprintf(`
+name: test-readfile
+runtime: yaml
+variables:
+  textData:
+    Fn::ReadFile: ./README.md
+  absInDirData:
+    Fn::ReadFile: ${pulumi.cwd}/README.md
+  absOutOfDirData:
+    Fn::ReadFile: %v
+`, repoReadmePath)
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	testTemplate(t, tmpl, func(r *evalContext) {
+		diags := r.Evaluate()
+		requireNoErrors(t, tmpl, diags)
+		result, ok := r.variables["textData"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, packageReadmeFile, result)
+
+		result, ok = r.variables["absInDirData"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, packageReadmeFile, result)
+
+		result, ok = r.variables["absOutOfDirData"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, string(repoReadmeText), result)
+	})
+}
+
+// TestReadFileForbidsPathTraversal ensures that we forbid certain malicious path behaviors which
+// allow escaping the project directory in static YAML.
+//
+// The example program uses a non-constant path which escapes the project directory.
+//
+// Non-constant paths which read from the project dir are considered safe, likely as uses of
+// ${pulumi.cwd}, see above. Constant, absolute path are also permitted, sometimes necessary to use
+// a secret or token.
+func TestReadFileForbidsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	text := `
+name: test-readfile
+runtime: yaml
+outputs:
+  readme:
+    Fn::ReadFile: ${pulumi.cwd}/../../go.mod # imagine this is /etc/shadow, /var/run/secrets/tokens, etc.
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	diags := testTemplateSyntaxDiags(t, tmpl, func(r *runner) {})
+
+	var diagStrings []string
+	for _, v := range diags {
+		diagStrings = append(diagStrings, diagString(v))
+	}
+	assert.ElementsMatch(t, diagStrings,
+		[]string{
+			"<stdin>:5:19: Argument to Fn::ReadFile must be a constant or contained in the project dir",
+		},
+	)
 }
 
 func TestUnicodeLogicalName(t *testing.T) {

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -65,7 +65,8 @@ var (
 		"azure-app-service":       Dotnet.And(Golang),
 		"pulumi-variable":         AllLanguages().Except(Python),
 		"kubernetes":              Golang, // returning string instead of *string in ApplyT
-		"readme":                  Dotnet, // https://github.com/pulumi/pulumi/issues/9642
+		"readme": (Dotnet.And( // https://github.com/pulumi/pulumi/issues/9642
+			Golang)), // https://github.com/pulumi/pulumi/issues/9692
 	}
 
 	failingTypecheck = map[string]LanguageList{

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -65,6 +65,7 @@ var (
 		"azure-app-service":       Dotnet.And(Golang),
 		"pulumi-variable":         AllLanguages().Except(Python),
 		"kubernetes":              Golang, // returning string instead of *string in ApplyT
+		"readme":                  Dotnet, // https://github.com/pulumi/pulumi/issues/9642
 	}
 
 	failingTypecheck = map[string]LanguageList{

--- a/pkg/tests/transpiled_examples/readme/go/main.go
+++ b/pkg/tests/transpiled_examples/readme/go/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func readFileOrPanic(path string) pulumi.StringPtrInput {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err.Error())
+	}
+	return pulumi.String(string(data))
+}
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ctx.Export("strVar", "foo")
+		ctx.Export("arrVar", []string{
+			"fizz",
+			"buzz",
+		})
+		ctx.Export("readme", readFileOrPanic("./Pulumi.README.md"))
+		return nil
+	})
+}

--- a/pkg/tests/transpiled_examples/readme/nodejs/index.ts
+++ b/pkg/tests/transpiled_examples/readme/nodejs/index.ts
@@ -1,0 +1,9 @@
+import * as pulumi from "@pulumi/pulumi";
+import * from "fs";
+
+export const strVar = "foo";
+export const arrVar = [
+    "fizz",
+    "buzz",
+];
+export const readme = fs.readFileSync("./Pulumi.README.md");

--- a/pkg/tests/transpiled_examples/readme/nodejs/index.ts
+++ b/pkg/tests/transpiled_examples/readme/nodejs/index.ts
@@ -1,5 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
-import * from "fs";
+import * as fs from "fs";
 
 export const strVar = "foo";
 export const arrVar = [

--- a/pkg/tests/transpiled_examples/readme/program.pp
+++ b/pkg/tests/transpiled_examples/readme/program.pp
@@ -1,0 +1,17 @@
+output strVar {
+	__logicalName = "strVar"
+	value = "foo"
+}
+
+output arrVar {
+	__logicalName = "arrVar"
+	value = [
+		"fizz",
+		"buzz"
+	]
+}
+
+output readme {
+	__logicalName = "readme"
+	value = readFile("./Pulumi.README.md")
+}

--- a/pkg/tests/transpiled_examples/readme/python/__main__.py
+++ b/pkg/tests/transpiled_examples/readme/python/__main__.py
@@ -1,0 +1,8 @@
+import pulumi
+
+pulumi.export("strVar", "foo")
+pulumi.export("arrVar", [
+    "fizz",
+    "buzz",
+])
+pulumi.export("readme", (lambda path: open(path).read())("./Pulumi.README.md"))


### PR DESCRIPTION
This enables YAML support for README embedding that closely matches the examples in the Stack README blog post:

https://www.pulumi.com/blog/stack-readme/

Fixes #200 
