### PR TITLE
[exec] Consume PackageReferences

### DIFF
--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -38,7 +38,7 @@ func newPluginHost() (plugin.Host, error) {
 	return pluginCtx.Host, nil
 }
 
-func ConvertTemplateIL(template *ast.TemplateDecl, loader schema.Loader) (string, hcl.Diagnostics, error) {
+func ConvertTemplateIL(template *ast.TemplateDecl, loader schema.ReferenceLoader) (string, hcl.Diagnostics, error) {
 	var diags hcl.Diagnostics
 
 	if loader == nil {
@@ -59,7 +59,7 @@ func ConvertTemplateIL(template *ast.TemplateDecl, loader schema.Loader) (string
 	return programText, nil, nil
 }
 
-func EjectProgram(template *ast.TemplateDecl, loader schema.Loader) (*pcl.Program, hcl.Diagnostics, error) {
+func EjectProgram(template *ast.TemplateDecl, loader schema.ReferenceLoader) (*pcl.Program, hcl.Diagnostics, error) {
 	programText, diags, err := ConvertTemplateIL(template, loader)
 	if err != nil {
 		return nil, diags, err
@@ -95,7 +95,7 @@ func EjectProgram(template *ast.TemplateDecl, loader schema.Loader) (*pcl.Progra
 // ConvertTemplate converts a Pulumi YAML template to a target language using PCL as an intermediate representation.
 //
 // loader is the schema.Loader used when binding the the PCL program. If `nil`, a `schema.Loader` will be created from `newPluginHost()`.
-func ConvertTemplate(template *ast.TemplateDecl, generate GenerateFunc, loader schema.Loader) (map[string][]byte, hcl.Diagnostics, error) {
+func ConvertTemplate(template *ast.TemplateDecl, generate GenerateFunc, loader schema.ReferenceLoader) (map[string][]byte, hcl.Diagnostics, error) {
 	program, diags, err := EjectProgram(template, loader)
 	if err != nil {
 		return nil, diags, err

--- a/pkg/pulumiyaml/codegen/eject.go
+++ b/pkg/pulumiyaml/codegen/eject.go
@@ -22,7 +22,7 @@ import (
 //
 // If no loader is provided (nil argument), a new plugin host will be spawned to obtain resource
 // provider schemas.
-func Eject(dir string, loader schema.Loader) (*workspace.Project, *pcl.Program, error) {
+func Eject(dir string, loader schema.ReferenceLoader) (*workspace.Project, *pcl.Program, error) {
 	proj, template, diags, err := LoadTemplate(dir)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/pulumiyaml/codegen/gen_program_test.go
+++ b/pkg/pulumiyaml/codegen/gen_program_test.go
@@ -52,7 +52,7 @@ func (l testPackageLoader) LoadPackage(name string) (pulumiyaml.Package, error) 
 		return FakePackage{l.T}, nil
 	}
 
-	pkg, err := rootPluginLoader.LoadPackage(name, nil)
+	pkg, err := schema.LoadPackageReference(rootPluginLoader, name, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change the package loader to use schema.PackageReference values rather
than *schema.Package values. The former load types, resources, and
functions as they are needed rather than up-front, which can drastically
reduce the peak memory consumption of the executor.