### PR TITLE
Document Fn::ToBase64

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,9 +22,6 @@
 
 ### Bug Fixes
 
-- Document Fn::ToBase64 in README.
-  [#245](https://github.com/pulumi/pulumi-yaml/pull/245)
-
 - De-duplicate error message added during pre-eval checking.
   [#207](https://github.com/pulumi/pulumi-yaml/pull/207)
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,9 @@
 
 ### Bug Fixes
 
+- Document Fn::ToBase64 in README.
+  [#245](https://github.com/pulumi/pulumi-yaml/pull/245)
+
 - De-duplicate error message added during pre-eval checking.
   [#207](https://github.com/pulumi/pulumi-yaml/pull/207)
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,18 @@ The last two lines are equivalent as if the variable were substituted for its va
 
 In any expression location, an object containing a single key beginning with "Fn::" calls a built-in function.
 
+##### `Fn::ToBase64`
+
+This function encodes a UTF-8 string with the base64-encoding using the [standard base-64 encoding](https://pkg.go.dev/encoding/base64#pkg-variables). **This will fail if the result is not a valid UTF-8 string**
+
+```yaml
+variables:
+  greeting: 
+    Fn::ToBase64: "Hello, world!"
+```
+
+The expression `${greeting}` will return `SGVsbG8sIHdvcmxkIQ==`
+
 ##### `Fn::FromBase64`
 
 Converts a Base64 encoded string into a UTF-8 string. **This will fail if the result is not a valid UTF-8 string**

--- a/README.md
+++ b/README.md
@@ -269,11 +269,11 @@ The last two lines are equivalent as if the variable were substituted for its va
 
 #### Built-in Functions
 
-In any expression location, an object containing a single key beginning with "Fn::" calls a built-in function.
+In any expression location, an object containing a single key beginning with `Fn::` calls a built-in function.
 
 ##### `Fn::ToBase64`
 
-This function encodes a UTF-8 string with the base64-encoding using the [standard base-64 encoding](https://pkg.go.dev/encoding/base64#pkg-variables). **This will fail if the result is not a valid UTF-8 string**
+Converts a UTF-8 string into a Base64 encoded string using the [standard encoding](https://pkg.go.dev/encoding/base64#pkg-variables).
 
 ```yaml
 variables:


### PR DESCRIPTION
This PR closes https://github.com/pulumi/pulumi-yaml/issues/235 by providing documentation for the built-in `Fn::Base64` function.