### PR TITLE
Support converting invokes with no arguments

### DIFF
--- a/pkg/pulumiyaml/codegen/eject.go
+++ b/pkg/pulumiyaml/codegen/eject.go
@@ -27,6 +27,9 @@ func Eject(dir string, loader schema.ReferenceLoader) (*workspace.Project, *pcl.
 	if err != nil {
 		return nil, nil, err
 	}
+	if template == nil && diags.HasErrors() {
+		return nil, nil, fmt.Errorf("failed to load the template: %s", diags.Error())
+	}
 	diagWriter := template.NewDiagnosticWriter(os.Stderr, 0, true)
 	if len(diags) != 0 {
 		err := diagWriter.WriteDiagnostics(diags)

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -264,6 +264,8 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 			diags.Extend(adiags...)
 
 			invokeArgs = append(invokeArgs, args)
+		} else {
+			invokeArgs = append(invokeArgs, &model.ObjectConsExpression{})
 		}
 
 		fn := &model.FunctionCallExpression{

--- a/pkg/pulumiyaml/codegen/load_test.go
+++ b/pkg/pulumiyaml/codegen/load_test.go
@@ -138,8 +138,8 @@ variables:
   noRet:
     Fn::Invoke:
       Function: test:mod:fn`,
-			expected: `ret = invoke("test:mod:fn").foo
-noRet = invoke("test:mod:fn")
+			expected: `ret = invoke("test:mod:fn", {}).foo
+noRet = invoke("test:mod:fn", {})
 `,
 		},
 	}


### PR DESCRIPTION
This is the YAML part of the fix of [#9896](https://github.com/pulumi/pulumi-yaml/issues/263). It provides empty args to PCL which seems to require them. It also prevents the panic for an empty `Arguments` in yaml, as the issue reported.

I tested it manually. Could you point me to an example of a test I need to write for this? (if any)