### PR TITLE
Observe TestGenerateExamples changed output

### DIFF
--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -309,6 +309,11 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 					return nil
 				}
 
+				// Program.cs is the driver for MyStack.cs, which is what we generate.
+				if d.Name() == "Program.cs" {
+					return nil
+				}
+
 				bytes, err := ioutil.ReadFile(filePath)
 				if err != nil {
 					return err

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -292,7 +292,13 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 				if err != nil {
 					return err
 				}
+
 				if d.IsDir() {
+					if d.Name() == "node_modules" ||
+						d.Name() == "__pycache__" ||
+						d.Name() == "bin" {
+						return fs.SkipDir
+					}
 					return nil
 				}
 

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -307,7 +307,7 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 					name == "package.json" ||
 					name == "yarn.lock" ||
 					name == "tsconfig.json" ||
-					name == "requirments.txt" {
+					name == "requirements.txt" {
 					return nil
 				}
 

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -294,11 +294,18 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 				}
 
 				if d.IsDir() {
-					if d.Name() == "node_modules" ||
-						d.Name() == "__pycache__" ||
-						d.Name() == "bin" {
+					if name := d.Name(); name == "node_modules" ||
+						name == "__pycache__" ||
+						name == "bin" {
 						return fs.SkipDir
 					}
+					return nil
+				}
+
+				if name := d.Name(); name == "Pulumi.yaml" ||
+					name == ".gitignore" ||
+					name == "package.json" ||
+					name == "tsconfig.json" {
 					return nil
 				}
 
@@ -343,7 +350,7 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 				return
 			}
 
-			check(t, writeTo, deps)
+			check(t, tmpDir, deps)
 		})
 	}
 }

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -302,12 +302,10 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 					return nil
 				}
 
-				if name := d.Name(); name == "Pulumi.yaml" ||
-					name == ".gitignore" ||
-					name == "package.json" ||
-					name == "yarn.lock" ||
-					name == "tsconfig.json" ||
-					name == "requirements.txt" {
+				if !(strings.HasSuffix(d.Name(), ".py") ||
+					strings.HasSuffix(d.Name(), ".cs") ||
+					strings.HasSuffix(d.Name(), ".go") ||
+					strings.HasSuffix(d.Name(), ".ts")) {
 					return nil
 				}
 

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -305,7 +305,9 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 				if name := d.Name(); name == "Pulumi.yaml" ||
 					name == ".gitignore" ||
 					name == "package.json" ||
-					name == "tsconfig.json" {
+					name == "yarn.lock" ||
+					name == "tsconfig.json" ||
+					name == "requirments.txt" {
 					return nil
 				}
 

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -5,8 +5,10 @@ package tests
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -269,7 +271,6 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 			}
 			t.Parallel()
 			var (
-				files map[string][]byte
 				diags hcl.Diagnostics
 				err   error
 			)
@@ -281,10 +282,46 @@ func convertTo(lang string, generator projectGeneratorFunc, check CheckFunc) Con
 			proj, pclProgram, err := codegen.Eject(projectDir, rootPluginLoader.ReferenceLoader)
 			require.NoError(t, err, "Failed to eject program")
 
-			err = generator(writeTo, *proj, pclProgram)
+			tmpDir := t.TempDir()
+			err = generator(tmpDir, *proj, pclProgram)
 			require.NoError(t, err, "Failed to generate project")
 
+			files := map[string][]byte{}
+
+			err = filepath.WalkDir(tmpDir, func(filePath string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() {
+					return nil
+				}
+
+				bytes, err := ioutil.ReadFile(filePath)
+				if err != nil {
+					return err
+				}
+
+				segments := []string{}
+				rest := filePath[len(tmpDir):]
+				for {
+					base := filepath.Base(rest)
+					segments = append(segments, base)
+
+					if base == rest {
+						break
+					}
+					rest = filepath.Dir(rest)
+
+				}
+
+				name := path.Join(segments...)
+				files[name] = bytes
+				return nil
+			})
+			require.NoError(t, err, "Failed to walk generated files")
+
 			writeOrCompare(t, writeTo, files)
+
 			deps := pcodegen.NewStringSet()
 			for _, d := range template.Resources.Entries {
 				// This will not handle invokes correctly

--- a/pkg/tests/transpiled_examples/azure-app-service/nodejs/index.ts
+++ b/pkg/tests/transpiled_examples/azure-app-service/nodejs/index.ts
@@ -75,7 +75,7 @@ const app = new azure_native.web.WebApp("app", {
         appSettings: [
             {
                 name: "WEBSITE_RUN_FROM_PACKAGE",
-                value: pulumi.interpolate`https://${sa.name}.blob.core.windows.net/${container.name}/${blob.name}?${blobAccessToken}`,
+                value: pulumi.all([sa.name, container.name, blob.name, blobAccessToken]).apply(([saName, containerName, blobName, blobAccessToken]) => `https://${saName}.blob.core.windows.net/${containerName}/${blobName}?${blobAccessToken}`),
             },
             {
                 name: "APPINSIGHTS_INSTRUMENTATIONKEY",

--- a/pkg/tests/transpiled_examples/azure-app-service/python/__main__.py
+++ b/pkg/tests/transpiled_examples/azure-app-service/python/__main__.py
@@ -17,7 +17,7 @@ container = azure_native.storage.BlobContainer("container",
     resource_group_name=appservicegroup.name,
     account_name=sa.name,
     public_access=azure_native.storage.PublicAccess.NONE)
-blob_access_token = pulumi.Output.all(sa.name, appservicegroup.name, sa.name, container.name).apply(lambda saName, appservicegroupName, saName1, containerName: azure_native.storage.list_storage_account_service_sas_output(account_name=sa_name,
+blob_access_token = pulumi.secret(pulumi.Output.all(sa.name, appservicegroup.name, sa.name, container.name).apply(lambda saName, appservicegroupName, saName1, containerName: azure_native.storage.list_storage_account_service_sas_output(account_name=sa_name,
     protocols=azure_native.storage.HttpProtocol.HTTPS,
     shared_access_start_time="2022-01-01",
     shared_access_expiry_time="2030-01-01",
@@ -28,7 +28,7 @@ blob_access_token = pulumi.Output.all(sa.name, appservicegroup.name, sa.name, co
     content_type="application/json",
     cache_control="max-age=5",
     content_disposition="inline",
-    content_encoding="deflate")).apply(lambda invoke: invoke.service_sas_token)
+    content_encoding="deflate")).apply(lambda invoke: invoke.service_sas_token))
 appserviceplan = azure_native.web.AppServicePlan("appserviceplan",
     resource_group_name=appservicegroup.name,
     kind="App",
@@ -67,7 +67,7 @@ app = azure_native.web.WebApp("app",
         app_settings=[
             azure_native.web.NameValuePairArgs(
                 name="WEBSITE_RUN_FROM_PACKAGE",
-                value=pulumi.Output.all(sa.name, container.name, blob.name).apply(lambda saName, containerName, blobName: f"https://{sa_name}.blob.core.windows.net/{container_name}/{blob_name}?{blob_access_token}"),
+                value=pulumi.Output.all(sa.name, container.name, blob.name, blob_access_token).apply(lambda saName, containerName, blobName, blob_access_token: f"https://{sa_name}.blob.core.windows.net/{container_name}/{blob_name}?{blob_access_token}"),
             ),
             azure_native.web.NameValuePairArgs(
                 name="APPINSIGHTS_INSTRUMENTATIONKEY",


### PR DESCRIPTION
Tests will now fail when codegened output changes without `PULUMI_ACCEPT=true`. 

Fixes #273