### PR TITLE
Codegen comments when translating PCL -> YAML

### DIFF
--- a/pkg/pulumiyaml/codegen/utils.go
+++ b/pkg/pulumiyaml/codegen/utils.go
@@ -3,12 +3,14 @@
 package codegen
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/iancoleman/strcase"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -66,4 +68,32 @@ func relativeTraversal(source model.Expression, attr string) *model.RelativeTrav
 		Traversal: hcl.Traversal{hcl.TraverseAttr{Name: attr}},
 		Parts:     []model.Traversable{model.DynamicType, model.DynamicType},
 	}
+}
+
+type BlockSyntax struct {
+	Leading  syntax.TriviaList
+	Trailing syntax.TriviaList
+}
+
+func (b BlockSyntax) convertTrivia(s syntax.TriviaList) string {
+	c := strings.TrimSpace(fmt.Sprint(s))
+	c = strings.TrimPrefix(c, "//")
+	c = strings.TrimSpace(c)
+	return c
+}
+
+func (b BlockSyntax) Range() *hcl.Range {
+	return nil
+}
+
+func (b BlockSyntax) HeadComment() string {
+	return b.convertTrivia(b.Leading)
+}
+
+func (b BlockSyntax) LineComment() string {
+	return b.convertTrivia(b.Trailing)
+}
+
+func (b BlockSyntax) FootComment() string {
+	return ""
 }

--- a/pkg/pulumiyaml/syntax/encoding/yaml.go
+++ b/pkg/pulumiyaml/syntax/encoding/yaml.go
@@ -171,15 +171,20 @@ func UnmarshalYAML(filename string, n *yaml.Node, tags TagDecoder) (syntax.Node,
 func MarshalYAML(n syntax.Node) (*yaml.Node, syntax.Diagnostics) {
 	var yamlNode yaml.Node
 	var originalValue interface{}
-	if original, ok := n.Syntax().(YAMLSyntax); ok {
-		yamlNode.Tag = original.Tag
-		yamlNode.Value = original.Value
-		yamlNode.Style = original.Style
-		yamlNode.HeadComment = original.HeadComment
-		yamlNode.LineComment = original.LineComment
-		yamlNode.FootComment = original.FootComment
+	switch s := n.Syntax().(type) {
+	case YAMLSyntax:
+		yamlNode.Tag = s.Tag
+		yamlNode.Value = s.Value
+		yamlNode.Style = s.Style
+		yamlNode.HeadComment = s.HeadComment
+		yamlNode.LineComment = s.LineComment
+		yamlNode.FootComment = s.FootComment
 
-		originalValue = original.value
+		originalValue = s.value
+	case syntax.Trivia:
+		yamlNode.HeadComment = s.HeadComment()
+		yamlNode.LineComment = s.LineComment()
+		yamlNode.FootComment = s.FootComment()
 	}
 
 	stringNode := func(value string) {

--- a/pkg/pulumiyaml/syntax/syntax.go
+++ b/pkg/pulumiyaml/syntax/syntax.go
@@ -15,3 +15,11 @@ type noSyntax int
 func (noSyntax) Range() *hcl.Range {
 	return nil
 }
+
+type Trivia interface {
+	Syntax
+
+	HeadComment() string
+	LineComment() string
+	FootComment() string
+}

--- a/pkg/pulumiyaml/testing/test/testdata/assets-archives-pp/yaml/assets-archives.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/assets-archives-pp/yaml/assets-archives.yaml
@@ -5,36 +5,42 @@ resources:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
+      # Reference the s3.Bucket object
       source:
         Fn::FileAsset: file.txt
   testStringAsset:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
+      # Reference the s3.Bucket object
       source:
         Fn::StringAsset: <h1>File contents</h1>
   testRemoteAsset:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
+      # Reference the s3.Bucket object
       source:
         Fn::RemoteAsset: https://pulumi.test
   testFileArchive:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
+      # Reference the s3.Bucket object
       source:
         Fn::FileArchive: file.tar.gz
   testRemoteArchive:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
+      # Reference the s3.Bucket object
       source:
         Fn::RemoteArchive: https://pulumi.test/foo.tar.gz
   testAssetArchive:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
+      # Reference the s3.Bucket object
       source:
         Fn::AssetArchive:
           file.txt:

--- a/pkg/pulumiyaml/testing/test/testdata/aws-fargate-pp/yaml/aws-fargate.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-fargate-pp/yaml/aws-fargate.yaml
@@ -1,4 +1,5 @@
 resources:
+  # Create a security group that permits HTTP ingress and unrestricted egress.
   webSecurityGroup:
     type: aws:ec2:SecurityGroup
     properties:
@@ -15,8 +16,10 @@ resources:
           toPort: 80
           cidrBlocks:
             - 0.0.0.0/0
+  # Create an ECS cluster to run a container-based service.
   cluster:
     type: aws:ecs:Cluster
+  # Create an IAM role that can be used by our service's task.
   taskExecRole:
     type: aws:iam:Role
     properties:
@@ -34,6 +37,7 @@ resources:
     properties:
       role: ${taskExecRole.name}
       policyArn: arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+  # Create a load balancer to listen for HTTP traffic on port 80.
   webLoadBalancer:
     type: aws:elasticloadbalancingv2:LoadBalancer
     properties:
@@ -55,6 +59,7 @@ resources:
       defaultActions:
         - type: forward
           targetGroupArn: ${webTargetGroup.arn}
+  # Spin up a load balanced service running NGINX
   appTask:
     type: aws:ecs:TaskDefinition
     properties:
@@ -93,6 +98,7 @@ resources:
       dependson:
         - ${webListener}
 variables:
+  # Read the default VPC and public subnets, which we will use.
   vpc:
     Fn::Invoke:
       Function: aws:ec2:getVpc
@@ -104,4 +110,5 @@ variables:
       Arguments:
         vpcId: ${vpc.id}
 outputs:
+  # Export the resulting web address.
   url: ${webLoadBalancer.dnsName}

--- a/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/yaml/aws-webserver.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/yaml/aws-webserver.yaml
@@ -1,4 +1,5 @@
 resources:
+  # Create a new security group for port 80.
   securityGroup:
     type: aws:ec2:SecurityGroup
     properties:
@@ -8,6 +9,7 @@ resources:
           toPort: 0
           cidrBlocks:
             - 0.0.0.0/0
+  # Create a simple web server using the startup script for the instance.
   server:
     type: aws:ec2:Instance
     properties:
@@ -22,6 +24,7 @@ resources:
         echo "Hello, World!" > index.html
         nohup python -m SimpleHTTPServer 80 &
 variables:
+  # Get the ID for the latest Amazon Linux AMI.
   ami:
     Fn::Invoke:
       Function: aws:getAmi
@@ -34,5 +37,6 @@ variables:
           - 137112412989
         mostRecent: true
 outputs:
+  # Export the resulting server's IP address and DNS name.
   publicIp: ${server.publicIp}
   publicHostName: ${server.publicDns}

--- a/pkg/pulumiyaml/testing/test/testdata/invalid-go-sprintf-pp/yaml/invalid-go-sprintf.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/invalid-go-sprintf-pp/yaml/invalid-go-sprintf.yaml
@@ -1,4 +1,5 @@
 resources:
+  # example
   argocd_serverDeployment:
     type: kubernetes:apps/v1:Deployment
     properties:

--- a/pkg/pulumiyaml/testing/test/testdata/output-funcs-aws-pp/yaml/output-funcs-aws.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/output-funcs-aws-pp/yaml/output-funcs-aws.yaml
@@ -30,6 +30,9 @@ variables:
       Function: aws:ec2:getPrefixList
       Arguments:
         prefixListId: ${privateS3VpcEndpoint.prefixListId}
+  # A contrived example to test that helper nested records ( `filters`
+  # below) generate correctly when using output-versioned function
+  # invoke forms.
   amis:
     Fn::Invoke:
       Function: aws:ec2:getAmiIds

--- a/pkg/pulumiyaml/testing/test/testdata/typed-enum-pp/yaml/typed-enum.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/typed-enum-pp/yaml/typed-enum.yaml
@@ -4,6 +4,7 @@ resources:
     properties:
       resourceGroupName: ${someString}
       accountName: ${someString}
+  # Safe enum
   faviconpng:
     type: azure-native:storage:Blob
     properties:
@@ -11,6 +12,7 @@ resources:
       accountName: ${someString}
       containerName: ${someString}
       type: Block
+  # Output umsafe enum
   _404html:
     type: azure-native:storage:Blob
     properties:
@@ -18,6 +20,7 @@ resources:
       accountName: ${someString}
       containerName: ${someString}
       type: ${staticwebsite.indexDocument}
+  # Unsafe enum
   another:
     type: azure-native:storage:Blob
     properties:


### PR DESCRIPTION
Fixes #150 

Note: we inject comments into the Key of object properties since the syntax of the object property itself seems to be ignored.