### PR TITLE
Add `Get` field to resources

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,5 +2,8 @@
 
 - Show all error/ warning messages
   [#279](https://github.com/pulumi/pulumi-yaml/pull/279)
-  
+
+- Add `Get` to resources, allowing Pulumi YAML programs to read external resources.
+  [#290](https://github.com/pulumi/pulumi-yaml/pull/290)
+
 ### Bug Fixes

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -455,13 +455,14 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 	}
 	if s := v.Syntax(); s != nil {
 		if o, ok := s.(*syntax.ObjectNode); ok {
-			validKeys := []string{"type", "properties", "options", "condition", "metadata"}
+			validKeys := append(v.Fields(), "condition", "metadata")
 			fmtr := yamldiags.InvalidFieldBagFormatter{
 				ParentLabel: fmt.Sprintf("Resource %s", typ.String()),
 				MaxListed:   5,
 				Bags: []yamldiags.TypeBag{
 					{Name: "properties", Properties: allProperties},
 					{Name: "options", Properties: allOptions},
+					{Name: "get", Properties: []string{"id", "state"}},
 					{Name: k, Properties: validKeys},
 				},
 				DistanceLimit: 3,

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -451,7 +451,7 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 		ctx.addDiag(syntax.Error(node.Key.Syntax().Syntax().Range(),
 			"Resource fields properties and get are mutually exclusive",
 			"Properties is used to describe a resource managed by Pulumi.\n"+
-				"Get is used to decribe a resource managed outside of the pulumi stack.\n"+
+				"Get is used to describe a resource managed outside of the current Pulumi stack.\n"+
 				"See https://www.pulumi.com/docs/intro/concepts/resources/get for more details on using Get.",
 		))
 	}

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -407,13 +407,9 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 		return true
 	}
 	hint := pkg.ResourceTypeHint(typ)
-	properties := map[string]*schema.Property{}
-	for _, prop := range hint.Resource.InputProperties {
-		properties[prop.Name] = prop
-	}
 	var allProperties []string
-	for k := range properties {
-		allProperties = append(allProperties, k)
+	for _, prop := range hint.Resource.InputProperties {
+		allProperties = append(allProperties, prop.Name)
 	}
 	fmtr := yamldiags.NonExistantFieldFormatter{
 		ParentLabel:         fmt.Sprintf("Resource %s", typ.String()),
@@ -422,29 +418,8 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 		FieldsAreProperties: true,
 	}
 
-	for _, kvp := range v.Properties.Entries {
-		if typ, hasField := properties[kvp.Key.Value]; !hasField {
-			summary, detail := fmtr.MessageWithDetail(kvp.Key.Value, fmt.Sprintf("Property %s", kvp.Key.Value))
-			subject := kvp.Key.Syntax().Syntax().Range()
-			valueRange := kvp.Value.Syntax().Syntax().Range()
-			context := hcl.RangeOver(*subject, *valueRange)
-			ctx.addDiag(syntax.Error(subject, summary, detail).WithContext(&context))
-		} else {
-			existing, ok := tc.exprs[kvp.Value]
-			rng := kvp.Key.Syntax().Syntax().Range()
-			if !ok {
-				ctx.addDiag(syntax.Warning(rng,
-					fmt.Sprintf("internal error: untyped input for %s.%s", k, kvp.Key.Value),
-					fmt.Sprintf("expected type %s", typ.Type)))
-			} else if typ.Type == nil {
-				ctx.addDiag(syntax.Warning(rng,
-					fmt.Sprintf("internal error: unable to discover expected type for %s.%s", k, kvp.Key.Value),
-					fmt.Sprintf("got type %s", existing)))
-			} else {
-				assertTypeAssignable(ctx, rng, existing, typ.Type)
-			}
-		}
-	}
+	tc.typePropertyEntries(ctx, k, fmtr, v.Properties.Entries, hint.Resource.InputProperties)
+
 	tc.registerResource(k, node.Value, hint)
 
 	if len(v.Properties.Entries) > 0 && (v.Get.Id != nil || len(v.Get.State.Entries) > 0) {
@@ -460,10 +435,6 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 		assertTypeAssignable(ctx, v.Get.Id.Syntax().Syntax().Range(), existing, schema.StringType)
 	}
 
-	stateProperties := map[string]*schema.Property{}
-	for _, prop := range hint.Resource.Properties {
-		stateProperties[prop.Name] = prop
-	}
 	statePropNames := []string{}
 	for _, prop := range hint.Resource.Properties {
 		statePropNames = append(statePropNames, prop.Name)
@@ -474,30 +445,7 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 		MaxElements:         5,
 		FieldsAreProperties: true,
 	}
-	// TODO: factor out type checking a property list against it's schema equivalent
-	for _, kvp := range v.Get.State.Entries {
-		if typ, hasField := stateProperties[kvp.Key.Value]; !hasField {
-			summary, detail := fmtr.MessageWithDetail(kvp.Key.Value, fmt.Sprintf("Property %s", kvp.Key.Value))
-			subject := kvp.Key.Syntax().Syntax().Range()
-			valueRange := kvp.Value.Syntax().Syntax().Range()
-			context := hcl.RangeOver(*subject, *valueRange)
-			ctx.addDiag(syntax.Error(subject, summary, detail).WithContext(&context))
-		} else {
-			existing, ok := tc.exprs[kvp.Value]
-			rng := kvp.Key.Syntax().Syntax().Range()
-			if !ok {
-				ctx.addDiag(syntax.Warning(rng,
-					fmt.Sprintf("internal error: untyped input for %s.%s", k, kvp.Key.Value),
-					fmt.Sprintf("expected type %s", typ.Type)))
-			} else if typ.Type == nil {
-				ctx.addDiag(syntax.Warning(rng,
-					fmt.Sprintf("internal error: unable to discover expected type for %s.%s", k, kvp.Key.Value),
-					fmt.Sprintf("got type %s", existing)))
-			} else {
-				assertTypeAssignable(ctx, rng, existing, typ.Type)
-			}
-		}
-	}
+	tc.typePropertyEntries(ctx, k, fmtr, v.Get.State.Entries, hint.Resource.Properties)
 
 	// Check for extra fields that didn't make it into the resource or resource options object
 	options := ResourceOptionsTypeHint()
@@ -574,6 +522,36 @@ func (tc *typeCache) typeResource(r *runner, node resourceNode) bool {
 	}
 
 	return true
+}
+
+func (tc *typeCache) typePropertyEntries(ctx *evalContext, resourceName string, fmtr yamldiags.NonExistantFieldFormatter, entries []ast.PropertyMapEntry, props []*schema.Property) {
+	propMap := map[string]*schema.Property{}
+	for _, p := range props {
+		propMap[p.Name] = p
+	}
+	for _, kvp := range entries {
+		if typ, hasField := propMap[kvp.Key.Value]; !hasField {
+			summary, detail := fmtr.MessageWithDetail(kvp.Key.Value, fmt.Sprintf("Property %s", kvp.Key.Value))
+			subject := kvp.Key.Syntax().Syntax().Range()
+			valueRange := kvp.Value.Syntax().Syntax().Range()
+			context := hcl.RangeOver(*subject, *valueRange)
+			ctx.addDiag(syntax.Error(subject, summary, detail).WithContext(&context))
+		} else {
+			existing, ok := tc.exprs[kvp.Value]
+			rng := kvp.Key.Syntax().Syntax().Range()
+			if !ok {
+				ctx.addDiag(syntax.Warning(rng,
+					fmt.Sprintf("internal error: untyped input for %s.%s", resourceName, kvp.Key.Value),
+					fmt.Sprintf("expected type %s", typ.Type)))
+			} else if typ.Type == nil {
+				ctx.addDiag(syntax.Warning(rng,
+					fmt.Sprintf("internal error: unable to discover expected type for %s.%s", resourceName, kvp.Key.Value),
+					fmt.Sprintf("got type %s", existing)))
+			} else {
+				assertTypeAssignable(ctx, rng, existing, typ.Type)
+			}
+		}
+	}
 }
 
 func (tc *typeCache) typeInvoke(ctx *evalContext, t *ast.InvokeExpr) bool {

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -342,8 +342,8 @@ func ResourceOptions(additionalSecretOutputs, aliases *StringListDecl,
 
 type GetResourceDecl struct {
 	declNode
-
-	Id    Expr
+	// We need to call the field Id instead of ID because we want the derived user field to be id instead of iD
+	Id    Expr //nolint:revive
 	State PropertyMapDecl
 }
 

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -343,7 +343,7 @@ func ResourceOptions(additionalSecretOutputs, aliases *StringListDecl,
 type GetResourceDecl struct {
 	declNode
 
-	Id    *StringExpr
+	Id    Expr
 	State PropertyMapDecl
 }
 

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -340,30 +340,64 @@ func ResourceOptions(additionalSecretOutputs, aliases *StringListDecl,
 		version, pluginDownloadURL, replaceOnChanges, retainOnDelete)
 }
 
+type GetResourceDecl struct {
+	declNode
+
+	Id    *StringExpr
+	State PropertyMapDecl
+}
+
+func (d *GetResourceDecl) defaultValue() interface{} {
+	return &GetResourceDecl{}
+}
+
+func (d *GetResourceDecl) recordSyntax() *syntax.Node {
+	return &d.syntax
+}
+
+func GetResourceSyntax(node *syntax.ObjectNode, id *StringExpr, state PropertyMapDecl) GetResourceDecl {
+	return GetResourceDecl{
+		declNode: decl(node),
+		Id:       id,
+		State:    state,
+	}
+}
+
+func GetResource(id *StringExpr, state PropertyMapDecl) GetResourceDecl {
+	return GetResourceSyntax(nil, id, state)
+}
+
 type ResourceDecl struct {
 	declNode
 
 	Type       *StringExpr
 	Properties PropertyMapDecl
 	Options    ResourceOptionsDecl
+	Get        GetResourceDecl
 }
 
 func (d *ResourceDecl) recordSyntax() *syntax.Node {
 	return &d.syntax
 }
 
+// The names of exported fields.
+func (*ResourceDecl) Fields() []string {
+	return []string{"type", "properties", "options", "get"}
+}
+
 func ResourceSyntax(node *syntax.ObjectNode, typ *StringExpr,
-	properties PropertyMapDecl, options ResourceOptionsDecl) *ResourceDecl {
+	properties PropertyMapDecl, options ResourceOptionsDecl, get GetResourceDecl) *ResourceDecl {
 	return &ResourceDecl{
 		declNode:   decl(node),
 		Type:       typ,
 		Properties: properties,
 		Options:    options,
+		Get:        get,
 	}
 }
 
-func Resource(typ *StringExpr, properties PropertyMapDecl, options ResourceOptionsDecl) *ResourceDecl {
-	return ResourceSyntax(nil, typ, properties, options)
+func Resource(typ *StringExpr, properties PropertyMapDecl, options ResourceOptionsDecl, get GetResourceDecl) *ResourceDecl {
+	return ResourceSyntax(nil, typ, properties, options, get)
 }
 
 type CustomTimeoutsDecl struct {

--- a/pkg/pulumiyaml/codegen/gen_program_test.go
+++ b/pkg/pulumiyaml/codegen/gen_program_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-var defaultPlugins []pulumiyaml.Plugin = []pulumiyaml.Plugin{
+var defaultPlugins = []pulumiyaml.Plugin{
 	{Package: "aws", Version: "5.4.0"},
 	{Package: "azure-native", Version: "1.56.0"},
 	{Package: "azure", Version: "4.18.0"},
@@ -76,7 +76,7 @@ func newPluginLoader() schema.Loader {
 	return schema.NewPluginLoader(deploytest.NewPluginHost(nil, nil, nil, pluginLoaders...))
 }
 
-var rootPluginLoader schema.Loader = newPluginLoader()
+var rootPluginLoader = newPluginLoader()
 
 // We stub out the real plugin hosting architecture for a fake that gives us reasonably good
 // results without the time and compute

--- a/pkg/pulumiyaml/expr.go
+++ b/pkg/pulumiyaml/expr.go
@@ -25,6 +25,9 @@ func GetResourceDependencies(r *ast.ResourceDecl) []*ast.StringExpr {
 	if r.Options.Providers != nil {
 		getExpressionDependencies(&deps, r.Options.Providers)
 	}
+	if r.Get.Id != nil {
+		getExpressionDependencies(&deps, r.Get.Id)
+	}
 	return deps
 }
 

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 	"gopkg.in/yaml.v3"
@@ -756,15 +757,22 @@ func (ctx *evalContext) registerResource(kvp resourceNode) (lateboundResource, b
 		overallOk = false
 	}
 
-	for _, kvp := range v.Properties.Entries {
-		vv, ok := ctx.evaluateExpr(kvp.Value)
-		if !ok {
-			overallOk = false
+	readIntoProperties := func(obj ast.PropertyMapDecl) (poisonMarker, bool) {
+		for _, kvp := range obj.Entries {
+			vv, ok := ctx.evaluateExpr(kvp.Value)
+			if !ok {
+				overallOk = false
+			}
+			if p, ok := vv.(poisonMarker); ok {
+				return p, true
+			}
+			props[kvp.Key.Value] = vv
 		}
-		if p, ok := vv.(poisonMarker); ok {
-			return p, true
-		}
-		props[kvp.Key.Value] = vv
+		return poisonMarker{}, false
+	}
+
+	if p, isPoison := readIntoProperties(v.Properties); isPoison {
+		return p, isPoison
 	}
 
 	var opts []pulumi.ResourceOption
@@ -914,9 +922,21 @@ func (ctx *evalContext) registerResource(kvp resourceNode) (lateboundResource, b
 		props[k] = v
 	}
 
+	isRead := v.Get.Id.GetValue() != ""
+	if isRead {
+		contract.Assertf(len(props) == 0, "Failed to check that Properties cannot be specified with Get.State")
+		p, isPoison := readIntoProperties(v.Get.State)
+		if isPoison {
+			return p, true
+		}
+	}
+
 	// Now register the resulting resource with the engine.
 	if isComponent {
 		err = ctx.ctx.RegisterRemoteComponentResource(string(typ), k, untypedArgs(props), res, opts...)
+	} else if isRead {
+		id := pulumi.ID(v.Get.Id.GetValue())
+		err = ctx.ctx.ReadResource(string(typ), k, id, untypedArgs(props), res.(pulumi.CustomResource), opts...)
 	} else {
 		err = ctx.ctx.RegisterResource(string(typ), k, untypedArgs(props), res, opts...)
 	}

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -132,7 +132,20 @@ func testInvokeDiags(t *testing.T, template *ast.TemplateDecl, callback func(*ru
 			return resource.PropertyMap{}, fmt.Errorf("Unexpected invoke %s", args.Token)
 		},
 		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
-
+			if args.ReadRPC != nil {
+				switch args.TypeToken {
+				case "test:read:Resource":
+					assert.Equal(t, "bucket-123456", args.ID)
+					assert.Equal(t, `string_value:"bar"`, args.ReadRPC.Properties.Fields["foo"].String())
+					assert.Len(t, args.ReadRPC.Properties.Fields, 1)
+					return "arn:aws:s3:::" + args.ID, resource.PropertyMap{
+						"tags": resource.NewObjectProperty(resource.PropertyMap{
+							"isRight": resource.NewStringProperty("yes"),
+						}),
+					}, nil
+				}
+				return "", resource.PropertyMap{}, fmt.Errorf("Unexpected read resource type %s", args.TypeToken)
+			}
 			switch args.TypeToken {
 			case testResourceToken:
 				assert.Equal(t, testResourceToken, args.TypeToken)

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -1720,3 +1720,31 @@ variables:
 			"<stdin>:4:10: Property access expressions cannot be empty",
 		})
 }
+
+func TestReadResource(t *testing.T) {
+	text := `
+name: consumer
+runtime: yaml
+resources:
+  bucket:
+    type: test:read:Resource
+    get:
+      id: ${id}
+      state:
+        foo: bar
+variables:
+  id: bucket-123456
+  isRight: ${bucket.tags["isRight"]}
+`
+	templ := yamlTemplate(t, text)
+	var wasRun bool
+	diags := testInvokeDiags(t, templ, func(r *runner) {
+		r.variables["isRight"].(pulumi.AnyOutput).ApplyT(func(s interface{}) interface{} {
+			wasRun = true
+			assert.Equal(t, "yes", s)
+			return s
+		})
+	})
+	assert.True(t, wasRun)
+	assert.Len(t, diags, 0)
+}

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -1722,6 +1722,7 @@ variables:
 }
 
 func TestReadResource(t *testing.T) {
+	t.Parallel()
 	text := `
 name: consumer
 runtime: yaml

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -171,7 +171,7 @@ func TestGenerateExamples(t *testing.T) {
 	}
 }
 
-var defaultPlugins []pulumiyaml.Plugin = []pulumiyaml.Plugin{
+var defaultPlugins = []pulumiyaml.Plugin{
 	{Package: "aws", Version: "5.4.0"},
 	{Package: "azure-native", Version: "1.56.0"},
 	{Package: "azure", Version: "4.18.0"},


### PR DESCRIPTION
Fixes #155 

Introduce syntax to initiate `ReadResource` requests. The syntax for making such a request is as follows:
```yaml
runtime: yaml
resources:
  bucket:
    type: aws:s3:BucketV2
    get:
      id: ${id}
      state:
        arn: ${arn}
```

The `get` field is mutually exclusive with the `properties` field, and Pulumi YAML errors if both are supplied.

- [x] Add a test.
- [ ] Update documentation as follow up.