### PR TITLE
Add sugar for `Fn::Invoke`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,4 +9,7 @@
 - Add `Get` to resources, allowing Pulumi YAML programs to read external resources.
   [#290](https://github.com/pulumi/pulumi-yaml/pull/290)
 
+- Add sugar for `Fn::Invoke`
+  [#294](https://github.com/pulumi/pulumi-yaml/pull/294)
+
 ### Bug Fixes

--- a/examples/azure-container-apps/Pulumi.yaml
+++ b/examples/azure-container-apps/Pulumi.yaml
@@ -20,7 +20,7 @@ variables:
       registryName: ${registry.name}
   adminUsername: ${adminRegistryCreds.username}
   adminPasswords:
-    Fn::Secret: ${adminRegistryCreds.password}
+    Fn::Secret: ${adminRegistryCreds.passwords}
 resources:
   resourceGroup:
     type: azure-native:resources:ResourceGroup
@@ -70,8 +70,8 @@ resources:
       kubeEnvironmentId: ${kubeEnv}
       configuration:
         ingress:
-            external: true
-            targetPort: 80
+          external: true
+          targetPort: 80
         registries:
           - server: ${registry.loginServer}
             username: ${adminUsername}

--- a/examples/azure-container-apps/Pulumi.yaml
+++ b/examples/azure-container-apps/Pulumi.yaml
@@ -14,13 +14,12 @@ variables:
           resourceGroupName: ${resourceGroup.name}
           workspaceName: ${workspace.name}
         Return: primarySharedKey
-  adminUsername:
-    Fn::Invoke:
-      Function: azure-native:containerregistry:listRegistryCredentials
+  adminRegistryCreds:
+    Fn::azure-native:containerregistry:listRegistryCredentials:
       Arguments:
         resourceGroupName: ${resourceGroup.name}
         registryName: ${registry.name}
-      Return: username
+  adminUsername: ${adminRegistryCreds.username}
   adminPasswords:
     Fn::Secret:
       Fn::Invoke:

--- a/examples/azure-container-apps/Pulumi.yaml
+++ b/examples/azure-container-apps/Pulumi.yaml
@@ -20,13 +20,7 @@ variables:
       registryName: ${registry.name}
   adminUsername: ${adminRegistryCreds.username}
   adminPasswords:
-    Fn::Secret:
-      Fn::Invoke:
-        Function: azure-native:containerregistry:listRegistryCredentials
-        Arguments:
-          resourceGroupName: ${resourceGroup.name}
-          registryName: ${registry.name}
-        Return: passwords
+    Fn::Secret: ${adminRegistryCreds.password}
 resources:
   resourceGroup:
     type: azure-native:resources:ResourceGroup

--- a/examples/azure-container-apps/Pulumi.yaml
+++ b/examples/azure-container-apps/Pulumi.yaml
@@ -16,9 +16,8 @@ variables:
         Return: primarySharedKey
   adminRegistryCreds:
     Fn::azure-native:containerregistry:listRegistryCredentials:
-      Arguments:
-        resourceGroupName: ${resourceGroup.name}
-        registryName: ${registry.name}
+      resourceGroupName: ${resourceGroup.name}
+      registryName: ${registry.name}
   adminUsername: ${adminRegistryCreds.username}
   adminPasswords:
     Fn::Secret:

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -747,7 +747,7 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		// Fn::Invoke can be called as Fn::{pkg}:{Name}
 		if match, _ := regexp.MatchString(fnInvokeRegexPattern, k); match {
 			// transform the node into standard Fn::Invoke format
-			fnVal := strings.Split(k, "Fn::")[1]
+			fnVal := strings.TrimPrefix(k, "Fn::")
 			if _, ok := kvp.Value.(*syntax.ObjectNode); ok {
 				kvp.Value = syntax.Object(
 					syntax.ObjectPropertyDef{

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -744,7 +744,8 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 	default:
 		var diags syntax.Diagnostics
 		k := kvp.Key.Value()
-		// Fn::Invoke can be called as Fn::{pkg}:{Name}
+		// Fn::Invoke can be called as FN::${pkg}:${module}(:${name})?
+		// error is thrown if regex pattern cannot be parsed — handled by `regex.MustCompile(fnInvokeRegexPattern)`
 		if match, _ := regexp.MatchString(fnInvokeRegexPattern, k); match {
 			// transform the node into standard Fn::Invoke format
 			fnVal := strings.TrimPrefix(k, "Fn::")

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-const fnInvokeRegexPattern = "Fn::([A-Za-z]+):([A-Za-z]+)(:)?([A-Za-z]*)"
+const fnInvokeRegexPattern = "Fn::.+:.+(:.+)?"
 
 // Expr represents a Pulumi YAML expression. Expressions may be literals, interpolated strings, symbols, or builtin
 // functions.

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-const fnInvokeRegexPattern = "Fn::.+:.+(:.+)?"
+var fnInvokeRegex = regex.MustCompile("Fn::.+:.+(:.+)?")
 
 // Expr represents a Pulumi YAML expression. Expressions may be literals, interpolated strings, symbols, or builtin
 // functions.

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-var fnInvokeRegex = regex.MustCompile("Fn::.+:.+(:.+)?")
+var fnInvokeRegex = regexp.MustCompile("Fn::[^:]+:[^:]+(:[^:]+)?$")
 
 // Expr represents a Pulumi YAML expression. Expressions may be literals, interpolated strings, symbols, or builtin
 // functions.
@@ -745,8 +745,8 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		var diags syntax.Diagnostics
 		k := kvp.Key.Value()
 		// Fn::Invoke can be called as FN::${pkg}:${module}(:${name})?
-		// error is thrown if regex pattern cannot be parsed — handled by `regex.MustCompile(fnInvokeRegexPattern)`
-		if match, _ := regexp.MatchString(fnInvokeRegexPattern, k); match {
+		// error is thrown if regex pattern cannot be parsed — handled by `regex.MustCompile(fnInvokeRegex)`
+		if match, _ := regexp.MatchString(fnInvokeRegex.String(), k); match {
 			// transform the node into standard Fn::Invoke format
 			fnVal := strings.TrimPrefix(k, "Fn::")
 			if _, ok := kvp.Value.(*syntax.ObjectNode); ok {

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -197,7 +197,7 @@ func TestInvokeNoInputsSugar(t *testing.T) {
 	const text = `
 variables:
   config:
-    Fn::test:invoke:empty:
+    Fn::test:invoke:empty: {}
 outputs:
   v: ${config.subscriptionId}
 name: test-yaml

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -143,6 +143,72 @@ runtime: yaml
 	requireNoErrors(t, tmpl, diags)
 }
 
+func TestInvokeVariableSugar(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+variables:
+  foo:
+    Fn::test:invoke:type:
+      quux: tuo
+resources:
+  res-a:
+    type: test:resource:type
+    properties:
+      foo: ${foo.retval}
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	diags := testInvokeDiags(t, tmpl, func(r *runner) {})
+	requireNoErrors(t, tmpl, diags)
+}
+
+func TestInvokeOutputVariableSugar(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+variables:
+  foo:
+    Fn::test:invoke:type:
+      quux: ${res-a.out}
+resources:
+  res-a:
+    type: test:resource:type
+    properties:
+      foo: oof
+  res-b:
+    type: test:resource:type
+    properties:
+      foo: ${foo.retval}
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	diags := testInvokeDiags(t, tmpl, func(r *runner) {})
+	requireNoErrors(t, tmpl, diags)
+}
+
+func TestInvokeNoInputsSugar(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+variables:
+  config:
+    Fn::test:invoke:empty:
+outputs:
+  v: ${config.subscriptionId}
+name: test-yaml
+runtime: yaml
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	diags := testInvokeDiags(t, tmpl, func(r *runner) {})
+	requireNoErrors(t, tmpl, diags)
+}
+
 func testInvokeDiags(t *testing.T, template *ast.TemplateDecl, callback func(*runner)) syntax.Diagnostics {
 	mocks := &testMonitor{
 		CallF: func(args pulumi.MockCallArgs) (resource.PropertyMap, error) {

--- a/pkg/tests/transpiled_examples/azure-container-apps/program.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps/program.pp
@@ -78,7 +78,7 @@ resource containerapp "azure-native:web:ContainerApp" {
 	kubeEnvironmentId = kubeEnv.id
 	configuration = {
 		ingress = {
-			texternal = true,
+		texternal = true,
 			external = true,
 			targetPort = 80
 		},

--- a/pkg/tests/transpiled_examples/azure-container-apps/program.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps/program.pp
@@ -11,10 +11,7 @@ adminRegistryCreds = invoke("azure-native:containerregistry:listRegistryCredenti
 	registryName = registry.name
 })
 adminUsername = adminRegistryCreds.username
-adminPasswords = secret(invoke("azure-native:containerregistry:listRegistryCredentials", {
-	resourceGroupName = resourceGroup.name,
-	registryName = registry.name
-}).passwords)
+adminPasswords = secret(adminRegistryCreds.password)
 
 resource resourceGroup "azure-native:resources:ResourceGroup" {
 	__logicalName = "resourceGroup"

--- a/pkg/tests/transpiled_examples/azure-container-apps/program.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps/program.pp
@@ -6,10 +6,11 @@ sharedKey = secret(invoke("azure-native:operationalinsights:getSharedKeys", {
 	resourceGroupName = resourceGroup.name,
 	workspaceName = workspace.name
 }).primarySharedKey)
-adminUsername = invoke("azure-native:containerregistry:listRegistryCredentials", {
+adminRegistryCreds = invoke("azure-native:containerregistry:listRegistryCredentials", {
 	resourceGroupName = resourceGroup.name,
 	registryName = registry.name
-}).username
+})
+adminUsername = adminRegistryCreds.username
 adminPasswords = secret(invoke("azure-native:containerregistry:listRegistryCredentials", {
 	resourceGroupName = resourceGroup.name,
 	registryName = registry.name
@@ -77,7 +78,7 @@ resource containerapp "azure-native:web:ContainerApp" {
 	kubeEnvironmentId = kubeEnv.id
 	configuration = {
 		ingress = {
-			external = true,
+			texternal = true,
 			targetPort = 80
 		},
 		registries = [{

--- a/pkg/tests/transpiled_examples/azure-container-apps/program.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps/program.pp
@@ -79,6 +79,7 @@ resource containerapp "azure-native:web:ContainerApp" {
 	configuration = {
 		ingress = {
 			texternal = true,
+			external = true,
 			targetPort = 80
 		},
 		registries = [{

--- a/pkg/tests/transpiled_examples/azure-container-apps/program.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps/program.pp
@@ -11,7 +11,7 @@ adminRegistryCreds = invoke("azure-native:containerregistry:listRegistryCredenti
 	registryName = registry.name
 })
 adminUsername = adminRegistryCreds.username
-adminPasswords = secret(adminRegistryCreds.password)
+adminPasswords = secret(adminRegistryCreds.passwords)
 
 resource resourceGroup "azure-native:resources:ResourceGroup" {
 	__logicalName = "resourceGroup"

--- a/pkg/tests/transpiled_examples/azure-container-apps/program.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps/program.pp
@@ -78,7 +78,6 @@ resource containerapp "azure-native:web:ContainerApp" {
 	kubeEnvironmentId = kubeEnv.id
 	configuration = {
 		ingress = {
-		texternal = true,
 			external = true,
 			targetPort = 80
 		},


### PR DESCRIPTION
Fixes #288 
Supports a more natural way of calling `Fn::Invoke` for calls with only `Arguments`, i.e.
```
Fn::pkg:module:Name:
  Arg1: ${Arg1}
  Arg2: ${Arg2}
# Would be equivalent to:
Fn::Invoke:
  Function: pkg:module:Name
  Arguments:
    Arg1: ${Arg1}
    Arg2: ${Arg2}
```

`Fn::Invoke` will still be supported for supplying invoke `Options` and `Return` values 

Todo: update docs