### PR TITLE
deduplicate template syntax error log message

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,5 +8,8 @@
 
 - Add `Get` to resources, allowing Pulumi YAML programs to read external resources.
   [#290](https://github.com/pulumi/pulumi-yaml/pull/290)
+  
+- pulumi yaml syntax errors emit one less log message
+  [#300](https://github.com/pulumi/pulumi-yaml/pull/300)
 
 ### Bug Fixes

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -162,7 +162,7 @@ func (host *yamlLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 				return nil, err
 			}
 			if diags.HasErrors() {
-				return &pulumirpc.RunResponse{Error: "failed to evaluate template"}, nil
+				return &pulumirpc.RunResponse{Error: "", Bail: true}, nil
 			}
 			return &pulumirpc.RunResponse{}, nil
 		}


### PR DESCRIPTION
pulumi yaml syntax errors no longer emit an extra log message

fixes #297

new state:
[![asciicast](https://asciinema.org/a/tXtTVPWlMpqD6wPkuxdGahekl.svg)](https://asciinema.org/a/tXtTVPWlMpqD6wPkuxdGahekl)

old state:
[![asciicast](https://asciinema.org/a/R1UqU31ts8dZxUwApA1wI24zU.svg)](https://asciinema.org/a/R1UqU31ts8dZxUwApA1wI24zU)

opinions?