### PR TITLE
Introduce Int Type + Refactor Config Types

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,13 +2,13 @@
 
 - Show all error/ warning messages
   [#279](https://github.com/pulumi/pulumi-yaml/pull/279)
-  
+
 - Support options on Fn::Invoke.
   [#284](https://github.com/pulumi/pulumi-yaml/pull/284)
 
 - Add `Get` to resources, allowing Pulumi YAML programs to read external resources.
   [#290](https://github.com/pulumi/pulumi-yaml/pull/290)
-  
+
 - pulumi yaml syntax errors emit one less log message
   [#300](https://github.com/pulumi/pulumi-yaml/pull/300)
 
@@ -20,6 +20,9 @@
 
 - CI check to ensure `pu/pkg` and `pu/sdk` versions are merged
   [#307](https://github.com/pulumi/pulumi-yaml/pull/307)
+
+- Add `Int` type to the configuration section.
+  [#313](https://github.com/pulumi/pulumi-yaml/pull/313)
 
 ### Bug Fixes
 

--- a/pkg/pulumiyaml/analyser_test.go
+++ b/pkg/pulumiyaml/analyser_test.go
@@ -239,7 +239,7 @@ func TestTypePropertyAccess(t *testing.T) {
 				&ast.PropertySubscript{Index: "bar"},
 			},
 			expectedType: "Invalid",
-			errMsg: `Cannot access into start of type Union<List<string>, Map<number>, >:'start' could be a type that does not support accessing:
+			errMsg: `Cannot access into start of type Union<List<string>, Map<number>, {foo: List<any>}>:'start' could be a type that does not support accessing:
   Array<string>: cannot access a property on 'start' (type List<string>)
   Map<number>: cannot access a property on 'start' (type Map<number>)
   Cannot index via string into 'start.foo' (type List<any>)`,

--- a/pkg/pulumiyaml/config/config.go
+++ b/pkg/pulumiyaml/config/config.go
@@ -33,13 +33,13 @@ func (t typ) Schema() schema.Type {
 
 var (
 	String      Type = typ{schema.StringType}
-	StringList       = newList(String)
+	StringList       = typ{&schema.ArrayType{ElementType: schema.StringType}}
 	Number           = typ{schema.NumberType}
-	NumberList       = newList(Number)
+	NumberList       = typ{&schema.ArrayType{ElementType: schema.NumberType}}
 	Boolean          = typ{schema.BoolType}
-	BooleanList      = newList(Boolean)
+	BooleanList      = typ{&schema.ArrayType{ElementType: schema.NumberType}}
 	Int              = typ{schema.IntType}
-	IntList          = newList(Int)
+	IntList          = typ{&schema.ArrayType{ElementType: schema.IntType}}
 	Invalid          = typ{&schema.InvalidType{}}
 )
 
@@ -48,6 +48,7 @@ type Types []Type
 var Primitives = Types{
 	String,
 	Number,
+	Int,
 	Boolean,
 }
 
@@ -56,12 +57,26 @@ var ConfigTypes = Types{
 	StringList,
 	Number,
 	NumberList,
+	Int,
+	IntList,
 	Boolean,
 	BooleanList,
 }
 
 func newList(c Type) typ {
-	return typ{&schema.ArrayType{ElementType: c.(typ).inner}}
+	// This is necessary to preserve switch equality
+	switch c {
+	case String:
+		return StringList
+	case Number:
+		return NumberList
+	case Int:
+		return IntList
+	case Boolean:
+		return BooleanList
+	default:
+		return typ{&schema.ArrayType{ElementType: c.(typ).inner}}
+	}
 }
 
 func IsValidType(c Type) bool {

--- a/pkg/pulumiyaml/config/config.go
+++ b/pkg/pulumiyaml/config/config.go
@@ -140,6 +140,11 @@ func (e *HeterogeneousListErr) Error() string {
 		e.T1, e.T2)
 }
 
+func (e *HeterogeneousListErr) Is(err error) bool {
+	_, ok := err.(*HeterogeneousListErr)
+	return ok
+}
+
 type UnexpectedTypeErr struct {
 	T interface{}
 }
@@ -151,6 +156,11 @@ func (e *UnexpectedTypeErr) Error() string {
 	return fmt.Sprintf("unexpected configuration type '%T': valid types are %s",
 		e.T, ConfigTypes,
 	)
+}
+
+func (e *UnexpectedTypeErr) Is(err error) bool {
+	_, ok := err.(*UnexpectedTypeErr)
+	return ok
 }
 
 // Type a go value into a configuration value.

--- a/pkg/pulumiyaml/config/config_test.go
+++ b/pkg/pulumiyaml/config/config_test.go
@@ -37,7 +37,7 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestTypeValue(t *testing.T) { //nolint:paralleltest
+func TestTypeValue(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		input    interface{}
@@ -54,6 +54,7 @@ func TestTypeValue(t *testing.T) { //nolint:paralleltest
 		{[]interface{}{}, nil, ErrEmptyList},
 		{[]interface{}{false, true}, BooleanList, nil},
 	}
+	//nolint:paralleltest // false positive that the "c" var isn't used, it is used via "c.input"
 	for _, c := range cases {
 		c := c
 		t.Run(fmt.Sprintf("%v", c.input), func(t *testing.T) {

--- a/pkg/pulumiyaml/config/config_test.go
+++ b/pkg/pulumiyaml/config/config_test.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,38 @@ func TestParse(t *testing.T) {
 			} else {
 				assert.True(t, ok)
 				assert.Equal(t, c.expected, output)
+			}
+		})
+	}
+}
+
+func TestTypeValue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input    interface{}
+		expected Type
+		error    error
+	}{
+		{"foo", String, nil},
+		{123, Int, nil},
+		{3.14, Number, nil},
+		{[]interface{}{123, 345}, IntList, nil},
+		{[]interface{}{123, 3.14}, nil, &ErrHeterogeneousList},
+		{struct{ s int }{8}, nil, &ErrUnexpectedType},
+		{[]int{}, IntList, nil},
+		{[]interface{}{}, nil, ErrEmptyList},
+		{[]interface{}{false, true}, BooleanList, nil},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(fmt.Sprintf("%v", c.input), func(t *testing.T) {
+			t.Parallel()
+			typ, err := TypeValue(c.input)
+			if c.error == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, c.expected, typ)
+			} else {
+				assert.ErrorIs(t, err, c.error)
 			}
 		})
 	}

--- a/pkg/pulumiyaml/config/config_test.go
+++ b/pkg/pulumiyaml/config/config_test.go
@@ -37,7 +37,7 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestTypeValue(t *testing.T) {
+func TestTypeValue(t *testing.T) { //nolint:paralleltest
 	t.Parallel()
 	cases := []struct {
 		input    interface{}
@@ -56,7 +56,7 @@ func TestTypeValue(t *testing.T) {
 	}
 	for _, c := range cases {
 		c := c
-		t.Run(fmt.Sprintf("%v", c.input), func(t *testing.T) { //nolint:paralleltest
+		t.Run(fmt.Sprintf("%v", c.input), func(t *testing.T) {
 			t.Parallel()
 			typ, err := TypeValue(c.input)
 			if c.error == nil {

--- a/pkg/pulumiyaml/config/config_test.go
+++ b/pkg/pulumiyaml/config/config_test.go
@@ -56,7 +56,7 @@ func TestTypeValue(t *testing.T) {
 	}
 	for _, c := range cases {
 		c := c
-		t.Run(fmt.Sprintf("%v", c.input), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v", c.input), func(t *testing.T) { //nolint:paralleltest
 			t.Parallel()
 			typ, err := TypeValue(c.input)
 			if c.error == nil {

--- a/pkg/pulumiyaml/diags/types.go
+++ b/pkg/pulumiyaml/diags/types.go
@@ -1,0 +1,64 @@
+package diags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+func DisplayType(t schema.Type) string {
+	return DisplayTypeWithAdhock(t, "")
+}
+
+func DisplayTypeWithAdhock(t schema.Type, adhockObjectToken string) string {
+	if schema.IsPrimitiveType(codegen.UnwrapType(t)) {
+		switch codegen.UnwrapType(t) {
+		case schema.ArchiveType:
+			return "archive"
+		case schema.AssetType:
+			return "asset"
+		case schema.JSONType:
+			fallthrough
+		case schema.AnyType:
+			return "any"
+		}
+
+		return codegen.UnwrapType(t).String()
+	}
+	switch t := codegen.UnwrapType(t).(type) {
+	case *schema.ObjectType:
+		if (adhockObjectToken != "" && strings.HasPrefix(t.Token, adhockObjectToken)) || t.Token == "" {
+			// The token is useless so display the fields
+			props := []string{}
+			for _, prop := range t.Properties {
+				props = append(props, fmt.Sprintf("%s: %s", prop.Name,
+					DisplayTypeWithAdhock(prop.Type, adhockObjectToken)))
+			}
+			return fmt.Sprintf("{%s}", strings.Join(props, ", "))
+		}
+		return t.Token
+
+	case *schema.ArrayType:
+		return fmt.Sprintf("List<%s>",
+			DisplayTypeWithAdhock(t.ElementType, adhockObjectToken))
+	case *schema.MapType:
+		return fmt.Sprintf("Map<%s>",
+			DisplayTypeWithAdhock(t.ElementType, adhockObjectToken))
+	case *schema.UnionType:
+		inner := make([]string, len(t.ElementTypes))
+		for i, t := range t.ElementTypes {
+			inner[i] = DisplayTypeWithAdhock(t, adhockObjectToken)
+		}
+		return fmt.Sprintf("Union<%s>", strings.Join(inner, ", "))
+	case *schema.TokenType:
+		underlying := DisplayTypeWithAdhock(schema.AnyType, adhockObjectToken)
+		if t.UnderlyingType != nil {
+			underlying = DisplayTypeWithAdhock(t.UnderlyingType, adhockObjectToken)
+		}
+		return fmt.Sprintf("%s<type = %s>", t.Token, underlying)
+	default:
+		return t.String()
+	}
+}

--- a/pkg/pulumiyaml/diags/types.go
+++ b/pkg/pulumiyaml/diags/types.go
@@ -1,3 +1,5 @@
+// Copyright 2022, Pulumi Corporation.  All rights reserved.
+
 package diags
 
 import (

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -727,8 +727,10 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 		switch d := d.(type) {
 		case string:
 			expectedType = ctypes.String
-		case float64, int:
+		case float64:
 			expectedType = ctypes.Number
+		case int:
+			expectedType = ctypes.Int
 		case bool:
 			expectedType = ctypes.Boolean
 		case []interface{}:
@@ -739,8 +741,10 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 			switch d[0].(type) {
 			case string:
 				expectedType = ctypes.StringList
-			case int, float64:
+			case float64:
 				expectedType = ctypes.NumberList
+			case int:
+				expectedType = ctypes.IntList
 			case bool:
 				expectedType = ctypes.BooleanList
 			}
@@ -750,8 +754,10 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 						"heterogeneous typed lists are not allowed: found types %T and %T", d[i-1], d[i])
 				}
 			}
-		case []int, []float64:
+		case []float64:
 			expectedType = ctypes.NumberList
+		case []int:
+			expectedType = ctypes.IntList
 		default:
 			return ctx.errorf(c.Default,
 				"unexpected configuration type '%T': valid types are %s",

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -800,7 +800,7 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 				" if the associated config value is secret")
 	}
 
-	var v interface{}
+	var v interface{} = nil
 	var err error
 	switch expectedType {
 	case ctypes.String:
@@ -852,6 +852,8 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 	} else if err != nil {
 		return ctx.errorf(intm.Key, err.Error())
 	}
+
+	contract.Assertf(v != nil, "let an uninitialized var slip through")
 
 	// The value was marked secret in the configuration section, but in the
 	// config section. We need to wrap it in `pulumi.ToSecret`.

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -800,7 +800,7 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 				" if the associated config value is secret")
 	}
 
-	var v interface{} = nil
+	var v interface{}
 	var err error
 	switch expectedType {
 	case ctypes.String:

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -815,6 +815,18 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 		} else {
 			v, err = config.TryFloat64(ctx.ctx, k)
 		}
+	case ctypes.Int:
+		if isSecretInConfig {
+			v, err = config.TrySecretInt(ctx.ctx, k)
+		} else {
+			v, err = config.TryInt(ctx.ctx, k)
+		}
+	case ctypes.Boolean:
+		if isSecretInConfig {
+			v, err = config.TrySecretBool(ctx.ctx, k)
+		} else {
+			v, err = config.TryInt(ctx.ctx, k)
+		}
 	case ctypes.NumberList:
 		var arr []float64
 		if isSecretInConfig {
@@ -822,6 +834,16 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 		} else {
 			err = config.TryObject(ctx.ctx, k, &arr)
 			if err == nil {
+				v = arr
+			}
+		}
+	case ctypes.IntList:
+		var arr []int
+		if isSecretInConfig {
+			v, err = config.TrySecretObject(ctx.ctx, k, &arr)
+		} else {
+			err = config.TryObject(ctx.ctx, k, &arr)
+			if err != nil {
 				v = arr
 			}
 		}

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -723,46 +723,12 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 		if !ok {
 			return nil, false
 		}
-		defaultValue = d
-		switch d := d.(type) {
-		case string:
-			expectedType = ctypes.String
-		case float64:
-			expectedType = ctypes.Number
-		case int:
-			expectedType = ctypes.Int
-		case bool:
-			expectedType = ctypes.Boolean
-		case []interface{}:
-			if len(d) == 0 && c.Type == nil {
-				return ctx.errorf(c.Default,
-					"unable to infer type: cannot infer type of empty list, please specify type")
-			}
-			switch d[0].(type) {
-			case string:
-				expectedType = ctypes.StringList
-			case float64:
-				expectedType = ctypes.NumberList
-			case int:
-				expectedType = ctypes.IntList
-			case bool:
-				expectedType = ctypes.BooleanList
-			}
-			for i := 1; i < len(d); i++ {
-				if reflect.TypeOf(d[i-1]) != reflect.TypeOf(d[i]) {
-					return ctx.errorf(c.Default,
-						"heterogeneous typed lists are not allowed: found types %T and %T", d[i-1], d[i])
-				}
-			}
-		case []float64:
-			expectedType = ctypes.NumberList
-		case []int:
-			expectedType = ctypes.IntList
-		default:
-			return ctx.errorf(c.Default,
-				"unexpected configuration type '%T': valid types are %s",
-				d, ctypes.ConfigTypes)
+		var err error
+		expectedType, err = ctypes.TypeValue(d)
+		if err != nil {
+			return ctx.error(c.Default, err.Error())
 		}
+		defaultValue = d
 	}
 
 	if c.Type != nil {
@@ -825,7 +791,7 @@ func (ctx *evalContext) registerConfig(intm configNode) (interface{}, bool) {
 		if isSecretInConfig {
 			v, err = config.TrySecretBool(ctx.ctx, k)
 		} else {
-			v, err = config.TryInt(ctx.ctx, k)
+			v, err = config.TryBool(ctx.ctx, k)
 		}
 	case ctypes.NumberList:
 		var arr []float64

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -448,7 +448,7 @@ configuration:
 		diagStrings = append(diagStrings, diagString(v))
 	}
 	assert.Contains(t, diagStrings,
-		"<stdin>:4:3: type mismatch: default value of type Number but type String was specified")
+		"<stdin>:4:3: type mismatch: default value of type number but type string was specified")
 	assert.Contains(t, diagStrings,
 		"<stdin>:7:3: unable to infer type: either 'default' or 'type' is required")
 	assert.Contains(t, diagStrings,


### PR DESCRIPTION
This PR improves the config in 4 ways:
1. It refactors backing config types to use `schema.Type` instead of string equality. This allows us to share `DisplayType`, so that config error messages and type error messages display types the same way.
2. It introduces the `Int` type, providing a distinction between `Number`(float64) and `Int`(int) in the config type system.
3. It allows `Boolean` types to be correctly read from the config (since that was missing before).
4. Fixes a bug in displaying adhock object types.

Part of https://github.com/pulumi/pulumi-yaml/issues/306.