### PR TITLE
fix: Type checker inaccurately allows using 'id' property of a component resource

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -38,3 +38,6 @@
 
 - Fix panic on empty object node on `pulumi convert`
   [#321](https://github.com/pulumi/pulumi-yaml/pull/321)
+
+- Fix type checker inaccurately allows using 'id' property of a component resource
+  [#324](https://github.com/pulumi/pulumi-yaml/pull/324)

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -663,7 +663,9 @@ func typePropertyAccess(ctx *evalContext, root schema.Type,
 			for _, prop := range root.Resource.Properties {
 				properties[prop.Name] = prop.Type
 			}
-			properties["id"] = schema.StringType
+			if !root.Resource.IsComponent {
+				properties["id"] = schema.StringType
+			}
 			properties["urn"] = schema.StringType
 		case *schema.InvalidType:
 			return root


### PR DESCRIPTION
Fixes the invalid Pulumi YAML program execution in #323, with this change the program in that issue will report an error like so:

```
pulumi:pulumi:Stack (k8s-aws-yaml-dev):
    error: id does not exist on vpc
    
      on Pulumi.yaml line 37:
      37:       vpcId: ${vpc.id}
    
    Existing properties are: eips, urn, vpc, vpcId, routes and 9 others
```

Hopefully pointing them in the direction of using `vpc.vpcId`.