### PR TITLE
Add codegen load config types

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -44,3 +44,6 @@
 
 - Fix resource option typo that make `parent` becomes `provider`
   [#326](https://github.com/pulumi/pulumi-yaml/pull/326)
+
+- Support ejecting all config types to other languages.
+  [#329](https://github.com/pulumi/pulumi-yaml/pull/329)

--- a/examples/azure-container-apps/Pulumi.yaml
+++ b/examples/azure-container-apps/Pulumi.yaml
@@ -5,6 +5,9 @@ configuration:
   sqlAdmin:
     type: String
     default: pulumi
+  retentionInDays:
+    default: 30
+    type: Int
 variables:
   sharedKey:
     Fn::Secret:
@@ -30,7 +33,7 @@ resources:
       resourceGroupName: ${resourceGroup.name}
       sku:
         name: "PerGB2018"
-      retentionInDays: 30
+      retentionInDays: ${retentionInDays}
   kubeEnv:
     type: azure-native:web:KubeEnvironment
     properties:

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml"
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/ast"
+	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/config"
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 )
 
@@ -461,18 +462,11 @@ func (imp *importer) importExpr(node ast.Expr, hint schema.Type) (model.Expressi
 
 // importParameterType converts a YAML config variable type to its equivalent PCL type.
 func importParameterType(s string) (string, bool) {
-	switch s {
-	case "String":
-		return "string", true
-	case "Number":
-		return "number", true
-	case "List<Number>":
-		return "list(number)", true
-	case "List<String>":
-		return "list(string)", true
-	default:
+	t, ok := config.Parse(s)
+	if !ok {
 		return "", false
 	}
+	return t.Pcl().String(), true
 }
 
 // importConfig imports a template config variable. The parameter is imported as a simple config variable definition.

--- a/pkg/tests/transpiled_examples/azure-container-apps/program.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps/program.pp
@@ -2,6 +2,10 @@ config sqlAdmin string {
 	default = "pulumi"
 }
 
+config retentionInDays int {
+	default = 30
+}
+
 sharedKey = secret(invoke("azure-native:operationalinsights:getSharedKeys", {
 	resourceGroupName = resourceGroup.name,
 	workspaceName = workspace.name
@@ -23,7 +27,7 @@ resource workspace "azure-native:operationalinsights:Workspace" {
 	sku = {
 		name = "PerGB2018"
 	}
-	retentionInDays = 30
+	retentionInDays = retentionInDays
 }
 
 resource kubeEnv "azure-native:web:KubeEnvironment" {


### PR DESCRIPTION
This is another step of moving switch statements on config types into the `config` module itself. We were missing `Int` and `Boolean` types, as well as the ability to parse lower case types (`string`, `number`, ect...).

Fixes #328