### PR TITLE
Set highest package version on all resources

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,6 +28,9 @@
 - Support `options.version` on `pulumi convert`
   [#291](https://github.com/pulumi/pulumi-yaml/pull/291)
 
+- Set highest package version on all resources
+  [#331](https://github.com/pulumi/pulumi-yaml/pull/331)
+
 ### Bug Fixes
 
 - Allow `bool` configuration type

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -943,7 +943,8 @@ func (imp *importer) importTemplate(file *ast.TemplateDecl) (*model.Body, syntax
 	// Import resources.
 	highestPkgVersion := make(map[string]string)
 	for _, kvp := range file.Resources.Entries {
-		imp.getHighestPkgVersions(kvp, highestPkgVersion)
+		rdiags := imp.getHighestPkgVersions(kvp, highestPkgVersion)
+		diags.Extend(rdiags...)
 	}
 	for _, kvp := range file.Resources.Entries {
 		resource, rdiags := imp.importResource(kvp, highestPkgVersion)


### PR DESCRIPTION
This sets on all resources the highest version when converting from YAML to PCL on `pulumi convert`, if at least one resource has a version set

Necessary for changes here https://github.com/pulumi/pulumi/pull/10194/