### PR TITLE
Catch extra properties on nested objects

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -37,7 +37,7 @@
 - Set highest package version and pluginDownloadURL on all invokes
   [#334](https://github.com/pulumi/pulumi-yaml/pull/334)
 
-- Enable transformation & type checking passes on `pulumi convert` 
+- Enable transformation & type checking passes on `pulumi convert`
   [#320](https://github.com/pulumi/pulumi-yaml/pull/320)
 
 ### Bug Fixes
@@ -65,3 +65,6 @@
 
 - Fix generated `Pulumi.yaml` on convert
   [#339](https://github.com/pulumi/pulumi-yaml/pull/339)
+
+- Error on non-existent fields in nested properties
+  [#348](https://github.com/pulumi/pulumi-yaml/pull/348)

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -318,6 +318,13 @@ func isAssignable(from, to schema.Type) *notAssignable {
 				continue
 			}
 		}
+		for _, prop := range from.Properties {
+			if _, ok := to.Property(prop.Name); !ok {
+				failures = append(failures, &notAssignable{
+					reason: fmt.Sprintf("Property '%s' does not exist on '%s'", prop.Name, dispType(to)),
+				})
+			}
+		}
 		return okIf(len(failures) == 0).Because(failures...)
 
 	case *schema.TokenType:


### PR DESCRIPTION
Fixes #330

We didn't check for extraneous properties in `isAssignable`. This PR adds that check.