### PR TITLE
Typecheck known enum values

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- Ensure that constant values passed to enums are valid.
+  [#357](https://github.com/pulumi/pulumi-yaml/pull/357)
+
 ### Bug Fixes
 
 - Fix generated `Pulumi.yaml` on convert


### PR DESCRIPTION
Must enum values are constant, and can thus be known at compile time. Since services reject invalid enum values (sometimes in the middle of long deployments), we can and should verify that enum constants are valid at TypeCheck time.

Fixes #343 