### PR TITLE
Warn on non-camelCase naming

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - Ensure that constant values passed to enums are valid.
   [#357](https://github.com/pulumi/pulumi-yaml/pull/357)
 
+- Warn on non camelCase names.
+  [#362](https://github.com/pulumi/pulumi-yaml/pull/362)
+
 ### Bug Fixes
 
 - Allow interpolations for `AssetOrArchive` function values

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ resources:
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::StringAsset: <h1>Hello, world!</h1>
+        fn::stringAsset: <h1>Hello, world!</h1>
       acl: public-read
       contentType: text/html
 outputs:
@@ -57,15 +57,15 @@ configuration:
     default: t3.micro
 variables:
   AmazonLinuxAmi:
-    Fn::Invoke:
-      Function: aws:getAmi
-      Arguments:
+    fn::invoke:
+      function: aws:getAmi
+      arguments:
         filters:
           - name: name
             values: ["amzn-ami-hvm-*-x86_64-ebs"]
         owners: ["137112412989"]
         mostRecent: true
-      Return: id
+      return: id
 resources:
   WebSecGrp:
     type: aws:ec2:SecurityGroup

--- a/examples/aws-eks/Pulumi.yaml
+++ b/examples/aws-eks/Pulumi.yaml
@@ -3,17 +3,17 @@ runtime: yaml
 description: An EKS cluster
 variables:
   vpcId:
-    Fn::Invoke:
-      Function: aws:ec2:getVpc
-      Arguments:
+    fn::invoke:
+      function: aws:ec2:getVpc
+      arguments:
         default: true
-      Return: id
+      return: id
   subnetIds:
-    Fn::Invoke:
-      Function: aws:ec2:getSubnetIds
-      Arguments:
+    fn::invoke:
+      function: aws:ec2:getSubnetIds
+      arguments:
         vpcId: ${vpcId}
-      Return: ids
+      return: ids
 resources:
   cluster:
     type: eks:Cluster

--- a/examples/aws-static-website/Pulumi.yaml
+++ b/examples/aws-static-website/Pulumi.yaml
@@ -12,7 +12,7 @@ resources:
     properties:
       bucket: ${site-bucket}
       source:
-        Fn::FileAsset: ./www/index.html
+        fn::fileAsset: ./www/index.html
       acl: public-read
       contentType: text/html
   favicon.png:
@@ -20,7 +20,7 @@ resources:
     properties:
       bucket: ${site-bucket}
       source:
-        Fn::FileAsset: ./www/favicon.png
+        fn::fileAsset: ./www/favicon.png
       acl: public-read
       contentType: image/png
   bucketPolicy:

--- a/examples/azure-app-service/Pulumi.yaml
+++ b/examples/azure-app-service/Pulumi.yaml
@@ -7,10 +7,10 @@ configuration:
     default: pulumi
 variables:
   blobAccessToken:
-    Fn::Secret:
-      Fn::Invoke:
-        Function: azure-native:storage:listStorageAccountServiceSAS
-        Arguments:
+    fn::secret:
+      fn::invoke:
+        function: azure-native:storage:listStorageAccountServiceSAS
+        arguments:
           accountName: ${sa.name}
           protocols: https
           sharedAccessStartTime: '2022-01-01'
@@ -23,7 +23,7 @@ variables:
           cacheControl: max-age=5
           contentDisposition: inline
           contentEncoding: deflate
-        Return: serviceSasToken
+        return: serviceSasToken
 resources:
   appservicegroup:
     type: azure-native:resources:ResourceGroup
@@ -55,7 +55,7 @@ resources:
       containerName: ${container.name}
       type: 'Block'
       source:
-        Fn::FileArchive: ./www
+        fn::fileArchive: ./www
   appInsights:
     type: azure-native:insights:Component
     properties:

--- a/examples/azure-container-apps/Pulumi.yaml
+++ b/examples/azure-container-apps/Pulumi.yaml
@@ -10,20 +10,20 @@ configuration:
     type: Int
 variables:
   sharedKey:
-    Fn::Secret:
-      Fn::Invoke:
-        Function: azure-native:operationalinsights:getSharedKeys
-        Arguments:
+    fn::secret:
+      fn::invoke:
+        function: azure-native:operationalinsights:getSharedKeys
+        arguments:
           resourceGroupName: ${resourceGroup.name}
           workspaceName: ${workspace.name}
-        Return: primarySharedKey
+        return: primarySharedKey
   adminRegistryCreds:
-    Fn::azure-native:containerregistry:listRegistryCredentials:
+    fn::azure-native:containerregistry:listRegistryCredentials:
       resourceGroupName: ${resourceGroup.name}
       registryName: ${registry.name}
   adminUsername: ${adminRegistryCreds.username}
   adminPasswords:
-    Fn::Secret: ${adminRegistryCreds.passwords}
+    fn::secret: ${adminRegistryCreds.passwords}
 resources:
   resourceGroup:
     type: azure-native:resources:ResourceGroup

--- a/examples/azure-static-website/Pulumi.yaml
+++ b/examples/azure-static-website/Pulumi.yaml
@@ -26,7 +26,7 @@ resources:
       contentType: text/html
       type: 'Block'
       source:
-          Fn::FileAsset: ./www/index.html
+          fn::fileAsset: ./www/index.html
   favicon.png:
     type: azure-native:storage:Blob
     properties:
@@ -36,7 +36,7 @@ resources:
       contentType: image/png
       type: 'Block'
       source:
-          Fn::FileAsset: ./www/favicon.png
+          fn::fileAsset: ./www/favicon.png
   404.html:
     type: azure-native:storage:Blob
     properties:
@@ -46,6 +46,6 @@ resources:
       contentType: text/html
       type: 'Block'
       source:
-          Fn::FileAsset: ./www/404.html
+          fn::fileAsset: ./www/404.html
 outputs:
   endpoint: ${storageaccount.primaryEndpoints.web}

--- a/examples/cue-static-web-app/app.cue
+++ b/examples/cue-static-web-app/app.cue
@@ -60,7 +60,7 @@ resources: {
 				contentType:       "text/html"
 				type:              "Block"
 				source: {
-					"Fn::FileAsset": "./\(_documents.root)/\(_documents.index)"
+					"fn::fileAsset": "./\(_documents.root)/\(_documents.index)"
 				}
 			}
 		}

--- a/examples/getting-started/Pulumi.yaml
+++ b/examples/getting-started/Pulumi.yaml
@@ -11,7 +11,7 @@ resources:
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::StringAsset: <h1>Hello, world!</h1>
+        fn::stringAsset: <h1>Hello, world!</h1>
       acl: public-read
       contentType: text/html
 outputs:

--- a/examples/readme/Pulumi.yaml
+++ b/examples/readme/Pulumi.yaml
@@ -6,4 +6,4 @@ outputs:
   - fizz
   - buzz
   readme:
-    Fn::ReadFile: ./Pulumi.README.md
+    fn::readFile: ./Pulumi.README.md

--- a/examples/stackreference-consumer/Pulumi.yaml
+++ b/examples/stackreference-consumer/Pulumi.yaml
@@ -2,7 +2,7 @@ name: stackreference-consumer
 runtime: yaml
 outputs:
   referencedImageName:
-    Fn::StackReference:
+    fn::stackReference:
       # These are placeholders that our test environment replaces.
       #
       # If you're using this sample:

--- a/examples/webserver-json/Main.json
+++ b/examples/webserver-json/Main.json
@@ -1,14 +1,14 @@
 {
-  "Configuration": {
+  "configuration": {
     "InstanceType": {
       "type": "String",
       "default": "t3.micro"
     }
   },
-  "Resources": {
+  "resources": {
     "WebSecGrp": {
-      "Type": "aws:ec2:SecurityGroup",
-      "Properties": {
+      "type": "aws:ec2:SecurityGroup",
+      "properties": {
         "ingress": [
           {
             "protocol": "tcp",
@@ -18,29 +18,29 @@
           }
         ]
       },
-      "Options": {
-        "Version": "4.37.1"
+      "options": {
+        "version": "4.37.1"
       }
     },
     "WebServer": {
-      "Type": "aws:ec2:Instance",
-      "Properties": {
+      "type": "aws:ec2:Instance",
+      "properties": {
         "instanceType": "${InstanceType}",
         "ami": {
-          "Fn::Invoke": {
-            "Function": "aws:getAmi",
-            "Arguments": {
+          "fn::invoke": {
+            "function": "aws:getAmi",
+            "arguments": {
               "filters": [
                 { "name": "name", "values": ["amzn-ami-hvm-*-x86_64-ebs"] }
               ],
               "owners": ["137112412989"],
               "mostRecent": true
             },
-            "Return": "id"
+            "return": "id"
           }
         },
         "userData": {
-          "Fn::Join": [
+          "fn::join": [
             "\n",
             [
               "#!/bin/bash",
@@ -53,7 +53,7 @@
       }
     }
   },
-  "Outputs": {
+  "outputs": {
     "InstanceId": "${WebServer.id}",
     "PublicIp": "${WebServer.publicIp}",
     "PublicHostName": "${WebServer.publicDns}"

--- a/examples/webserver/Pulumi.yaml
+++ b/examples/webserver/Pulumi.yaml
@@ -7,15 +7,15 @@ configuration:
     default: t3.micro
 variables:
   ec2ami:
-    Fn::Invoke:
-      Function: aws:getAmi
-      Arguments:
+    fn::invoke:
+      function: aws:getAmi
+      arguments:
         filters:
           - name: name
             values: ["amzn-ami-hvm-*-x86_64-ebs"]
         owners: ["137112412989"]
         mostRecent: true
-      Return: id
+      return: id
 resources:
   WebSecGrp:
     type: aws:ec2:SecurityGroup

--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -27,7 +27,7 @@ resources:
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::StringAsset: <h1>Hello, world!</h1>
+        fn::stringAsset: <h1>Hello, world!</h1>
       acl: public-read
       contentType: text/html
 outputs:

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -530,7 +530,7 @@ func (g *generator) expr(e model.Expression) syn.Node {
 			if len(e.Traversal) > 0 {
 				YAMLError{
 					kind:   "Traversal not allowed on function result",
-					detail: "Cannot traverse the return value of Fn::" + f.Name,
+					detail: "Cannot traverse the return value of fn::" + f.Name,
 					rng:    f.Syntax.Range(),
 				}.AppendTo(g)
 			}
@@ -567,10 +567,10 @@ func (g *generator) expr(e model.Expression) syn.Node {
 			}
 		}
 
-		// useJoin implies we need to use "Fn::Join" to construct the desired
+		// useJoin implies we need to use "fn::join" to construct the desired
 		// string.
 		if useJoin {
-			return wrapFn("Join", syn.List(syn.String(""), syn.List(nodes...)))
+			return wrapFn("join", syn.List(syn.String(""), syn.List(nodes...)))
 		}
 
 		s := ""
@@ -664,21 +664,21 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		for i, arg := range f.Args {
 			args[i] = g.expr(arg)
 		}
-		return wrapFn("Join", syn.List(args...))
+		return wrapFn("join", syn.List(args...))
 	case "split":
-		return wrapFn("Split", syn.List(g.expr(f.Args[1]), g.expr(f.Args[0])))
+		return wrapFn("split", syn.List(g.expr(f.Args[1]), g.expr(f.Args[0])))
 	case "toBase64":
-		return wrapFn("ToBase64", g.expr(f.Args[0]))
+		return wrapFn("toBase64", g.expr(f.Args[0]))
 	case "fromBase64":
-		return wrapFn("FromBase64", g.expr(f.Args[0]))
+		return wrapFn("fromBase64", g.expr(f.Args[0]))
 	case "toJSON":
-		return wrapFn("ToJSON", g.expr(f.Args[0]))
+		return wrapFn("toJSON", g.expr(f.Args[0]))
 	case "element":
 		args := make([]syn.Node, len(f.Args))
 		for i, arg := range f.Args {
 			args[i] = g.expr(arg)
 		}
-		return wrapFn("Select", syn.List(args[1], args[0]))
+		return wrapFn("select", syn.List(args[1], args[0]))
 	case pcl.IntrinsicConvert:
 		// We can't perform the convert, but it might happen automatically.
 		// This works for enums, as well as number -> strings.
@@ -694,7 +694,7 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 	default:
 		YAMLError{
 			kind:   "Unknown Function",
-			detail: fmt.Sprintf("YAML does not support Fn::%s.", f.Name),
+			detail: fmt.Sprintf("YAML does not support fn::%s.", f.Name),
 			rng:    getRange(),
 		}.AppendTo(g)
 		return wrapFn(f.Name, syn.Null())
@@ -702,14 +702,14 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 }
 
 func wrapFn(name string, body syn.Node) *syn.ObjectNode {
-	entry := syn.ObjectProperty(syn.String("Fn::"+name), body)
+	entry := syn.ObjectProperty(syn.String("fn::"+name), body)
 	return syn.Object(entry)
 }
 
 type Invoke struct {
-	Function  string      `yaml:"Function" json:"Function"`
-	Arguments interface{} `yaml:"Arguments,omitempty" json:"Arguments,omitempty"`
-	Return    string      `yaml:"Return" json:"Return"`
+	Function  string      `yaml:"function" json:"function"`
+	Arguments interface{} `yaml:"arguments,omitempty" json:"arguments,omitempty"`
+	Return    string      `yaml:"return,omitempty" json:"return,omitempty"`
 }
 
 func (g *generator) MustInvoke(f *model.FunctionCallExpression, ret string) *syn.ObjectNode {
@@ -738,7 +738,7 @@ func (g *generator) MustInvoke(f *model.FunctionCallExpression, ret string) *syn
 			))
 	}
 
-	return wrapFn("Invoke", syn.Object(properties...))
+	return wrapFn("invoke", syn.Object(properties...))
 }
 
 func (g *generator) TypeProperty(s string) syn.ObjectPropertyDef {

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -187,7 +187,7 @@ func (imp *importer) importInterpolate(node *ast.InterpolateExpr, substitutions 
 	return &model.TemplateExpression{Parts: parts}, diags
 }
 
-// importJoin imports a call to Fn::Join as a call to the `join` function.
+// importJoin imports a call to fn::join as a call to the `join` function.
 func (imp *importer) importJoin(node *ast.JoinExpr) (model.Expression, syntax.Diagnostics) {
 	var diags syntax.Diagnostics
 
@@ -208,7 +208,7 @@ func (imp *importer) importJoin(node *ast.JoinExpr) (model.Expression, syntax.Di
 	return call, diags
 }
 
-// importSplit imports a call to Fn::Split as a call to the `split` function.
+// importSplit imports a call to fn::split as a call to the `split` function.
 func (imp *importer) importSplit(node *ast.SplitExpr) (model.Expression, syntax.Diagnostics) {
 	var diags syntax.Diagnostics
 
@@ -232,11 +232,11 @@ func (imp *importer) importSplit(node *ast.SplitExpr) (model.Expression, syntax.
 // importFunctionCall imports a call to an AWS intrinsic function. The way the function is imported depends on the
 // function:
 //
-// - `Fn::Asset` is imported as a call to the `fileAsset` function
-// - `Fn::Invoke` is imported as a call to `invoke`
-// - `Fn::Join` is imported as either a template expression or a call to `join`
-// - `Fn::Split` is imported as a call to `split`
-// - `Fn::StackReference` is imported as a reference to the named stack
+// - `fn::asset` is imported as a call to the `fileAsset` function
+// - `fn::invoke` is imported as a call to `invoke`
+// - `fn::join` is imported as either a template expression or a call to `join`
+// - `fn::split` is imported as a call to `split`
+// - `fn::stackReference` is imported as a reference to the named stack
 func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, syntax.Diagnostics) {
 	switch node := node.(type) {
 	case *ast.StringAssetExpr:

--- a/pkg/pulumiyaml/codegen/load_test.go
+++ b/pkg/pulumiyaml/codegen/load_test.go
@@ -131,12 +131,12 @@ resources:
 			input: `
 variables:
   ret:
-    Fn::Invoke:
-      Function: test:mod:fn
-      Return: foo
+    fn::invoke:
+      function: test:mod:fn
+      return: foo
   noRet:
-    Fn::Invoke:
-      Function: test:mod:fn`,
+    fn::invoke:
+      function: test:mod:fn`,
 			expected: `ret = invoke("test:mod:fn", {}).foo
 noRet = invoke("test:mod:fn", {})
 `,

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1626,7 +1626,7 @@ func (e *programEvaluator) evaluateBuiltinInvoke(t *ast.InvokeExpr) (interface{}
 		retv, ok := result[t.Return.Value]
 		if !ok {
 			e.error(t.Return, fmt.Sprintf("Unable to evaluate result[%v], result is: %+v", t.Return.Value, t.Return))
-			return e.error(t.Return, fmt.Sprintf("Fn::Invoke of %s did not contain a property '%s' in the returned value", t.Token.Value, t.Return.Value))
+			return e.error(t.Return, fmt.Sprintf("fn::invoke of %s did not contain a property '%s' in the returned value", t.Token.Value, t.Return.Value))
 		}
 		return retv, true
 	})
@@ -1662,7 +1662,7 @@ func (e *programEvaluator) evaluateBuiltinJoin(v *ast.JoinExpr) (interface{}, bo
 		parts, ok := args[1].([]interface{})
 		overallOk = overallOk && ok
 		if !ok {
-			e.error(v.Values, fmt.Sprintf("the second argument to Fn::Join must be a list, found %v", typeString(args[1])))
+			e.error(v.Values, fmt.Sprintf("the second argument to fn::join must be a list, found %v", typeString(args[1])))
 		}
 
 		if !overallOk {
@@ -1673,7 +1673,7 @@ func (e *programEvaluator) evaluateBuiltinJoin(v *ast.JoinExpr) (interface{}, bo
 		for i, p := range parts {
 			str, ok := p.(string)
 			if !ok {
-				e.error(v.Values, fmt.Sprintf("the second argument to Fn::Join must be a list of strings, found %v at index %v", typeString(p), i))
+				e.error(v.Values, fmt.Sprintf("the second argument to fn::join must be a list of strings, found %v at index %v", typeString(p), i))
 				overallOk = false
 			} else {
 				strs[i] = str
@@ -1768,15 +1768,15 @@ func (e *programEvaluator) evaluateBuiltinFromBase64(v *ast.FromBase64Expr) (int
 	fromBase64 := e.lift(func(args ...interface{}) (interface{}, bool) {
 		s, ok := args[0].(string)
 		if !ok {
-			return e.error(v.Value, fmt.Sprintf("expected argument to Fn::FromBase64 to be a string, got %v", typeString(args[0])))
+			return e.error(v.Value, fmt.Sprintf("expected argument to fn::fromBase64 to be a string, got %v", typeString(args[0])))
 		}
 		b, err := b64.StdEncoding.DecodeString(s)
 		if err != nil {
-			return e.error(v.Value, fmt.Sprintf("Fn::FromBase64 unable to decode %v, error: %v", args[0], err))
+			return e.error(v.Value, fmt.Sprintf("fn::fromBase64 unable to decode %v, error: %v", args[0], err))
 		}
 		decoded := string(b)
 		if !utf8.ValidString(decoded) {
-			return e.error(v.Value, "Fn::FromBase64 output is not a valid UTF-8 string")
+			return e.error(v.Value, "fn::fromBase64 output is not a valid UTF-8 string")
 		}
 		return decoded, true
 	})
@@ -1791,7 +1791,7 @@ func (e *programEvaluator) evaluateBuiltinToBase64(v *ast.ToBase64Expr) (interfa
 	toBase64 := e.lift(func(args ...interface{}) (interface{}, bool) {
 		s, ok := args[0].(string)
 		if !ok {
-			return e.error(v.Value, fmt.Sprintf("expected argument to Fn::ToBase64 to be a string, got %v", typeString(args[0])))
+			return e.error(v.Value, fmt.Sprintf("expected argument to fn::toBase64 to be a string, got %v", typeString(args[0])))
 		}
 		return b64.StdEncoding.EncodeToString([]byte(s)), true
 	})
@@ -1847,7 +1847,7 @@ func (e *programEvaluator) evaluateBuiltinStackReference(v *ast.StackReferenceEx
 		s, ok := n.(string)
 		if !ok {
 			e.error(v.PropertyName,
-				fmt.Sprintf("expected property name argument to Fn::StackReference to be a string, got %v", typeString(n)),
+				fmt.Sprintf("expected property name argument to fn::stackReference to be a string, got %v", typeString(n)),
 			)
 		}
 		return s, nil
@@ -1874,7 +1874,7 @@ func (e *programEvaluator) evaluateInterpolatedBuiltinAssetArchive(x, s ast.Expr
 	createAssetArchiveF := e.lift(func(args ...interface{}) (interface{}, bool) {
 		value, ok := args[0].(string)
 		if !ok {
-			return e.error(s, fmt.Sprintf("Argument to Fn::* must be a string, got %v", reflect.TypeOf(args[0])))
+			return e.error(s, fmt.Sprintf("Argument to fn::* must be a string, got %v", reflect.TypeOf(args[0])))
 		}
 
 		switch x.(type) {
@@ -1894,12 +1894,12 @@ func (e *programEvaluator) evaluateInterpolatedBuiltinAssetArchive(x, s ast.Expr
 			return pulumi.NewFileAsset(path), true
 		case *ast.RemoteArchiveExpr:
 			if !isConstant {
-				return e.error(s, "Argument to Fn::RemoteArchiveExpr must be a constantr")
+				return e.error(s, "Argument to fn::remoteArchiveExpr must be a constantr")
 			}
 			return pulumi.NewRemoteArchive(value), true
 		case *ast.RemoteAssetExpr:
 			if !isConstant {
-				return e.error(s, "Argument to Fn::RemoteAssetExpr must be a constant")
+				return e.error(s, "Argument to fn::remoteAssetExpr must be a constant")
 			}
 			return pulumi.NewRemoteAsset(value), true
 
@@ -1974,7 +1974,7 @@ func (e *programEvaluator) evaluateBuiltinReadFile(s *ast.ReadFileExpr) (interfa
 	readFileF := e.lift(func(args ...interface{}) (interface{}, bool) {
 		path, ok := args[0].(string)
 		if !ok {
-			return e.error(s.Path, fmt.Sprintf("Argument to Fn::ReadFile must be a string, got %v", reflect.TypeOf(args[0])))
+			return e.error(s.Path, fmt.Sprintf("Argument to fn::readFile must be a string, got %v", reflect.TypeOf(args[0])))
 		}
 		path, err := e.sanitizePath(path, isConstant)
 		if err != nil {

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -35,11 +35,11 @@ resources:
     type: test:resource:type
     properties:
       foo:
-        Fn::Invoke:
-          Function: test:invoke:type
-          Arguments:
+        fn::invoke:
+          function: test:invoke:type
+          arguments:
             quux: ${res-a.out}
-          Return: retval
+          return: retval
 `
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
@@ -64,13 +64,13 @@ resources:
     type: test:resource:type
     properties:
       foo:
-        Fn::Invoke:
-          Function: test:invoke:type2
-          Arguments:
+        fn::invoke:
+          function: test:invoke:type2
+          arguments:
             quux: ${res-a.out}
-          Options:
+          options:
             Provider: ${provider-a}
-          Return: retval
+          return: retval
 `
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
@@ -86,9 +86,9 @@ name: test-yaml
 runtime: yaml
 variables:
   foo:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: tuo
 resources:
   res-a:
@@ -110,9 +110,9 @@ name: test-yaml
 runtime: yaml
 variables:
   foo:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: ${res-a.out}
 resources:
   res-a:
@@ -136,8 +136,8 @@ func TestInvokeNoInputs(t *testing.T) {
 	const text = `
 variables:
   config:
-    Fn::Invoke:
-      Function: test:invoke:empty
+    fn::invoke:
+      function: test:invoke:empty
 outputs:
   v: ${config.subscriptionId}
 name: test-yaml
@@ -157,7 +157,7 @@ name: test-yaml
 runtime: yaml
 variables:
   foo:
-    Fn::test:invoke:type:
+    fn::test:invoke:type:
       quux: tuo
 resources:
   res-a:
@@ -179,7 +179,7 @@ name: test-yaml
 runtime: yaml
 variables:
   foo:
-    Fn::test:invoke:type:
+    fn::test:invoke:type:
       quux: ${res-a.out}
 resources:
   res-a:
@@ -203,7 +203,7 @@ func TestInvokeNoInputsSugar(t *testing.T) {
 	const text = `
 variables:
   config:
-    Fn::test:invoke:empty: {}
+    fn::test:invoke:empty: {}
 outputs:
   v: ${config.subscriptionId}
 name: test-yaml

--- a/pkg/pulumiyaml/run_options_test.go
+++ b/pkg/pulumiyaml/run_options_test.go
@@ -130,8 +130,8 @@ resources:
     type: test:component:type
 variables:
   var-a:
-    Fn::Invoke:
-      Function: test:invoke:type
+    fn::Invoke:
+      function: test:invoke:type
 `
 	template := yamlTemplate(t, strings.TrimSpace(text))
 

--- a/pkg/pulumiyaml/run_plugin_version_test.go
+++ b/pkg/pulumiyaml/run_plugin_version_test.go
@@ -122,9 +122,9 @@ resources:
     properties:
       instanceType: ${InstanceType}
       ami:
-        Fn::Invoke:
-          Function: aws:getAmi
-          Arguments:
+        fn::invoke:
+          function: aws:getAmi
+          arguments:
             filters:
               - name: name
                 values: ["amzn-ami-hvm-*-x86_64-ebs"]

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -360,19 +360,19 @@ variables:
   foo: bar
   foo2: ./README.md
   dir:
-    Fn::AssetArchive:
+    fn::assetArchive:
       str:
-        Fn::StringAsset: this is home
+        fn::stringAsset: this is home
       strIter:
-        Fn::StringAsset: start ${foo} end
+        fn::stringAsset: start ${foo} end
       away:
-        Fn::RemoteAsset: example.org/asset
+        fn::remoteAsset: example.org/asset
       local:
-        Fn::FileAsset: ${foo2}
+        fn::fileAsset: ${foo2}
       folder:
-        Fn::AssetArchive:
+        fn::assetArchive:
           docs:
-            Fn::RemoteArchive: example.org/docs
+            fn::remoteArchive: example.org/docs
 `
 	tmpl := yamlTemplate(t, text)
 	testTemplate(t, tmpl, func(e *programEvaluator) {
@@ -717,9 +717,9 @@ runtime: yaml
 description: An EKS cluster
 variables:
   vpcId:
-    Fn::Invoke:
-      Function: test:fn
-      Arguments:
+    fn::invoke:
+      function: test:fn
+      arguments:
         noArg: false
         yesArg: true
 resources:
@@ -1492,7 +1492,7 @@ name: test-secret
 runtime: yaml
 variables:
   mySecret:
-    Fn::Secret: my-special-secret
+    fn::secret: my-special-secret
 `
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
 	var hasRun = false
@@ -1524,11 +1524,11 @@ name: test-readfile
 runtime: yaml
 variables:
   textData:
-    Fn::ReadFile: ./README.md
+    fn::readFile: ./README.md
   absInDirData:
-    Fn::ReadFile: ${pulumi.cwd}/README.md
+    fn::readFile: ${pulumi.cwd}/README.md
   absOutOfDirData:
-    Fn::ReadFile: %v
+    fn::readFile: %v
 `, repoReadmePath)
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
@@ -1565,7 +1565,7 @@ name: test-readfile
 runtime: yaml
 outputs:
   readme:
-    Fn::ReadFile: ${pulumi.cwd}/../../go.mod # imagine this is /etc/shadow, /var/run/secrets/tokens, etc.
+    fn::readFile: ${pulumi.cwd}/../../go.mod # imagine this is /etc/shadow, /var/run/secrets/tokens, etc.
 `
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
@@ -1593,7 +1593,7 @@ variables:
     - "foo"
     - "bar"
   foo-bar:
-    Fn::Join:
+    fn::join:
       - "-"
       - ${inputs}
 `
@@ -1621,11 +1621,11 @@ variables:
     - [1, 2, 3]
     - true
   foo-bar:
-    Fn::Join:
+    fn::join:
       - "-"
       - ${inputs}
   foo-err:
-    Fn::Join:
+    fn::join:
       - "-"
       - ${inputs[1]}
 `
@@ -1639,12 +1639,11 @@ variables:
 	}
 	assert.ElementsMatch(t, diagStrings,
 		[]string{
-			"<stdin>:12:9: the second argument to Fn::Join must be a list of strings, found a number at index 0",
-			"<stdin>:12:9: the second argument to Fn::Join must be a list of strings, found an object at index 1",
-			"<stdin>:12:9: the second argument to Fn::Join must be a list of strings, found a list at index 2",
-			"<stdin>:12:9: the second argument to Fn::Join must be a list of strings, found a boolean at index 3",
-
-			"<stdin>:16:9: the second argument to Fn::Join must be a list, found an object",
+			"<stdin>:12:9: the second argument to fn::join must be a list of strings, found a number at index 0",
+			"<stdin>:12:9: the second argument to fn::join must be a list of strings, found an object at index 1",
+			"<stdin>:12:9: the second argument to fn::join must be a list of strings, found a list at index 2",
+			"<stdin>:12:9: the second argument to fn::join must be a list of strings, found a boolean at index 3",
+			"<stdin>:16:9: the second argument to fn::join must be a list, found an object",
 		},
 	)
 }
@@ -1678,15 +1677,15 @@ name: test-poison
 runtime: yaml
 variables:
   poisoned:
-    Fn::Invoke:
-      Function: test:invoke:poison
-      Arguments:
+    fn::invoke:
+      function: test:invoke:poison
+      arguments:
         foo: three
       return: value
   never-run:
-    Fn::Invoke:
-      Function: test:invoke:poison
-      Arguments:
+    fn::invoke:
+      function: test:invoke:poison
+      arguments:
         foo: ${poisoned}
       return: value
 resources:

--- a/pkg/pulumiyaml/run_variable_test.go
+++ b/pkg/pulumiyaml/run_variable_test.go
@@ -72,9 +72,9 @@ name: test-yaml
 runtime: yaml
 variables:
   someVar:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: tuo
       Return: retval
 resources:
@@ -102,9 +102,9 @@ name: test-yaml
 runtime: yaml
 variables:
   someVar:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::Invoke:
+      function: test:invoke:type
+      arguments:
         quux: tuo
       Return: retval
 resources:
@@ -132,11 +132,11 @@ name: test-yaml
 runtime: yaml
 variables:
   someVar:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: ${res-a.out}
-      Return: retval
+      return: retval
 resources:
   res-a:
     type: test:resource:type
@@ -167,17 +167,17 @@ name: test-yaml
 runtime: yaml
 variables:
   passthrough:
-    Fn::Invoke:
-      Function: test:invoke-passthrough:type
-      Arguments:
+    fn::Invoke:
+      function: test:invoke-passthrough:type
+      arguments:
         returnValue: ${res-a.out}
-      Return: returnValue
+      return: returnValue
   someVar:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: ${passthrough}
-      Return: retval
+      return: retval
 resources:
   res-a:
     type: test:resource:type
@@ -206,11 +206,11 @@ name: test-yaml
 runtime: yaml
 variables:
   someVar:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: ${resFinal.out}
-      Return: retval
+      return: retval
 resources:
   resFinal:
     type: test:resource:type
@@ -233,11 +233,11 @@ name: test-yaml
 runtime: yaml
 variables:
   someVar:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: ${res-a.out}
-      Return: retval
+      return: retval
 resources:
   res-a:
     type: test:resource:type
@@ -267,11 +267,11 @@ name: test-yaml
 runtime: yaml
 variables:
   someVar:
-    Fn::Invoke:
-      Function: test:invoke:type
-      Arguments:
+    fn::invoke:
+      function: test:invoke:type
+      arguments:
         quux: tuo
-      Return: retval
+      return: retval
 resources:
   resFinal:
     type: test:resource:type

--- a/pkg/pulumiyaml/syntax/diags.go
+++ b/pkg/pulumiyaml/syntax/diags.go
@@ -135,6 +135,6 @@ func UnexpectedCasing(rng *hcl.Range, expected, found string) *Diagnostic {
 		return nil
 	}
 	summary := fmt.Sprintf("'%s' looks like a miscapitalization of '%s'", found, expected)
-	detail := "Pulumi YAML will enforce camelCase capitalization by GA. See https://github.com/pulumi/pulumi-yaml/issues/355 for details."
+	detail := "A future version of Pulumi YAML will enforce camelCase fields. See https://github.com/pulumi/pulumi-yaml/issues/355 for details."
 	return Warning(rng, summary, detail)
 }

--- a/pkg/pulumiyaml/syntax/diags.go
+++ b/pkg/pulumiyaml/syntax/diags.go
@@ -97,7 +97,11 @@ func (d Diagnostics) Error() string {
 // Extend appends the given list of diagnostics to the list.
 func (d *Diagnostics) Extend(diags ...*Diagnostic) {
 	if len(diags) != 0 {
-		*d = append(*d, diags...)
+		for _, diag := range diags {
+			if diag != nil {
+				*d = append(*d, diag)
+			}
+		}
 	}
 }
 
@@ -120,4 +124,17 @@ func (d Diagnostics) Unshown() *Diagnostics {
 		}
 	}
 	return &diags
+}
+
+// Inform the user that they did not conform with the expected capitalization style. If
+// `expected` matches `found`, then `nil` is returned. This allows
+// `Diagnostics.Extend(UnexpectedCasing(location, expected, found))` without checking if
+// expected equals found.
+func UnexpectedCasing(rng *hcl.Range, expected, found string) *Diagnostic {
+	if expected == found {
+		return nil
+	}
+	summary := fmt.Sprintf("'%s' looks like a miscapitalization of '%s'", found, expected)
+	detail := "Pulumi YAML will enforce camelCase capitalization by GA. See https://github.com/pulumi/pulumi-yaml/issues/355 for details."
+	return Warning(rng, summary, detail)
 }

--- a/pkg/pulumiyaml/template.go
+++ b/pkg/pulumiyaml/template.go
@@ -18,7 +18,7 @@ type Template struct {
 	// TODO: Mappings and Conditions
 
 	// Mappings provides the ability to have a static set of maps for programs that need to
-	// perform lookups using Fn::FindInMap. For instance, we can map from region name to AMI IDs:
+	// perform lookups using fn::FindInMap. For instance, we can map from region name to AMI IDs:
 	//      "Mappings": {
 	//          "RegionMap": {
 	//              "us-east-1"     : { "HVM64": "ami-0ff8a91507f77f867" },

--- a/pkg/pulumiyaml/testing/test/testdata/assets-archives-pp/yaml/assets-archives.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/assets-archives-pp/yaml/assets-archives.yaml
@@ -7,61 +7,61 @@ resources:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        Fn::FileAsset: file.txt
+        fn::FileAsset: file.txt
   testStringAsset:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        Fn::StringAsset: <h1>File contents</h1>
+        fn::StringAsset: <h1>File contents</h1>
   testRemoteAsset:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        Fn::RemoteAsset: https://pulumi.test
+        fn::RemoteAsset: https://pulumi.test
   testFileArchive:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        Fn::FileArchive: file.tar.gz
+        fn::FileArchive: file.tar.gz
   testRemoteArchive:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        Fn::RemoteArchive: https://pulumi.test/foo.tar.gz
+        fn::RemoteArchive: https://pulumi.test/foo.tar.gz
   testAssetArchive:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        Fn::AssetArchive:
+        fn::AssetArchive:
           file.txt:
-            Fn::FileAsset: file.txt
+            fn::FileAsset: file.txt
           string.txt:
-            Fn::StringAsset: <h1>File contents</h1>
+            fn::StringAsset: <h1>File contents</h1>
           remote.txt:
-            Fn::RemoteAsset: https://pulumi.test
+            fn::RemoteAsset: https://pulumi.test
           file.tar:
-            Fn::FileArchive: file.tar.gz
+            fn::FileArchive: file.tar.gz
           remote.tar:
-            Fn::RemoteArchive: https://pulumi.test/foo.tar.gz
+            fn::RemoteArchive: https://pulumi.test/foo.tar.gz
           .nestedDir:
-            Fn::AssetArchive:
+            fn::AssetArchive:
               file.txt:
-                Fn::FileAsset: file.txt
+                fn::FileAsset: file.txt
               string.txt:
-                Fn::StringAsset: <h1>File contents</h1>
+                fn::StringAsset: <h1>File contents</h1>
               remote.txt:
-                Fn::RemoteAsset: https://pulumi.test
+                fn::RemoteAsset: https://pulumi.test
               file.tar:
-                Fn::FileArchive: file.tar.gz
+                fn::FileArchive: file.tar.gz
               remote.tar:
-                Fn::RemoteArchive: https://pulumi.test/foo.tar.gz
+                fn::RemoteArchive: https://pulumi.test/foo.tar.gz

--- a/pkg/pulumiyaml/testing/test/testdata/aws-fargate-pp/yaml/aws-fargate.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-fargate-pp/yaml/aws-fargate.yaml
@@ -24,7 +24,7 @@ resources:
     type: aws:iam:Role
     properties:
       assumeRolePolicy:
-        Fn::ToJSON:
+        fn::toJSON:
           Version: 2008-10-17
           Statement:
             - Sid:
@@ -71,7 +71,7 @@ resources:
         - FARGATE
       executionRoleArn: ${taskExecRole.arn}
       containerDefinitions:
-        Fn::ToJSON:
+        fn::toJSON:
           - name: my-app
             image: nginx
             portMappings:
@@ -100,12 +100,12 @@ resources:
 variables:
   # Read the default VPC and public subnets, which we will use.
   vpc:
-    Fn::Invoke:
+    fn::invoke:
       Function: aws:ec2:getVpc
       Arguments:
         default: true
   subnets:
-    Fn::Invoke:
+    fn::invoke:
       Function: aws:ec2:getSubnetIds
       Arguments:
         vpcId: ${vpc.id}

--- a/pkg/pulumiyaml/testing/test/testdata/aws-iam-policy-pp/yaml/aws-iam-policy.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-iam-policy-pp/yaml/aws-iam-policy.yaml
@@ -6,7 +6,7 @@ resources:
       path: /
       description: My test policy
       policy:
-        Fn::ToJSON:
+        fn::toJSON:
           Version: 2012-10-17
           Statement:
             - Effect: Allow

--- a/pkg/pulumiyaml/testing/test/testdata/aws-lambda-pp/yaml/aws-lambda.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-lambda-pp/yaml/aws-lambda.yaml
@@ -7,7 +7,7 @@ resources:
     type: aws:lambda:Function
     properties:
       code:
-        Fn::FileArchive: lambda_function_payload.zip
+        fn::FileArchive: lambda_function_payload.zip
       role: ${iamForLambda.arn}
       handler: index.test
       runtime: nodejs12.x

--- a/pkg/pulumiyaml/testing/test/testdata/aws-optionals-pp/yaml/aws-optionals.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-optionals-pp/yaml/aws-optionals.yaml
@@ -7,7 +7,7 @@ resources:
       policy: ${policyDocument.json}
 variables:
   policyDocument:
-    Fn::Invoke:
+    fn::invoke:
       Function: aws:iam:getPolicyDocument
       Arguments:
         statements:

--- a/pkg/pulumiyaml/testing/test/testdata/aws-s3-folder-pp/yaml/aws-s3-folder.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-s3-folder-pp/yaml/aws-s3-folder.yaml
@@ -1,33 +1,33 @@
 resources:
-    siteBucket:
-        type: aws:s3/bucket:Bucket
-        properties:
-            website:
-                indexDocument: index.html
-    files:
-        type: aws:s3/bucketObject:BucketObject
-        properties:
-            bucket: ${siteBucket.id}
-            key: ${range.value}
-            source:
-                Fn::FileAsset: ${siteDir}/${range.value}
-            contentType: ${range.value}
-    bucketPolicy:
-        type: aws:s3/bucketPolicy:BucketPolicy
-        properties:
-            bucket: ${siteBucket.id}
-            policy:
-                Fn::ToJSON:
-                    Version: 2012-10-17
-                    Statement:
-                        - Effect: Allow
-                          Principal: '*'
-                          Action:
-                            - s3:GetObject
-                          Resource:
-                            - arn:aws:s3:::${siteBucket.id}/*
+  siteBucket:
+    type: aws:s3/bucket:Bucket
+    properties:
+      website:
+        indexDocument: index.html
+  files:
+    type: aws:s3/bucketObject:BucketObject
+    properties:
+      bucket: ${siteBucket.id}
+      key: ${range.value}
+      source:
+        fn::fileAsset: ${siteDir}/${range.value}
+      contentType: ${range.value}
+  bucketPolicy:
+    type: aws:s3/bucketPolicy:BucketPolicy
+    properties:
+      bucket: ${siteBucket.id}
+      policy:
+        fn::toJSON:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Principal: "*"
+              Action:
+                - s3:GetObject
+              Resource:
+                - arn:aws:s3:::${siteBucket.id}/*
 variables:
-    siteDir: www
+  siteDir: www
 outputs:
-    bucketName: ${siteBucket.bucket}
-    websiteUrl: ${siteBucket.websiteEndpoint}
+  bucketName: ${siteBucket.bucket}
+  websiteUrl: ${siteBucket.websiteEndpoint}

--- a/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/yaml/aws-webserver.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/yaml/aws-webserver.yaml
@@ -26,7 +26,7 @@ resources:
 variables:
   # Get the ID for the latest Amazon Linux AMI.
   ami:
-    Fn::Invoke:
+    fn::invoke:
       Function: aws:getAmi
       Arguments:
         filters:

--- a/pkg/pulumiyaml/testing/test/testdata/azure-sa-pp/yaml/azure-sa.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/azure-sa-pp/yaml/azure-sa.yaml
@@ -1,33 +1,33 @@
 configuration:
-    storageAccountNameParam:
-        type: string
-    resourceGroupNameParam:
-        type: string
-    locationParam:
-        type: string
-        default: ${resourceGroupVar}
-    storageAccountTierParam:
-        type: string
-        default: Standard
-    storageAccountTypeReplicationParam:
-        type: string
-        default: LRS
+  storageAccountNameParam:
+    type: string
+  resourceGroupNameParam:
+    type: string
+  locationParam:
+    type: string
+    default: ${resourceGroupVar}
+  storageAccountTierParam:
+    type: string
+    default: Standard
+  storageAccountTypeReplicationParam:
+    type: string
+    default: LRS
 resources:
-    storageAccountResource:
-        type: azure:storage/account:Account
-        properties:
-            name: ${storageAccountNameParam}
-            accountKind: StorageV2
-            location: ${locationParam}
-            resourceGroupName: ${resourceGroupNameParam}
-            accountTier: ${storageAccountTierParam}
-            accountReplicationType: ${storageAccountTypeReplicationParam}
+  storageAccountResource:
+    type: azure:storage/account:Account
+    properties:
+      name: ${storageAccountNameParam}
+      accountKind: StorageV2
+      location: ${locationParam}
+      resourceGroupName: ${resourceGroupNameParam}
+      accountTier: ${storageAccountTierParam}
+      accountReplicationType: ${storageAccountTypeReplicationParam}
 variables:
-    resourceGroupVar:
-        Fn::Invoke:
-            Function: azure:core/getResourceGroup:getResourceGroup
-            Arguments:
-                name: ${resourceGroupNameParam}
-            Return: location
+  resourceGroupVar:
+    fn::invoke:
+      function: azure:core/getResourceGroup:getResourceGroup
+      arguments:
+        name: ${resourceGroupNameParam}
+      return: location
 outputs:
-    storageAccountNameOut: ${storageAccountResource.name}
+  storageAccountNameOut: ${storageAccountResource.name}

--- a/pkg/pulumiyaml/testing/test/testdata/direct-invoke-pp/yaml/direct-invoke.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/direct-invoke-pp/yaml/direct-invoke.yaml
@@ -5,7 +5,7 @@ resources:
       name: example_policy
       path: /
       policy:
-        Fn::Invoke:
+        fn::invoke:
           Function: aws:iam:getPolicyDocument
           Arguments:
             statements:

--- a/pkg/pulumiyaml/testing/test/testdata/functions-pp/yaml/functions.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/functions-pp/yaml/functions.yaml
@@ -1,8 +1,8 @@
 variables:
   encoded:
-    Fn::ToBase64: haha business
+    fn::toBase64: haha business
   joined:
-    Fn::Join:
+    fn::join:
       - '-'
       - - haha
         - business

--- a/pkg/pulumiyaml/testing/test/testdata/join-template-pp/yaml/join-template.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/join-template-pp/yaml/join-template.yaml
@@ -3,17 +3,17 @@ resources:
     type: aws:iam:Policy
     properties:
       name:
-        Fn::Join:
+        fn::join:
           -
-          - - Fn::Select:
+          - - fn::select:
                 - 0
                 - - foo
                   - bar
             - -policy
       path: /
       policy:
-        Fn::Select:
+        fn::select:
           - 0
-          - Fn::Split:
+          - fn::split:
               - '-'
               - '{}-foo'

--- a/pkg/pulumiyaml/testing/test/testdata/output-funcs-aws-pp/yaml/output-funcs-aws.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/output-funcs-aws-pp/yaml/output-funcs-aws.yaml
@@ -26,7 +26,7 @@ resources:
       toPort: 443
 variables:
   privateS3PrefixList:
-    Fn::Invoke:
+    fn::invoke:
       Function: aws:ec2:getPrefixList
       Arguments:
         prefixListId: ${privateS3VpcEndpoint.prefixListId}
@@ -34,7 +34,7 @@ variables:
   # below) generate correctly when using output-versioned function
   # invoke forms.
   amis:
-    Fn::Invoke:
+    fn::invoke:
       Function: aws:ec2:getAmiIds
       Arguments:
         owners:

--- a/templates/azure-yaml/Pulumi.yaml
+++ b/templates/azure-yaml/Pulumi.yaml
@@ -23,9 +23,9 @@ resources:
       kind: StorageV2
 variables:
   storageAccountKeys:
-    Fn::Invoke:
-      Function: azure-native:storage:listStorageAccountKeys
-      Arguments:
+    fn::Invoke:
+      function: azure-native:storage:listStorageAccountKeys
+      arguments:
         resourceGroupName: ${resourceGroup.name}
         accountName: ${storageAccount.name}
 outputs:


### PR DESCRIPTION
Fixes #355 

Generated warnings look like this:

```yaml
name: yaml
runtime: yAML
Resources:
  provider:
    type: pulumi:providers:aws
    PrOperties:
      region: us-east-1
    DefaultProvider: true
  bucket:
    Type: aws:s3:BucketV2
```

```
Diagnostics:
  pulumi:pulumi:Stack (yaml-dev):
    Warning: 'Resources' looks like a miscapitalization of 'resources'
      on Pulumi.yaml line 3:
       3: Resources:
    Pulumi YAML will enforce camelCase capitalization by GA. See https://github.com/pulumi/pulumi-yaml/issues/355 for details.
    Warning: 'PrOperties' looks like a miscapitalization of 'properties'
      on Pulumi.yaml line 6:
       6:     PrOperties:
    Pulumi YAML will enforce camelCase capitalization by GA. See https://github.com/pulumi/pulumi-yaml/issues/355 for details.
    Warning: 'DefaultProvider' looks like a miscapitalization of 'defaultProvider'
      on Pulumi.yaml line 8:
       8:     DefaultProvider: true
    Pulumi YAML will enforce camelCase capitalization by GA. See https://github.com/pulumi/pulumi-yaml/issues/355 for details.
    Warning: 'Type' looks like a miscapitalization of 'type'
      on Pulumi.yaml line 10:
      10:     Type: aws:s3:BucketV2
    Pulumi YAML will enforce camelCase capitalization by GA. See https://github.com/pulumi/pulumi-yaml/issues/355 for details.
```