### PR TITLE
Sync PCL files with pu/pu on release

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,3 @@
+pulumi/pulumi:
+  - source: ../pkg/tests/transpiled_examples
+    dest: pkg/codegen/testing/test/testdata/transpiled_examples

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,18 @@
+name: Sync Files
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  convert-test-sync:
+    name: Sync PCL test files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@40da4d517e0a744fce9e8aed03e63d6c8bafbdc0 # v1.17.21
+        with:
+          GH_PAT: ${{ secrets.PULUMI_BOT_TOKEN }}
+          TEAM_REVIEWERS: pulumi/platform


### PR DESCRIPTION
Keep PCL test files in both repos in sync after they are decoupled per #251 