### PR TITLE
Fix PCL sync workflow

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,3 +1,10 @@
 pulumi/pulumi:
-  - source: ../pkg/tests/transpiled_examples
+  - source: pkg/tests/transpiled_examples
     dest: pkg/codegen/testing/test/testdata/transpiled_examples
+    exclude: |
+      .gitignore
+pulumi/pulumi-java:
+  - source: pkg/tests/transpiled_examples
+    dest: pkg/codegen/testing/test/testdata/transpiled_examples
+    exclude: |
+      .gitignore

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -3,6 +3,7 @@ name: Sync Files
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   convert-test-sync:
@@ -15,4 +16,8 @@ jobs:
         uses: BetaHuhn/repo-file-sync-action@40da4d517e0a744fce9e8aed03e63d6c8bafbdc0 # v1.17.21
         with:
           GH_PAT: ${{ secrets.PULUMI_BOT_TOKEN }}
-          TEAM_REVIEWERS: pulumi/platform
+          TEAM_REVIEWERS: Platform
+          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release"
+          COMMIT_PREFIX: "(pulumi-bot)"
+          PR_LABELS: |
+            impact/no-changelog-required


### PR DESCRIPTION
Extension of https://github.com/pulumi/pulumi-yaml/pull/370

-Sync files to `pulumi-java`
-Fix adding Platform team as reviewer
-Add no changelog required label to PR's