### PR TITLE
Accept `Resource.Get` when they have required properties.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,3 +20,6 @@
 
 - Respect import option on resource.
   [#367](https://github.com/pulumi/pulumi-yaml/issues/367)
+
+- Don't reject `get` resources with required properties.
+  [#373](https://github.com/pulumi/pulumi-yaml/pull/373)

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -246,9 +246,11 @@ func testInvokeDiags(t *testing.T, template *ast.TemplateDecl, callback func(*Ru
 			if args.ReadRPC != nil {
 				switch args.TypeToken {
 				case "test:read:Resource":
-					assert.Equal(t, "bucket-123456", args.ID)
-					assert.Equal(t, `string_value:"bar"`, args.ReadRPC.Properties.Fields["foo"].String())
-					assert.Len(t, args.ReadRPC.Properties.Fields, 1)
+					if args.ID != "no-state" {
+						assert.Equal(t, "bucket-123456", args.ID)
+						assert.Equal(t, `string_value:"bar"`, args.ReadRPC.Properties.Fields["foo"].String())
+						assert.Len(t, args.ReadRPC.Properties.Fields, 1)
+					}
 					return "arn:aws:s3:::" + args.ID, resource.PropertyMap{
 						"tags": resource.NewObjectProperty(resource.PropertyMap{
 							"isRight": resource.NewStringProperty("yes"),

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -1762,7 +1762,34 @@ variables:
 	assert.Len(t, diags, 0)
 }
 
-func TestReadResourceTyping(t *testing.T) {
+func TestReadResourceNoState(t *testing.T) {
+	t.Parallel()
+	text := `
+name: consumer
+runtime: yaml
+resources:
+  bucket:
+    type: test:read:Resource
+    get:
+      id: no-state
+variables:
+  id: bucket-123456
+  isRight: ${bucket.tags["isRight"]}
+`
+	templ := yamlTemplate(t, text)
+	var wasRun bool
+	diags := testInvokeDiags(t, templ, func(r *Runner) {
+		r.variables["isRight"].(pulumi.AnyOutput).ApplyT(func(s interface{}) interface{} {
+			wasRun = true
+			assert.Equal(t, "yes", s)
+			return s
+		})
+	})
+	assert.True(t, wasRun)
+	assert.Len(t, diags, 0)
+}
+
+func TestReadResourceErrorTyping(t *testing.T) {
 	t.Parallel()
 	text := `
 name: consumer


### PR DESCRIPTION
We were previously rejecting valid programs such the following if `pkg:Resource` has required properties. We need to only test if there are properties or we **don't** have a `get` type resource.
```
resource:
  foo:
    type: pkg:Resource
    get:
      id: ${ID}
```