### PR TITLE
Fix sync workflow

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -8,3 +8,4 @@ pulumi/pulumi-java:
     dest: pkg/codegen/testing/test/testdata/transpiled_examples
     exclude: |
       .gitignore
+      go.mod


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/11058 revealed that we should ignore the `go.mod` as well