### PR TITLE
Escaped interpolated strings remove one more $ sign from evaluation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,3 +23,6 @@
 
 - Discover Invokes during `GetReferencedPlugins`.
   [#381](https://github.com/pulumi/pulumi-yaml/pull/381)
+
+- Escaped interpolated strings now remove one extra dollar sign.
+  [#382](https://github.com/pulumi/pulumi-yaml/pull/382)

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -117,17 +117,12 @@ func (x *StringExpr) GetValue() string {
 
 // StringSyntax creates a new string literal expression with the given value and associated syntax.
 func StringSyntax(node *syntax.StringNode) *StringExpr {
-	parts, diags := parseInterpolate(node, node.Value())
-	if diags.HasErrors() {
-		return &StringExpr{exprNode: expr(node), Value: node.Value()}
-	}
-
-	if len(parts) == 1 && parts[0].Value == nil {
-		interpolated := &InterpolateExpr{Parts: parts}
-		return &StringExpr{exprNode: expr(node), Value: interpolated.String()}
-	}
-
 	return &StringExpr{exprNode: expr(node), Value: node.Value()}
+}
+
+// StringSyntaxValue creates a new string literal expression with the given syntax and value.
+func StringSyntaxValue(node *syntax.StringNode, value string) *StringExpr {
+	return &StringExpr{exprNode: expr(node), Value: value}
 }
 
 // String creates a new string literal expression with the given value.
@@ -303,7 +298,7 @@ func ParseExpr(node syntax.Node) (Expr, syntax.Diagnostics) {
 			case 1:
 				switch {
 				case interpolate.Parts[0].Value == nil:
-					return StringSyntax(node), diags
+					return StringSyntaxValue(node, interpolate.Parts[0].Text), diags
 				case interpolate.Parts[0].Text == "":
 					return &SymbolExpr{
 						exprNode: expr(node),

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -146,7 +146,10 @@ type InterpolateExpr struct {
 func (n *InterpolateExpr) String() string {
 	var str strings.Builder
 	for _, p := range n.Parts {
-		str.WriteString(strings.ReplaceAll(p.Text, "$$", "$"))
+		// un-escape the string back to its original form
+		// this is necessary because the parser will escape the string
+		// so when we print it back out as string, we need to un-escape it
+		str.WriteString(strings.ReplaceAll(p.Text, "$", "$$"))
 		if p.Value != nil {
 			fmt.Fprintf(&str, "${%v}", p.Value)
 		}

--- a/pkg/pulumiyaml/ast/interpolation_test.go
+++ b/pkg/pulumiyaml/ast/interpolation_test.go
@@ -1,0 +1,17 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeInterpolationWorks(t *testing.T) {
+	t.Parallel()
+	node := syntax.String("Hello $${world}!")
+	parts, diags := parseInterpolate(node, node.Value())
+	assert.Empty(t, diags)
+	assert.Len(t, parts, 1, "Expected one interpolation part")
+	assert.Equal(t, "Hello ${world}!", parts[0].Text)
+}

--- a/pkg/pulumiyaml/ast/interpolation_test.go
+++ b/pkg/pulumiyaml/ast/interpolation_test.go
@@ -1,3 +1,4 @@
+// Copyright 2022, Pulumi Corporation.  All rights reserved.
 package ast
 
 import (

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -1613,6 +1613,32 @@ variables:
 	})
 }
 
+func TestEscapingInterpolationInTemplate(t *testing.T) {
+	t.Parallel()
+
+	text := `
+name: test-readfile
+runtime: yaml
+variables:
+    world: world
+    interpolated: hello ${world}!
+    escaped: hello $${world}!
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	testTemplate(t, tmpl, func(e *programEvaluator) {
+		diags := e.evalContext.Evaluate(e.pulumiCtx)
+		requireNoErrors(t, tmpl, diags)
+		result, ok := e.variables["interpolated"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "hello world!", result)
+
+		result, ok = e.variables["escaped"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "hello ${world}!", result)
+	})
+}
+
 func TestJoinForbidsNonStringArgs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The following YAML program:
```yaml
name: yamlescape
runtime: yaml
outputs:
  message: hello $${world}
```
evaluated `message` to just `hello $${world}` where it should have been `hello ${world}`

It turns out, the parsed Value node of `hello $${world}` is just `StringExpr` where it should have been an `InterpolatedExpr` so I've added interpolation logic where we construct `StringExpr` (I have a feeling it should be somewhere else?) 

I've also changed the escaping logic from `strings.ReplaceAll(p.Text, "$", "$$")` to `strings.ReplaceAll(p.Text, "$$", "$")` such that `$$` now is replaced with `$`
