### PR TITLE
Ensure that node order is deterministic

### DIFF
--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/iancoleman/strcase"
@@ -174,6 +175,17 @@ func GetReferencedPlugins(tmpl *ast.TemplateDecl) ([]Plugin, syntax.Diagnostics)
 			PluginDownloadURL: meta.pluginDownloadURL,
 		})
 	}
+
+	sort.Slice(plugins, func(i, j int) bool {
+		pI, pJ := plugins[i], plugins[j]
+		if pI.Package != pJ.Package {
+			return pI.Package < pJ.Package
+		}
+		if pI.Version != pJ.Version {
+			return pI.Version < pJ.Version
+		}
+		return pI.PluginDownloadURL < pJ.PluginDownloadURL
+	})
 
 	return plugins, nil
 }

--- a/pkg/pulumiyaml/sort.go
+++ b/pkg/pulumiyaml/sort.go
@@ -56,6 +56,28 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 
 	// Precompute dependencies for each resource
 	intermediates := map[string]graphNode{}
+	// The list of keys to intermediates in the order they were first added.
+	sortedIntermediatesKeys := []string{}
+
+	// Add a new node to intermediates.
+	addItermediate := func(key string, node graphNode) {
+		_, duplicate := intermediates[key]
+		intermediates[key] = node
+		if !duplicate {
+			sortedIntermediatesKeys = append(sortedIntermediatesKeys, key)
+		}
+	}
+
+	// A list of graphNodes from intermediates in the order they were inserted in.
+	// This ensures iteration order is deterministic.
+	intermediateValues := func() []graphNode {
+		sorted := make([]graphNode, len(sortedIntermediatesKeys))
+		for i, k := range sortedIntermediatesKeys {
+			sorted[i] = intermediates[k]
+		}
+		return sorted
+	}
+
 	dependencies := map[string][]*ast.StringExpr{}
 	for _, kvp := range t.Configuration.Entries {
 		cname := kvp.Key.Value
@@ -65,7 +87,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 		diags = append(diags, cdiags...)
 
 		if !cdiags.HasErrors() {
-			intermediates[cname] = node
+			addItermediate(cname, node)
 			dependencies[cname] = nil
 
 			// Special case: configuration goes first
@@ -81,7 +103,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 		diags = append(diags, cdiags...)
 
 		if !cdiags.HasErrors() {
-			intermediates[rname] = node
+			addItermediate(rname, node)
 			dependencies[rname] = GetResourceDependencies(r)
 		}
 	}
@@ -93,7 +115,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 		diags = append(diags, cdiags...)
 
 		if !cdiags.HasErrors() {
-			intermediates[vname] = node
+			addItermediate(vname, node)
 			dependencies[vname] = GetVariableDependencies(kvp)
 		}
 	}
@@ -147,7 +169,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 	// Repeatedly visit the first unvisited unode until none are left
 	for {
 		progress := false
-		for _, e := range intermediates {
+		for _, e := range intermediateValues() {
 			if !visited[e.key().Value] {
 				if visit(e.key()) {
 					progress = true

--- a/pkg/pulumiyaml/sort.go
+++ b/pkg/pulumiyaml/sort.go
@@ -60,7 +60,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 	sortedIntermediatesKeys := []string{}
 
 	// Add a new node to intermediates.
-	addItermediate := func(key string, node graphNode) {
+	addIntermediate := func(key string, node graphNode) {
 		_, duplicate := intermediates[key]
 		intermediates[key] = node
 		if !duplicate {
@@ -87,7 +87,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 		diags = append(diags, cdiags...)
 
 		if !cdiags.HasErrors() {
-			addItermediate(cname, node)
+			addIntermediate(cname, node)
 			dependencies[cname] = nil
 
 			// Special case: configuration goes first
@@ -103,7 +103,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 		diags = append(diags, cdiags...)
 
 		if !cdiags.HasErrors() {
-			addItermediate(rname, node)
+			addIntermediate(rname, node)
 			dependencies[rname] = GetResourceDependencies(r)
 		}
 	}
@@ -115,7 +115,7 @@ func topologicallySortedResources(t *ast.TemplateDecl) ([]graphNode, syntax.Diag
 		diags = append(diags, cdiags...)
 
 		if !cdiags.HasErrors() {
-			addItermediate(vname, node)
+			addIntermediate(vname, node)
 			dependencies[vname] = GetVariableDependencies(kvp)
 		}
 	}

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 var (
@@ -42,26 +41,6 @@ var (
 		"stackreference-consumer",
 		// PCL does not have stringAssets
 		"getting-started",
-	}
-
-	// failingCompile examples are known to produce valid PCL, but produce
-	// invalid transpiled code.
-	failingCompile = map[string]LanguageList{
-		"stackreference-producer": Dotnet.And(Golang),
-		"stackreference-consumer": AllLanguages().Except(Python),
-		"random":                  Dotnet.And(Nodejs),
-		"azure-static-website":    AllLanguages(),
-		"aws-static-website":      AllLanguages().Except(Python),
-		"webserver":               AllLanguages().Except(Nodejs),
-		"azure-container-apps":    AllLanguages(),
-		"webserver-json":          AllLanguages().Except(Nodejs),
-		"aws-eks":                 AllLanguages().Except(Python), // plain inputs
-		"cue-eks":                 AllLanguages().Except(Python), // plain inputs
-		"azure-app-service":       Dotnet.And(Golang),
-		"pulumi-variable":         AllLanguages().Except(Python),
-		"kubernetes":              Golang, // returning string instead of *string in ApplyT
-		"readme": (Dotnet.And( // https://github.com/pulumi/pulumi/issues/9642
-			Golang)), // https://github.com/pulumi/pulumi/issues/9692
 	}
 )
 
@@ -227,8 +206,6 @@ func writeOrCompare(t *testing.T, dir string, files map[string][]byte) {
 		}
 	}
 }
-
-type projectGeneratorFunc func(directory string, project workspace.Project, p *pcl.Program) error
 
 type LanguageList struct {
 	list []string


### PR DESCRIPTION
We were seeing non-deterministic test results such as https://github.com/pulumi/pulumi-yaml/actions/runs/3340731857/attempts/1. The problem was inconsistent node order when the walker was running. 

Since the top-sort algorithm does not rely on iteration order, we are free to choose an arbitrary order. I have chosen insertion order following the principle of least surprise.

The problem and the solution can be verified by running the `pulumiyaml/TestVersionConflicts` tests with a high count number. You will see intermittent failures before the change, but not after.