### PR TITLE
Make resource ref "id" insertion type aware

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -29,3 +29,6 @@
 
 - Escaped interpolated strings now remove one extra dollar sign.
   [#382](https://github.com/pulumi/pulumi-yaml/pull/382)
+
+- Only insert "id" in ejected resource refs when the receiver type is a string.
+  [#389](https://github.com/pulumi/pulumi-yaml/pull/389)

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -27,7 +27,6 @@ type importer struct {
 	referencedStacks []string
 
 	loader          pulumiyaml.PackageLoader
-	typing          pulumiyaml.Typing
 	configuration   map[string]*model.Variable
 	variables       map[string]*model.Variable
 	stackReferences map[string]*model.Variable
@@ -1074,16 +1073,9 @@ func (imp *importer) importTemplate(file *ast.TemplateDecl) (*model.Body, syntax
 
 // ImportTemplate converts a YAML template to a PCL definition.
 func ImportTemplate(file *ast.TemplateDecl, loader pulumiyaml.PackageLoader) (*model.Body, syntax.Diagnostics) {
-	// We are ignoring errors since runner will be treated as advisory
-	runner, _, _ := pulumiyaml.PrepareTemplate(file, nil, loader)
-	var typing pulumiyaml.Typing
-	if runner != nil {
-		// We ignore diags, since typing is advisory
-		typing, _ = pulumiyaml.TypeCheck(runner)
-	}
+
 	imp := importer{
 		loader:          loader,
-		typing:          typing,
 		configuration:   map[string]*model.Variable{},
 		variables:       map[string]*model.Variable{},
 		stackReferences: map[string]*model.Variable{},

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -57,6 +57,12 @@ func (imp *importer) importRef(node ast.Expr, name string, environment map[strin
 		return model.VariableReference(v), nil
 	}
 	if v, ok := imp.resources[name]; ok {
+		// TODO: This comparison is not 100% sound, since hint may be a union that
+		// includes a `string` type but does not include the resource type itself.
+		//
+		// The solution is to expose IsAssignable from pulumiyaml.Typing, but for that to
+		// be reliable we would need to harden a lot of our top-sort algorithm against
+		// missing nodes.
 		exportID := codegen.UnwrapType(hint) == schema.StringType
 		if isAccess || !exportID {
 			return model.VariableReference(v), nil

--- a/pkg/tests/transpiled_examples/aws-static-website-pp/aws-static-website.pp
+++ b/pkg/tests/transpiled_examples/aws-static-website-pp/aws-static-website.pp
@@ -7,7 +7,7 @@ resource siteBucket "aws-native:s3:Bucket" {
 
 resource indexHtml "aws:s3/bucketObject:BucketObject" {
 	__logicalName = "index.html"
-	bucket = siteBucket.id
+	bucket = siteBucket
 	source = fileAsset("./www/index.html")
 	acl = "public-read"
 	contentType = "text/html"
@@ -15,7 +15,7 @@ resource indexHtml "aws:s3/bucketObject:BucketObject" {
 
 resource faviconPng "aws:s3/bucketObject:BucketObject" {
 	__logicalName = "favicon.png"
-	bucket = siteBucket.id
+	bucket = siteBucket
 	source = fileAsset("./www/favicon.png")
 	acl = "public-read"
 	contentType = "image/png"


### PR DESCRIPTION
Fixes #386

Pulumi YAML used to turn resource refs into strings by adding the "id" property to the end of resources. Sometimes this is the correct behavior, reflecting Pulumi YAMLs ability to pass resources where strings go by converting them to strings vie their ID.

In other places, the resource itself needs to be passed directly, and the implicit string conversion is not OK.

This PR makes the ID insertion conditional on the receiver being a string type. It is tested by our own examples, but I have confirmed that it works on the repro introduced in the PR.