### PR TITLE
Eject with missing nodes

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,34 +1,6 @@
 ### Improvements
 
-- Ensure that constant values passed to enums are valid.
-  [#357](https://github.com/pulumi/pulumi-yaml/pull/357)
-
-- Warn on non camelCase names.
-  [#362](https://github.com/pulumi/pulumi-yaml/pull/362)
-
-- Recognize the new core project-level `config` block.
-  [#369](https://github.com/pulumi/pulumi-yaml/pull/369)
+- Allow ejecting when relying on `config` nodes.
+  [#393](https://github.com/pulumi/pulumi-yaml/pull/393)
 
 ### Bug Fixes
-
-- Allow interpolations for `AssetOrArchive` function values
-  [#341](https://github.com/pulumi/pulumi-yaml/pull/341)
-
-- Clarify the lifetimes when calling `codegen.Eject`. This is a breaking change to the
-  `codegen.Eject` API.
-  [#358](https://github.com/pulumi/pulumi-yaml/pull/358)
-
-- Quote generated strings that could be numbers.
-  [#363](https://github.com/pulumi/pulumi-yaml/issues/363)
-
-- Respect import option on resource.
-  [#367](https://github.com/pulumi/pulumi-yaml/issues/367)
-
-- Discover Invokes during `GetReferencedPlugins`.
-  [#381](https://github.com/pulumi/pulumi-yaml/pull/381)
-
-- Escaped interpolated strings now remove one extra dollar sign.
-  [#382](https://github.com/pulumi/pulumi-yaml/pull/382)
-
-- Only insert "id" in ejected resource refs when the receiver type is a string.
-  [#389](https://github.com/pulumi/pulumi-yaml/pull/389)

--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -53,11 +53,13 @@ func ConvertTemplateIL(template *ast.TemplateDecl, loader schema.ReferenceLoader
 
 	pkgLoader := pulumiyaml.NewPackageLoaderFromSchemaLoader(loader)
 	// nil runner passed in since template is not executed and we can use pkgLoader
-	_, tdiags, err := pulumiyaml.PrepareTemplate(template, nil, pkgLoader)
+	r, tdiags, err := pulumiyaml.PrepareTemplate(template, nil, pkgLoader)
 	if err != nil {
 		return "", diags, err
 	}
 	diags = diags.Extend(tdiags.HCL())
+
+	pulumiyaml.InjectMissingNodes(r, template)
 
 	templateBody, tdiags := ImportTemplate(template, pkgLoader)
 	diags = diags.Extend(tdiags.HCL())

--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -58,36 +58,37 @@ func ConvertTemplateIL(template *ast.TemplateDecl, loader schema.ReferenceLoader
 		return "", diags, err
 	}
 	diags = diags.Extend(tdiags.HCL())
-	if diags.HasErrors() {
-		return "", diags, nil
-	}
 
 	templateBody, tdiags := ImportTemplate(template, pkgLoader)
 	diags = diags.Extend(tdiags.HCL())
-	if diags.HasErrors() {
-		return "", diags, nil
+	if templateBody == nil {
+		// This is a irrecoverable error, so we make sure the error field is non-nil
+		return "", diags, diags
 	}
 	programText := fmt.Sprintf("%v", templateBody)
 
-	return programText, nil, nil
+	if programText == "" {
+		return "", diags, diags
+	}
+
+	return programText, diags, nil
 }
 
 func EjectProgram(template *ast.TemplateDecl, loader schema.ReferenceLoader) (*pcl.Program, hcl.Diagnostics, error) {
-	programText, diags, err := ConvertTemplateIL(template, loader)
-	if err != nil {
-		return nil, diags, err
+	programText, yamlDiags, err := ConvertTemplateIL(template, loader)
+	if err != nil || programText == "" {
+		return nil, yamlDiags, err
 	}
-	if diags.HasErrors() {
-		return nil, diags, fmt.Errorf("internal error: %w", diags)
-	}
+
 	parser := hclsyntax.NewParser()
 	if err := parser.ParseFile(strings.NewReader(programText), "program.pp"); err != nil {
-		return nil, diags, err
+		return nil, yamlDiags, err
 	}
-	diags = diags.Extend(parser.Diagnostics)
+	diags := parser.Diagnostics
 	if diags.HasErrors() {
-		return nil, diags, nil
+		return nil, append(yamlDiags, diags...), diags
 	}
+
 	bindOpts := []pcl.BindOption{
 		pcl.SkipResourceTypechecking,
 		pcl.AllowMissingProperties,
@@ -95,14 +96,15 @@ func EjectProgram(template *ast.TemplateDecl, loader schema.ReferenceLoader) (*p
 	}
 	bindOpts = append(bindOpts, pcl.Loader(loader))
 	program, pdiags, err := pcl.BindProgram(parser.Files, bindOpts...)
+	diags = diags.Extend(pdiags)
 	if err != nil {
-		return nil, diags, err
+		return nil, append(yamlDiags, diags...), err
 	}
-	if pdiags.HasErrors() {
-		return nil, diags, fmt.Errorf("internal error: %w", pdiags)
+	if pdiags.HasErrors() || program == nil {
+		return nil, append(yamlDiags, diags...), fmt.Errorf("internal error: %w", pdiags)
 	}
 
-	return program, diags, nil
+	return program, append(yamlDiags, diags...), nil
 }
 
 // ConvertTemplate converts a Pulumi YAML template to a target language using PCL as an intermediate representation.

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -511,7 +511,7 @@ func (imp *importer) importConfig(kvp ast.ConfigMapEntry) (model.BodyItem, synta
 		typeExpr = "string"
 	}
 
-	configVar, ok := imp.configuration[name]
+	_, ok := imp.configuration[name]
 	contract.Assert(ok)
 
 	var defaultValue model.Expression
@@ -526,8 +526,11 @@ func (imp *importer) importConfig(kvp ast.ConfigMapEntry) (model.BodyItem, synta
 	// TODO(pdg): secret configuration -- requires changes in PCL
 
 	configDef := &model.Block{
-		Type:   "config",
-		Labels: []string{configVar.Name, typeExpr},
+		Type: "config",
+		// The raw config value might not be a valid identifier, but the value needs to be
+		// preserved. It is the responcibility of the caller to adjust kvp.Key.GetValue()
+		// so it is valid in the target language.
+		Labels: []string{kvp.Key.GetValue(), typeExpr},
 		Body:   &model.Body{},
 	}
 	if defaultValue != nil {

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -923,9 +923,14 @@ func (imp *importer) assignNames() {
 		"cwd",
 	)
 
-	assign := func(name, suffix string) *model.Variable {
+	assign := func(name, suffix string, literal bool) *model.Variable {
 		assignName := func(name, suffix string) string {
-			name = camel(makeLegalIdentifier(name))
+
+			name = makeLegalIdentifier(name)
+			// TODO: Remove this when pcl supports logical names for config vars
+			if !literal {
+				name = camel(name)
+			}
 			if !assigned.Has(name) {
 				assigned.Add(name)
 				return name
@@ -947,7 +952,7 @@ func (imp *importer) assignNames() {
 	}
 
 	// TODO: do this in source order
-	assignNames := func(m map[string]*model.Variable, suffix string) {
+	assignNames := func(m map[string]*model.Variable, suffix string, literal bool) {
 		names := make([]string, 0, len(m))
 		for n := range m {
 			names = append(names, n)
@@ -955,15 +960,15 @@ func (imp *importer) assignNames() {
 		sort.Strings(names)
 
 		for _, n := range names {
-			m[n] = assign(n, suffix)
+			m[n] = assign(n, suffix, literal)
 		}
 	}
 
-	assignNames(imp.configuration, "")
-	assignNames(imp.outputs, "")
-	assignNames(imp.variables, "Var")
-	assignNames(imp.stackReferences, "Stack")
-	assignNames(imp.resources, "Resource")
+	assignNames(imp.configuration, "", true)
+	assignNames(imp.outputs, "", false)
+	assignNames(imp.variables, "Var", false)
+	assignNames(imp.stackReferences, "Stack", false)
+	assignNames(imp.resources, "Resource", false)
 }
 
 func (imp *importer) findStackReferences(node ast.Expr) {

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -78,7 +78,7 @@ func (imp *importer) importRef(node ast.Expr, name string, environment map[strin
 	}
 
 	return &model.ScopeTraversalExpression{
-		Traversal: hcl.Traversal{hcl.TraverseRoot{Name: name}},
+		Traversal: hcl.Traversal{hcl.TraverseRoot{Name: camel(makeLegalIdentifier(name))}},
 		Parts:     []model.Traversable{model.DynamicType},
 	}, syntax.Diagnostics{ast.ExprError(node, fmt.Sprintf("unknown config, variable, or resource '%v'", name), "")}
 }

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -2187,9 +2187,7 @@ func listStrings(v *ast.StringListDecl) []string {
 func InjectMissingNodes(r *Runner, template *ast.TemplateDecl) {
 	for _, node := range r.intermediates {
 		if node, ok := node.(missingNode); ok {
-			fmt.Printf("Found missing node: %s\n", node.name.GetValue())
 			if isGlobalConfigName(node.name.GetValue()) {
-				fmt.Printf("Injecting node: %s\n", node.name.GetValue())
 				template.Configuration.Entries = append(template.Configuration.Entries,
 					ast.ConfigMapEntry{
 						Key:   node.key(),

--- a/pkg/pulumiyaml/run_options_test.go
+++ b/pkg/pulumiyaml/run_options_test.go
@@ -160,7 +160,8 @@ variables:
 	}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		runner := newRunner(template, newMockPackageMap())
-		assert.Equal(t, runner.setDefaultProviders(), nil)
+		runner.setDefaultProviders()
+		requireNoErrors(t, template, runner.sdiags.diags)
 		diags := runner.Evaluate(ctx)
 		requireNoErrors(t, template, diags)
 		return nil

--- a/pkg/pulumiyaml/sort.go
+++ b/pkg/pulumiyaml/sort.go
@@ -75,6 +75,18 @@ func (e configNodeEnv) value() interface{} {
 	return e.Value
 }
 
+type missingNode struct {
+	name *ast.StringExpr
+}
+
+func (e missingNode) key() *ast.StringExpr {
+	return e.name
+}
+
+func (missingNode) valueKind() string {
+	return "missing node"
+}
+
 func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNode) ([]graphNode, syntax.Diagnostics) {
 	var diags syntax.Diagnostics
 
@@ -167,7 +179,8 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 		e, ok := intermediates[name.Value]
 		if !ok {
 			diags.Extend(ast.ExprError(name, fmt.Sprintf("resource %q not found", name.Value), ""))
-			return false
+			e = missingNode{name}
+			addIntermediate(name.Value, e)
 		}
 		kind := e.valueKind()
 

--- a/pkg/tests/transpiled_examples/azure-app-service-pp/azure-app-service.pp
+++ b/pkg/tests/transpiled_examples/azure-app-service-pp/azure-app-service.pp
@@ -1,4 +1,5 @@
 config sqlAdmin string {
+	__logicalName = "sqlAdmin"
 	default = "pulumi"
 }
 

--- a/pkg/tests/transpiled_examples/azure-container-apps-pp/azure-container-apps.pp
+++ b/pkg/tests/transpiled_examples/azure-container-apps-pp/azure-container-apps.pp
@@ -1,8 +1,10 @@
 config sqlAdmin string {
+	__logicalName = "sqlAdmin"
 	default = "pulumi"
 }
 
 config retentionInDays int {
+	__logicalName = "retentionInDays"
 	default = 30
 }
 

--- a/pkg/tests/transpiled_examples/kubernetes-pp/kubernetes.pp
+++ b/pkg/tests/transpiled_examples/kubernetes-pp/kubernetes.pp
@@ -1,4 +1,5 @@
 config hostname string {
+	__logicalName = "hostname"
 	default = "example.com"
 }
 

--- a/pkg/tests/transpiled_examples/webserver-json-pp/webserver-json.pp
+++ b/pkg/tests/transpiled_examples/webserver-json-pp/webserver-json.pp
@@ -1,4 +1,5 @@
-config InstanceType string {
+config instanceType string {
+	__logicalName = "InstanceType"
 	default = "t3.micro"
 }
 
@@ -18,7 +19,7 @@ resource webSecGrp "aws:ec2/securityGroup:SecurityGroup" {
 
 resource webServer "aws:ec2/instance:Instance" {
 	__logicalName = "WebServer"
-	instanceType = InstanceType
+	instanceType = instanceType
 	ami = invoke("aws:index/getAmi:getAmi", {
 		filters = [{
 			name = "name",

--- a/pkg/tests/transpiled_examples/webserver-json-pp/webserver-json.pp
+++ b/pkg/tests/transpiled_examples/webserver-json-pp/webserver-json.pp
@@ -1,4 +1,4 @@
-config instanceType string {
+config InstanceType string {
 	default = "t3.micro"
 }
 
@@ -18,7 +18,7 @@ resource webSecGrp "aws:ec2/securityGroup:SecurityGroup" {
 
 resource webServer "aws:ec2/instance:Instance" {
 	__logicalName = "WebServer"
-	instanceType = instanceType
+	instanceType = InstanceType
 	ami = invoke("aws:index/getAmi:getAmi", {
 		filters = [{
 			name = "name",

--- a/pkg/tests/transpiled_examples/webserver-pp/webserver.pp
+++ b/pkg/tests/transpiled_examples/webserver-pp/webserver.pp
@@ -1,4 +1,4 @@
-config instanceType string {
+config InstanceType string {
 	default = "t3.micro"
 }
 
@@ -23,7 +23,7 @@ resource webSecGrp "aws:ec2/securityGroup:SecurityGroup" {
 
 resource webServer "aws:ec2/instance:Instance" {
 	__logicalName = "WebServer"
-	instanceType = instanceType
+	instanceType = InstanceType
 	ami = ec2Ami
 	userData = "#!/bin/bash\necho 'Hello, World from ${webSecGrp.arn}!' > index.html\nnohup python -m SimpleHTTPServer 80 &"
 	vpcSecurityGroupIds = [webSecGrp.id]

--- a/pkg/tests/transpiled_examples/webserver-pp/webserver.pp
+++ b/pkg/tests/transpiled_examples/webserver-pp/webserver.pp
@@ -1,4 +1,5 @@
-config InstanceType string {
+config instanceType string {
+	__logicalName = "InstanceType"
 	default = "t3.micro"
 }
 
@@ -23,7 +24,7 @@ resource webSecGrp "aws:ec2/securityGroup:SecurityGroup" {
 
 resource webServer "aws:ec2/instance:Instance" {
 	__logicalName = "WebServer"
-	instanceType = InstanceType
+	instanceType = instanceType
 	ami = ec2Ami
 	userData = "#!/bin/bash\necho 'Hello, World from ${webSecGrp.arn}!' > index.html\nnohup python -m SimpleHTTPServer 80 &"
 	vpcSecurityGroupIds = [webSecGrp.id]


### PR DESCRIPTION
This PR makes three adjustments. 
1. It allows an `Eject` to proceed with missing nodes.
2. It injects artificial config nodes during an `Eject` when it looks like it is a missing config value. This is a best effort heuristic but works in the simple case.
3. It modifies how we eject config nodes, preventing any normalization on the lookup value. This ensures nodes like `foo:bar` don't get ejected as `fooBar` (which is invalid). (This behavior requires https://github.com/pulumi/pulumi/pull/11231)