### PR TITLE
Set version as not current on sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,3 +21,8 @@ jobs:
           COMMIT_PREFIX: "(pulumi-bot)"
           PR_LABELS: |
             impact/no-changelog-required
+          # Forces examples to regenerate in pulumi/pulumi
+          version-set: |
+            {
+              "name": "not-current"
+            }

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           GH_PAT: ${{ secrets.PULUMI_BOT_TOKEN }}
           TEAM_REVIEWERS: Platform
-          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release"
+          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release.\nThis PR was run with PULUMI_ACCEPT=true. You need to manually confirm that changes are valid before accepting."
           COMMIT_PREFIX: "(pulumi-bot)"
           PR_LABELS: |
             impact/no-changelog-required


### PR DESCRIPTION
We want to set `PULUMI_ACCEPT=true` to rerun program generation on synced examples in `pulumi/pulumi` https://github.com/pulumi/pulumi/blob/master/.github/workflows/ci-run-test.yml#L300