### PR TITLE
Update sync examples workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,3 +21,8 @@ jobs:
           COMMIT_PREFIX: "(pulumi-bot)"
           PR_LABELS: |
             impact/no-changelog-required
+          # Forces examples to regenerate in pulumi/pulumi
+          version-set: |
+            {
+              "name": "not-current"
+            }

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,12 +17,7 @@ jobs:
         with:
           GH_PAT: ${{ secrets.PULUMI_BOT_TOKEN }}
           TEAM_REVIEWERS: Platform
-          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release.\nThis PR was run with PULUMI_ACCEPT=true. You need to manually confirm that changes are valid before accepting."
+          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release.\nTo program-generate new/modified examples, please fork this branch and run `cd pkg/codegen && PULUMI_ACCEPT=true go test -timeout 1h -tags all,smoke -run '^TestGenerateProgram$' ./...`."
           COMMIT_PREFIX: "(pulumi-bot)"
           PR_LABELS: |
             impact/no-changelog-required
-          # Forces examples to regenerate in pulumi/pulumi
-          version-set: |
-            {
-              "name": "not-current"
-            }

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           GH_PAT: ${{ secrets.PULUMI_BOT_TOKEN }}
           TEAM_REVIEWERS: Platform
-          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release"
+          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release.\nThis PR was run with PULUMI_ACCEPT=true. You need to manually confirm that changes are valid before accepting."
           COMMIT_PREFIX: "(pulumi-bot)"
           PR_LABELS: |
             impact/no-changelog-required


### PR DESCRIPTION
The workflow doesn't allow external inputs to pass through to workflows in the target repo, so for now we add a comment with instructions to regenerate new/modified examples.