### PR TITLE
Loosen constraint on int vs number type check

### DIFF
--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -1085,7 +1085,7 @@ func (tc *typeCache) typeConfig(r *Runner, node configNode) bool {
 	}
 	// check for incompatible types between config/ configuration
 	if typExisting, ok := tc.configuration[k]; ok {
-		if typExisting.String() != typ.String() {
+		if !tc.compatibleType(typExisting, typ) {
 			ctx := r.newContext(node)
 			ctx.error(nil, fmt.Sprintf("config key %s cannot have conflicting types %v, %v",
 				k, codegen.UnwrapType(typExisting), codegen.UnwrapType(typ)))
@@ -1094,6 +1094,15 @@ func (tc *typeCache) typeConfig(r *Runner, node configNode) bool {
 	}
 	tc.configuration[k] = typ
 	return true
+}
+
+func (tc *typeCache) compatibleType(a, b schema.Type) bool {
+	if a.String() == b.String() {
+		return true
+	} else if (a == schema.IntType && b == schema.NumberType) || (b == schema.IntType && a == schema.NumberType) {
+		return true
+	}
+	return false
 }
 
 func (tc *typeCache) typeOutput(r *Runner, node ast.PropertyMapEntry) bool {

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -1085,7 +1085,7 @@ func (tc *typeCache) typeConfig(r *Runner, node configNode) bool {
 	}
 	// check for incompatible types between config/ configuration
 	if typExisting, ok := tc.configuration[k]; ok {
-		if typMatch, ok := tc.isConfigEquivalent(typExisting, typCurrent); !ok {
+		if typMatch, ok := unifyConfigType(typExisting, typCurrent); !ok {
 			ctx := r.newContext(node)
 			ctx.error(nil, fmt.Sprintf("config key %s cannot have conflicting types %v, %v",
 				k, codegen.UnwrapType(typExisting), codegen.UnwrapType(typCurrent)))
@@ -1098,7 +1098,8 @@ func (tc *typeCache) typeConfig(r *Runner, node configNode) bool {
 	return true
 }
 
-func (tc *typeCache) isConfigEquivalent(a, b schema.Type) (schema.Type, bool) {
+// checks for config type compatibility
+func unifyConfigType(a, b schema.Type) (schema.Type, bool) {
 	a, b = codegen.UnwrapType(a), codegen.UnwrapType(b)
 	if a.String() == b.String() {
 		return a, true

--- a/pkg/pulumiyaml/analyser_test.go
+++ b/pkg/pulumiyaml/analyser_test.go
@@ -308,3 +308,40 @@ func TestTypePropertyAccess(t *testing.T) {
 		})
 	}
 }
+
+// tests for type compatibility, i.e. int&number are compatible, int&string are not
+func TestConfigCompatibility(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		typeA      schema.Type
+		typeB      schema.Type
+		compatible bool
+	}{
+		{
+			typeA:      schema.IntType,
+			typeB:      schema.IntType,
+			compatible: true,
+		},
+		{
+			typeA:      schema.IntType,
+			typeB:      schema.NumberType,
+			compatible: true,
+		},
+		{
+			typeA:      schema.IntType,
+			typeB:      schema.StringType,
+			compatible: false,
+		},
+	}
+
+	for _, c := range cases { //nolint:paralleltest
+		// false positive. The parallel call is below
+
+		c := c
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			_, ok := unifyConfigType(c.typeA, c.typeB)
+			assert.Equal(t, c.compatible, ok)
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -204,3 +204,8 @@ func (host *yamlLanguageHost) GetProgramDependencies(ctx context.Context, req *p
 func (host *yamlLanguageHost) About(ctx context.Context, req *emptypb.Empty) (*pulumirpc.AboutResponse, error) {
 	return &pulumirpc.AboutResponse{}, nil
 }
+
+func (host *yamlLanguageHost) RunPlugin(*pulumirpc.RunPluginRequest, pulumirpc.LanguageRuntime_RunPluginServer) error {
+	// No plugins to run for YAML
+	return nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -204,8 +204,3 @@ func (host *yamlLanguageHost) GetProgramDependencies(ctx context.Context, req *p
 func (host *yamlLanguageHost) About(ctx context.Context, req *emptypb.Empty) (*pulumirpc.AboutResponse, error) {
 	return &pulumirpc.AboutResponse{}, nil
 }
-
-func (host *yamlLanguageHost) RunPlugin(*pulumirpc.RunPluginRequest, pulumirpc.LanguageRuntime_RunPluginServer) error {
-	// No plugins to run for YAML
-	return nil
-}


### PR DESCRIPTION
Fixes `pu/templates` https://github.com/pulumi/templates/issues/465

Since the project-level `config` block supports `integer` but not `number`, we can loosen the type check constraint for now until `configuration` is fully deprecated