### PR TITLE
Exclude cue-static-web-app test from sync action

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -8,4 +8,5 @@ group:
       exclude: |
         .gitignore
         go.mod
+        pkg/tests/transpiled_examples/cue-static-web-app
       deleteOrphaned: true

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,12 +17,7 @@ jobs:
         with:
           GH_PAT: ${{ secrets.PULUMI_BOT_TOKEN }}
           TEAM_REVIEWERS: Platform
-          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release.\nTo program-generate new/modified examples, please fork this branch and run `cd pkg/codegen && PULUMI_ACCEPT=true go test -timeout 1h -tags all,smoke -run '^TestGenerateProgram$' ./...`."
+          PR_BODY: "This PR syncs changes to the codegen'd PCL files from the latest `pulumi/yaml` release.\nTo program-gen new/ modified examples, please fork this branch and run `cd pkg/codegen && PULUMI_ACCEPT=true go test -timeout 1h -tags all,smoke -run '^TestGenerateProgram$' ./...`.\nThis is not required if all files in the PR have been deleted (no new examples)."
           COMMIT_PREFIX: "(pulumi-bot)"
           PR_LABELS: |
             impact/no-changelog-required
-          # Forces examples to regenerate in pulumi/pulumi
-          version-set: |
-            {
-              "name": "not-current"
-            }


### PR DESCRIPTION
Removing test from sync action temporarily due to failure in `pu/pu` CI per https://github.com/pulumi/pulumi/pull/11513