### PR TITLE
Deprecate fn::stackReference

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
+- Deprecate `fn::stackReference`.
+  [#419](https://github.com/pulumi/pulumi-yaml/pull/419)
 
 ### Bug Fixes

--- a/examples/stackreference-consumer/Pulumi.yaml
+++ b/examples/stackreference-consumer/Pulumi.yaml
@@ -13,4 +13,4 @@ resources:
       # So you might use "alice/infra-project-name/dev", as an example.
       name: PLACEHOLDER_ORG_NAME/stackreference-producer/PLACEHOLDER_STACK_NAME
 outputs:
-  referencedImageName: ${stackRef.imageName}
+  referencedImageName: ${stackRef.outputs["imageName"]}

--- a/examples/stackreference-consumer/Pulumi.yaml
+++ b/examples/stackreference-consumer/Pulumi.yaml
@@ -1,8 +1,9 @@
 name: stackreference-consumer
 runtime: yaml
-outputs:
-  referencedImageName:
-    fn::stackReference:
+resources:
+  stackRef:
+    type: pulumi:pulumi:StackReference
+    properties:
       # These are placeholders that our test environment replaces.
       #
       # If you're using this sample:
@@ -10,5 +11,6 @@ outputs:
       # * Stack name is determined when you run "pulumi up" for the first time, such as "dev"
       #
       # So you might use "alice/infra-project-name/dev", as an example.
-      - PLACEHOLDER_ORG_NAME/stackreference-producer/PLACEHOLDER_STACK_NAME
-      - imageName
+      name: PLACEHOLDER_ORG_NAME/stackreference-producer/PLACEHOLDER_STACK_NAME
+outputs:
+  referencedImageName: ${stackRef}

--- a/examples/stackreference-consumer/Pulumi.yaml
+++ b/examples/stackreference-consumer/Pulumi.yaml
@@ -13,4 +13,4 @@ resources:
       # So you might use "alice/infra-project-name/dev", as an example.
       name: PLACEHOLDER_ORG_NAME/stackreference-producer/PLACEHOLDER_STACK_NAME
 outputs:
-  referencedImageName: ${stackRef}
+  referencedImageName: ${stackRef.imageName}


### PR DESCRIPTION
Fixes #285 
Now that YAML is GA, `fn::stackReference` should be deprecated in favor of using the resource type `pulumi:pulumi:StackResource`.