### PR TITLE
Deprecate `fn::stackReference`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
+- Deprecate `fn::stackReference`.
+  [#420](https://github.com/pulumi/pulumi-yaml/pull/420)
 
 ### Bug Fixes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,5 @@
 ### Improvements
+
 - Deprecate `fn::stackReference`.
   [#420](https://github.com/pulumi/pulumi-yaml/pull/420)
 

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -774,6 +774,9 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		set("fn::split", parseSplit)
 	case "fn::stackreference":
 		set("fn::stackReference", parseStackReference)
+		diags = append(diags, syntax.Warning(kvp.Key.Syntax().Range(),
+			`'fn::stackReference' is deprecated; please use 'pulumi:pulumi:StackReference' instead`,
+			`see "https://www.pulumi.com/docs/intro/concepts/stack/#stackreferences for more info.`))
 	case "fn::assetarchive":
 		set("fn::assetArchive", parseAssetArchive)
 	case "fn::secret":

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1376,6 +1376,10 @@ func (e *programEvaluator) evaluateExpr(x ast.Expr) (interface{}, bool) {
 	case *ast.AssetArchiveExpr:
 		return e.evaluateBuiltinAssetArchive(x)
 	case *ast.StackReferenceExpr:
+		e.addWarnDiag(x.Syntax().Syntax().Range(),
+			"'fn::stackReference' is deprecated",
+			"Please use `pulumi:pulumi:StackReference`; see"+
+				"https://www.pulumi.com/docs/intro/concepts/stack/#stackreferences")
 		return e.evaluateBuiltinStackReference(x)
 	case *ast.SecretExpr:
 		return e.evaluateBuiltinSecret(x)


### PR DESCRIPTION
Fixes #285 

Now that YAML is GA, `fn::stackReference` should be deprecated in favor of using the resource type pulumi:pulumi:StackResource.