### PR TITLE
Avoid panicing for non-string map keys

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,3 +8,6 @@
   [#423](https://github.com/pulumi/pulumi-yaml/pull/423)
 
 ### Bug Fixes
+
+- Avoid panicing for non-string map keys
+  [#428](https://github.com/pulumi/pulumi-yaml/pull/428)

--- a/pkg/pulumiyaml/testing/test/testdata/direct-invoke-pp/direct-invoke.pp
+++ b/pkg/pulumiyaml/testing/test/testdata/direct-invoke-pp/direct-invoke.pp
@@ -1,6 +1,7 @@
 resource example "aws:iam:Policy" {
   name   = "example_policy"
   path   = "/"
+  tags = { 3 = 4 }
   policy = invoke("aws:iam:getPolicyDocument", {
     statements = [{
       sid = "1"

--- a/pkg/pulumiyaml/testing/test/testdata/direct-invoke-pp/yaml/direct-invoke.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/direct-invoke-pp/yaml/direct-invoke.yaml
@@ -4,6 +4,8 @@ resources:
     properties:
       name: example_policy
       path: /
+      tags:
+        '3': 4
       policy:
         fn::invoke:
           Function: aws:iam:getPolicyDocument


### PR DESCRIPTION
Fixes a panic when converting a map with non-string keys.