### PR TITLE
Test docker version against resolved package

### DIFF
--- a/pkg/pulumiyaml/codegen/gen_program_test.go
+++ b/pkg/pulumiyaml/codegen/gen_program_test.go
@@ -141,6 +141,10 @@ func (m FakePackage) Name() string {
 	return "fake"
 }
 
+func (m FakePackage) Version() *semver.Version {
+	return nil
+}
+
 //nolint:paralleltest // mutates environment variables
 func TestGenerateProgram(t *testing.T) {
 	filter := func(tests []test.ProgramTest) []test.ProgramTest {

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -36,6 +36,12 @@ type MockPackageLoader struct {
 }
 
 func (m MockPackageLoader) LoadPackage(name string, version *semver.Version) (Package, error) {
+	if version != nil {
+		// See if there is a version specific package
+		if pkg, found := m.packages[name+"@"+version.String()]; found {
+			return pkg, nil
+		}
+	}
 	if pkg, found := m.packages[name]; found {
 		return pkg, nil
 	}
@@ -45,6 +51,7 @@ func (m MockPackageLoader) LoadPackage(name string, version *semver.Version) (Pa
 func (m MockPackageLoader) Close() {}
 
 type MockPackage struct {
+	version          *semver.Version
 	isComponent      func(typeName string) (bool, error)
 	resolveResource  func(typeName string) (ResourceTypeToken, error)
 	resolveFunction  func(typeName string) (FunctionTypeToken, error)
@@ -87,7 +94,7 @@ func (m MockPackage) Name() string {
 }
 
 func (m MockPackage) Version() *semver.Version {
-	return nil
+	return m.version
 }
 
 func inputProperties(token string, props ...schema.Property) *schema.ResourceType {
@@ -124,9 +131,22 @@ func function(token string, inputs, outputs []schema.Property) *schema.Function 
 }
 
 func newMockPackageMap() PackageLoader {
+	version := func(tag string) *semver.Version {
+		v := semver.MustParse(tag)
+		return &v
+	}
 	return MockPackageLoader{
 		packages: map[string]Package{
 			"aws": MockPackage{},
+			"docker": MockPackage{
+				version: version("4.0.0"),
+				resourceTypeHint: func(typeName string) *schema.ResourceType {
+					return inputProperties(typeName)
+				},
+			},
+			"docker@3.0.0": MockPackage{
+				version: version("3.0.0"),
+			},
 			"test": MockPackage{
 				resourceTypeHint: func(typeName string) *schema.ResourceType {
 					switch typeName {

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -86,6 +86,10 @@ func (m MockPackage) Name() string {
 	return "test"
 }
 
+func (m MockPackage) Version() *semver.Version {
+	return nil
+}
+
 func inputProperties(token string, props ...schema.Property) *schema.ResourceType {
 	p := make([]*schema.Property, 0, len(props))
 	for _, prop := range props {

--- a/pkg/pulumiyaml/run_token_blocklist_test.go
+++ b/pkg/pulumiyaml/run_token_blocklist_test.go
@@ -19,7 +19,17 @@ runtime: yaml
 resources:
   dockerImageFull:
     type: docker:image:Image
+    options:
+      version: 3.0.0
   dockerImageShort:
+    type: docker:Image
+    options:
+      version: 3.0.0
+  dockerImageOkSpecific:
+    type: docker:Image
+    options:
+      version: 4.0.0
+  dockerImageOkAmbient:
     type: docker:Image
   kubeCustomResource:
     type: kubernetes:apiextensions.k8s.io:CustomResource
@@ -42,14 +52,14 @@ resources:
 		diagStrings = append(diagStrings, diagString(v))
 	}
 	expectedErrors := []string{
-		"<stdin>:5:11: error resolving type of resource dockerImageFull: Docker Image resources are not supported in YAML without an explicit version, see: https://github.com/pulumi/pulumi-yaml/issues/421",
-		"<stdin>:7:11: error resolving type of resource dockerImageShort: Docker Image resources are not supported in YAML without an explicit version, see: https://github.com/pulumi/pulumi-yaml/issues/421",
-		"<stdin>:9:11: error resolving type of resource kubeCustomResource: The resource type [kubernetes:apiextensions.k8s.io:CustomResource] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:11:11: error resolving type of resource kubeKustomizeDir: The resource type [kubernetes:kustomize:Directory] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:13:11: error resolving type of resource kubeYamlConfigFile: The resource type [kubernetes:yaml:ConfigFile] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:15:11: error resolving type of resource kubeYamlConfigGroup: The resource type [kubernetes:yaml:ConfigGroup] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:17:11: error resolving type of resource helmChartV2: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
-		"<stdin>:19:11: error resolving type of resource helmChartV3: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
+		"<stdin>:5:11: error resolving type of resource dockerImageFull: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
+		"<stdin>:9:11: error resolving type of resource dockerImageShort: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
+		"<stdin>:19:11: error resolving type of resource kubeCustomResource: The resource type [kubernetes:apiextensions.k8s.io:CustomResource] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:21:11: error resolving type of resource kubeKustomizeDir: The resource type [kubernetes:kustomize:Directory] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:23:11: error resolving type of resource kubeYamlConfigFile: The resource type [kubernetes:yaml:ConfigFile] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:25:11: error resolving type of resource kubeYamlConfigGroup: The resource type [kubernetes:yaml:ConfigGroup] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:27:11: error resolving type of resource helmChartV2: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
+		"<stdin>:29:11: error resolving type of resource helmChartV3: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
 	}
 	assert.ElementsMatch(t, expectedErrors, diagStrings)
 	assert.Len(t, diagStrings, len(expectedErrors))


### PR DESCRIPTION
To prevent users creating a v3.* instance of `docker:Image` (an overlay resource), we have special checks in pulumi-yaml. We were checking against the **requested** version, which meant that not specifying a version resulted in an error, even when the default package loaded was >=4.*.

This PR changes the check to run agains the **resolved** package version.