### PR TITLE
Fix functions-pp test

### DIFF
--- a/pkg/pulumiyaml/testing/test/testdata/functions-pp/functions.pp
+++ b/pkg/pulumiyaml/testing/test/testdata/functions-pp/functions.pp
@@ -10,4 +10,4 @@ resource bucket "aws:s3:Bucket" {
 
 encoded2 = toBase64(bucket.id)
 
-decoded2 = fromBase64(bucket.id)
+decoded2 = fromBase64(encoded2)

--- a/pkg/pulumiyaml/testing/test/testdata/functions-pp/yaml/functions.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/functions-pp/yaml/functions.yaml
@@ -15,4 +15,4 @@ variables:
   encoded2:
     fn::toBase64: ${bucket.id}
   decoded2:
-    fn::fromBase64: ${bucket.id}
+    fn::fromBase64: ${encoded2}


### PR DESCRIPTION
bucket.id isn't a valid base64 string to decode. This was showing up in test runs as a pass but with the message:
```
=== RUN   TestGenerateProgram/functions
    gen_program_test.go:200: 
        	Error Trace:	/home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/codegen/gen_program_test.go:200
        	            				/home/runner/work/pulumi-yaml/pulumi-yaml/pkg/pulumiyaml/codegen/program_driver.go:498
        	Error:      	Received unexpected error:
        	            	1 error occurred:
        	            		* ../testing/test/testdata/functions-pp/yaml/functions.yaml:18,21-33: fn::fromBase64 unable to decode bucket, error: illegal base64 data at input byte 4; 
        	            	
        	Test:       	TestGenerateProgram/functions
```