### PR TITLE
Enable workaround for using objects in config

### DIFF
--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -852,6 +852,9 @@ func typePropertyAccess(ctx *evalContext, root schema.Type,
 	if len(accessors) == 0 {
 		return root
 	}
+	if root == schema.AnyType {
+		return schema.AnyType
+	}
 	if root, ok := root.(*schema.UnionType); ok {
 		var possibilities OrderedTypeSet
 		errs := []*notAssignable{}

--- a/pkg/pulumiyaml/analyser_test.go
+++ b/pkg/pulumiyaml/analyser_test.go
@@ -229,14 +229,24 @@ func TestTypePropertyAccess(t *testing.T) {
 		errMsg       string
 	}{
 		{
-			root: &schema.MapType{ElementType: &schema.ArrayType{ElementType: schema.AnyType}},
+			root: &schema.MapType{ElementType: &schema.ArrayType{ElementType: schema.IntType}},
 			list: []ast.PropertyAccessor{
 				&ast.PropertySubscript{Index: "foo"},
 				&ast.PropertySubscript{Index: 7},
 				&ast.PropertySubscript{Index: "foo"},
 			},
 			expectedType: "Invalid",
-			errMsg:       `Cannot index into 'start["foo"][7]' (type any):Index property access is only allowed on Maps and Lists`,
+			errMsg:       `Cannot index into 'start["foo"][7]' (type integer):Index property access is only allowed on Maps and Lists`,
+		},
+		{
+			// Once in any Any type, all property access is valid:
+			root: schema.AnyType,
+			list: []ast.PropertyAccessor{
+				&ast.PropertySubscript{Index: "foo"},
+				&ast.PropertySubscript{Index: 7},
+				&ast.PropertySubscript{Index: "foo"},
+			},
+			expectedType: "any",
 		},
 		{
 			root: &schema.ResourceType{


### PR DESCRIPTION
The type checker is modified to make property access on 'Any' return 'Any', which enables workarounds for #434 using programs like below.

Unblocking this sans workaround will require further implementation of these issues to support more complex structured, hierarchical config:
- pulumi/pulumi#1052
- pulumi/pulumi#2307

The workaround program is:

```yaml
name: tmp.0T7TLEvBj8
runtime: yaml
description: A minimal Pulumi YAML program
variables:
  myObject:
    fn::secret:
      fn::std:jsondecode:
        input:
          fn::fromBase64: ${myJSON}
outputs:
  test: ${myObject.result.test.password}
```

In this workaround we:

1. Base64 encode the JSON object we want to use in Pulumi YAML. This is necessary because Pulumi will attempt to JSON decode the value of config variables into objects on our behalf.

   ```sh pulumi config set --secret \ myJSON \ $(printf '{ "test": { "password": "secretpassword123" } }' | base64) ```

2. Use `fn::fromBase64` to decode that string into its original value.
3. Use `fn::std:jsondecode` to convert that string to an object.
4. Use `fn::secret` to ensure the value is marked as a secret. (Experimentally, this was necessary.)

The code change in the analyzer is necessary to allow indexing into the `Any` type on `${myObject.result}`.