### PR TITLE
Return an error when a resource is missing a type

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,6 @@
 
 ### Bug Fixes
 
+- Return a useful error message when a resource does not have a 'type' field
+  specified, rather than a panic.
+  [#468](https://github.com/pulumi/pulumi-yaml/pull/468)


### PR DESCRIPTION
Return a useful error message when a resource does not have a 'type' field specified, rather than a panic.

Fixes #465