### PR TITLE
ci: Use Go 1.20

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Set up Go 1.19.x
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - run: go mod tidy -compat=1.17
       - name: Fail if god mod not tidy
         run: |
@@ -40,9 +40,9 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.5.0
         with:
           repo: pulumi/pulumictl
-      - name: Set up Go 1.18.x
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Lint
         run: make lint-copyright

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags || true
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -64,10 +64,9 @@ jobs:
         with:
           ref: ${{ inputs.commit-ref }}
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-          stable: ${{ matrix.go-stable }}
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -114,5 +113,4 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x]
-        go-stable: [true]
+        go-version: [1.20.x]

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,6 @@
 ### Improvements
 
+- Pre-built binaries of pulumi-language-yaml are now built with Go 1.20.
+
 ### Bug Fixes
 


### PR DESCRIPTION
Build and test using Go 1.20 instead of 1.19 or older,
and use setup-go v4 everywhere because it caches-by-default.
