### PR TITLE
go.mod: Tidy with Go 1.19

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-      - run: go mod tidy -compat=1.17
+      - run: go mod tidy -go=1.19
       - name: Fail if god mod not tidy
         run: |
           if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -103,11 +103,6 @@ jobs:
         with:
           repo: cue-lang/cue
           version: v0.4.3
-      - name: Fixup go.mod if we're not targeting 1.17x
-        run: |
-          if [ "${{ matrix.go-version }}" != "1.17.x" ]; then
-            go mod tidy -compat=1.17
-          fi
       - name: Test
         run: make test
     strategy:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-yaml
 
-go 1.17
+go 1.19
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Runs `go mod tidy` with -go=1.19 on the go.mod for the project.
Note that as of Go 1.20, the `go` directive is **not**
the minimum required Go version.
It's the version of the toolchain we developed against.
This is changing in Go 1.21.

The `-compat` flag specifies which version of Go the go.mod file
needs to be compatible with.
By default, this is one release behind the `-go` flag
(or `go` directive).
So we don't need to specify it manually.

Lastly, this deletes the `go mod tidy` in the test job.
Only the lint job should bbe modifying the go.mod
to ensure that the go.mod is up to date.
