### PR TITLE
ci: Use golangci-lint-action

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -7,10 +7,10 @@ permissions: read-all
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GOLANGCI_LINT_VERSION: v1.53
 
 jobs:
   lint:
-    container: golangci/golangci-lint:latest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
+          # golangci-lint-action handles all the caching for Go.
+          cache: false
       - run: go mod tidy -go=1.19
       - name: Fail if god mod not tidy
         run: |
@@ -26,10 +28,11 @@ jobs:
             echo "::error go.mod not tidy"
             exit 1
           fi
-      - name: Lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
-          make lint-golang || true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
 
   check-copyright:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,3 +21,10 @@ linters:
     - lll
     - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
     - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0
+
+issues:
+  exclude-rules:
+    # Don't warn on unused parameters.
+    # Parameter names are useful; replacing them with '_' is undesirable.
+    - linters: [revive]
+      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -1099,9 +1099,8 @@ func (tc *typeCache) typeConfig(r *Runner, node configNode) bool {
 			ctx.errorf(node.key(), `config key "%s" cannot have conflicting types %v, %v`,
 				k, codegen.UnwrapType(typExisting), codegen.UnwrapType(typCurrent))
 			return false
-		} else {
-			typCurrent = typExisting
 		}
+		typCurrent = typExisting
 	}
 	tc.configuration[k] = typCurrent
 	return true

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -29,6 +29,7 @@ func TestTypeCheckError(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // uses parallel programtest
 func TestMismatchedConfigType(t *testing.T) {
 	testWrapper(t, integrationDir("mismatched-config-type"), ExpectFailure, StderrValidator{
 		f: func(t *testing.T, stderr string) {
@@ -38,6 +39,7 @@ func TestMismatchedConfigType(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // uses parallel programtest
 func TestProjectConfigRef(t *testing.T) {
 	testWrapper(t, integrationDir("project-config-ref"), ExpectFailure, StderrValidator{
 		f: func(t *testing.T, stderr string) {


### PR DESCRIPTION
Instead of downloading and installing golangci-lint manually,
use the golangci-lint-action.

Besides caching Go-specific files,
this also caches information computed by golangci-lint
so lint checks should run faster.

For this change, I've left the version of golangci-lint
the same as what we were using previously.
