### PR TITLE
ci: Upgrade to latest golangci-lint

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -28,7 +28,7 @@ jobs:
           fi
       - name: Lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
           make lint-golang || true
 
   check-copyright:


### PR DESCRIPTION
Upgrades to the latest release of golangci-lint.
This will allow enabling more checks, using the GitHub action, etc.