### PR TITLE
ci: Cache downloaded schemas between runs

### DIFF
--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -103,6 +103,23 @@ jobs:
         with:
           repo: cue-lang/cue
           version: v0.4.3
+
+      - id: list-schemas
+        name: List required schemas
+        run: |
+          # ref: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+          {
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "schemas<<$EOF"
+            LIST_ONLY=true ./scripts/get_schemas.sh
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Restore cached schemas
+        uses: actions/cache@v3
+        with:
+          key: ${{ hashFiles('scripts/get_schemas.sh') }}
+          path: ${{ steps.list-schemas.outputs.schemas }}
+
       - name: Test
         run: make test
     strategy:

--- a/scripts/get_schemas.sh
+++ b/scripts/get_schemas.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+LIST_ONLY=${LIST_ONLY:-false}
+
 default_url_template='https://raw.githubusercontent.com/pulumi/pulumi-_NAME_/v_VERSION_/provider/cmd/pulumi-resource-_NAME_/schema.json'
 awsx_url='https://raw.githubusercontent.com/pulumi/pulumi-awsx/v_VERSION_/awsx/schema.json'
 function pulumi_schema { echo "$1@$2@https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/testing/test/testdata/$1-$2.json"; }
@@ -46,6 +48,12 @@ for s in "${schemas[@]}"; do
 
 
   FILEPATH="pkg/pulumiyaml/testing/test/testdata/${NAME}-${VERSION}.json"
+
+  if [ "${LIST_ONLY}" = "true" ]; then
+      echo "${FILEPATH}"
+      continue
+  fi
+
   if [ -f "${FILEPATH}" ]; then
     FOUND=$(jq -r '.version' "${FILEPATH}") &&
       if ! [ "$FOUND" = "${VERSION}" ]; then


### PR DESCRIPTION
Our tests download schemas anew each run.
This changes the CI job to cache the downloaded schemas
in the GitHub Actions cache.

A hash of get_schemas.sh is used as the cache key
since that's where we list all required schemas.

To faciliate this, get_schemas.sh gets a new LIST_ONLY option.
When set, it'll only list the files (relative to repository root)
that would be downloaded.
This is passed as input to the actions/cache action,
to let it know which files it should persist in the cache.
