### PR TITLE
ci/lint: Enable staticcheck and other linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,24 +3,38 @@ run:
 linters:
   enable-all: false
   enable:
-    - deadcode
     - errcheck
-    - goconst
     - gofmt
     - revive
     - gosec
     - govet
     - ineffassign
     - misspell
+    - nolintlint
     - nakedret
-    - structcheck
     - unconvert
-    - varcheck
+    - unused
     - paralleltest
-  disable:
-    - lll
-    - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
-    - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0
+
+linters-settings:
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 60
+  nolintlint:
+    # Some linter exclusions are added to generated or templated files
+    # pre-emptively.
+    # Don't complain about these.
+    allow-unused: true
+  govet:
+    enable:
+      - nilness
+      # Reject comparisons of reflect.Value with DeepEqual or '=='.
+      - reflectvaluecompare
+      # Reject sort.Slice calls with a non-slice argument.
+      - sortslice
+      # Detect write to struct/arrays by-value that aren't read again.
+      - unusedwrite
 
 issues:
   exclude-rules:
@@ -28,3 +42,14 @@ issues:
     # Parameter names are useful; replacing them with '_' is undesirable.
     - linters: [revive]
       text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+
+    # staticcheck already has smarter checks for empty blocks.
+    # revive's empty-block linter has false positives.
+    # For example, as of writing this, the following is not allowed.
+    #   for foo() { }
+    - linters: [revive]
+      text: 'empty-block: this block is empty, you can remove it'
+
+  exclude:
+    # https://github.com/pulumi/pulumi/issues/9469
+    - 'Name is deprecated: Name returns the variable or declaration name of the resource'

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -797,7 +797,7 @@ func (tc *typeCache) typeInvoke(ctx *evalContext, t *ast.InvokeExpr) bool {
 		if o := hint.Outputs; o != nil {
 			for _, output := range o.Properties {
 				fields = append(fields, output.Name)
-				if strings.ToLower(t.Return.Value) == strings.ToLower(output.Name) {
+				if strings.EqualFold(t.Return.Value, output.Name) {
 					returnType = output.Type
 					validReturn = true
 				}
@@ -1222,11 +1222,7 @@ func (e walker) walk(ctx *evalContext, x ast.Expr) bool {
 	default:
 		panic(fmt.Sprintf("fatal: invalid expr type %T", x))
 	}
-	if !e.VisitExpr(ctx, x) {
-		return false
-	}
-
-	return true
+	return e.VisitExpr(ctx, x)
 }
 
 func (e walker) EvalConfig(r *Runner, node configNode) bool {

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -64,7 +64,7 @@ func (d *StringListDecl) parse(name string, node syntax.Node) syntax.Diagnostics
 
 	var diags syntax.Diagnostics
 
-	elements := make([]*StringExpr, list.Len(), list.Len())
+	elements := make([]*StringExpr, list.Len())
 	for i := range elements {
 		ename := fmt.Sprintf("%s[%d]", name, i)
 		ediags := parseField(ename, reflect.ValueOf(&elements[i]).Elem(), list.Index(i))
@@ -99,7 +99,7 @@ func (d *ConfigMapDecl) parse(name string, node syntax.Node) syntax.Diagnostics 
 
 	var diags syntax.Diagnostics
 
-	entries := make([]ConfigMapEntry, obj.Len(), obj.Len())
+	entries := make([]ConfigMapEntry, obj.Len())
 	for i := range entries {
 		kvp := obj.Index(i)
 		if _, ok := kvp.Value.(*syntax.ObjectNode); !ok {
@@ -154,7 +154,7 @@ func (d *VariablesMapDecl) parse(name string, node syntax.Node) syntax.Diagnosti
 
 	var diags syntax.Diagnostics
 
-	entries := make([]VariablesMapEntry, obj.Len(), obj.Len())
+	entries := make([]VariablesMapEntry, obj.Len())
 	for i := range entries {
 		kvp := obj.Index(i)
 
@@ -196,7 +196,7 @@ func (d *ResourcesMapDecl) parse(name string, node syntax.Node) syntax.Diagnosti
 
 	var diags syntax.Diagnostics
 
-	entries := make([]ResourcesMapEntry, obj.Len(), obj.Len())
+	entries := make([]ResourcesMapEntry, obj.Len())
 	for i := range entries {
 		kvp := obj.Index(i)
 
@@ -248,7 +248,7 @@ func (d *PropertyMapDecl) parse(name string, node syntax.Node) syntax.Diagnostic
 
 	var diags syntax.Diagnostics
 
-	entries := make([]PropertyMapEntry, obj.Len(), obj.Len())
+	entries := make([]PropertyMapEntry, obj.Len())
 	for i := range entries {
 		kvp := obj.Index(i)
 
@@ -615,7 +615,7 @@ func parseRecord(objName string, dest recordDecl, node syntax.Node, noMatchWarni
 		key := kvp.Key.Value()
 		var hasMatch bool
 		for _, f := range reflect.VisibleFields(t) {
-			if f.IsExported() && strings.ToLower(f.Name) == strings.ToLower(key) {
+			if f.IsExported() && strings.EqualFold(f.Name, key) {
 				diags.Extend(syntax.UnexpectedCasing(kvp.Key.Syntax().Range(), camel(f.Name), key))
 				diags.Extend(parseField(camel(f.Name), v.FieldByIndex(f.Index), kvp.Value)...)
 				hasMatch = true

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -222,12 +222,10 @@ func (g *generator) genResourceOpts(opts *pcl.ResourceOptions) *syn.ObjectNode {
 
 func (g *generator) genResource(n *pcl.Resource) {
 	properties := make([]syn.ObjectPropertyDef, len(n.Inputs))
-	var additionalSecrets []*syn.StringNode
 	for i, input := range n.Inputs {
 		value := input.Value
 		if f, ok := value.(*model.FunctionCallExpression); ok && f.Name == "secret" {
 			contract.Assertf(len(f.Args) == 1, "Expected exactly one argument to secret, got %d", len(f.Args))
-			additionalSecrets = append(additionalSecrets, syn.String(input.Name))
 			value = f.Args[0]
 		}
 		v := g.expr(value)

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -7,7 +7,7 @@ package codegen
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -84,7 +84,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 
 	for filename, data := range files {
 		outPath := path.Join(directory, filename)
-		err := ioutil.WriteFile(outPath, data, 0600)
+		err := os.WriteFile(outPath, data, 0600)
 		if err != nil {
 			return fmt.Errorf("could not write output program: %w", err)
 		}
@@ -165,7 +165,7 @@ func (g *generator) genNode(n pcl.Node) {
 
 func unquoteInterpolation(n syn.Node) *syn.StringNode {
 	s, ok := n.(*syn.StringNode)
-	contract.Assert(ok)
+	contract.Assertf(ok, "Expected a string node, got %T", n)
 	v := strings.TrimPrefix(s.Value(), "${")
 	v = strings.TrimSuffix(v, "}")
 	return syn.String(v)
@@ -178,7 +178,7 @@ func mustCoerceBoolean(n syn.Node) *syn.BooleanNode {
 	case *syn.StringNode:
 		return syn.Boolean(n.Value() == "true")
 	default:
-		panic(fmt.Sprintf("Could not coerce type %[1]T to a boolean: '%[1]#v'", n))
+		panic(fmt.Sprintf("Could not coerce type %[1]T to a boolean: '%#[1]v'", n))
 	}
 }
 
@@ -200,7 +200,7 @@ func (g *generator) genResourceOpts(opts *pcl.ResourceOptions) *syn.ObjectNode {
 	if opts.DependsOn != nil {
 		elems := g.expr(opts.DependsOn)
 		_, ok := elems.(*syn.ListNode)
-		contract.Assert(ok)
+		contract.Assertf(ok, "Expected a list node, got %T", elems)
 		rOpts = append(rOpts, syn.ObjectProperty(syn.String("dependson"), elems))
 	}
 	if opts.IgnoreChanges != nil {
@@ -226,7 +226,7 @@ func (g *generator) genResource(n *pcl.Resource) {
 	for i, input := range n.Inputs {
 		value := input.Value
 		if f, ok := value.(*model.FunctionCallExpression); ok && f.Name == "secret" {
-			contract.Assert(len(f.Args) == 1)
+			contract.Assertf(len(f.Args) == 1, "Expected exactly one argument to secret, got %d", len(f.Args))
 			additionalSecrets = append(additionalSecrets, syn.String(input.Name))
 			value = f.Args[0]
 		}
@@ -528,7 +528,7 @@ func (g *generator) expr(e model.Expression) syn.Node {
 			return syn.Boolean(e.Value.True())
 		default:
 			contract.Failf("Unexpected LiteralValueExpression (%[1]v): %[1]v", e.Type(), e)
-			panic(nil)
+			panic("unreachable")
 		}
 
 	case *model.FunctionCallExpression:
@@ -729,14 +729,14 @@ type Invoke struct {
 }
 
 func (g *generator) MustInvoke(f *model.FunctionCallExpression, ret string) *syn.ObjectNode {
-	contract.Assert(f.Name == pcl.Invoke)
-	contract.Assert(len(f.Args) > 0)
+	contract.Assertf(f.Name == pcl.Invoke, "MustInvoke called on non-invoke function: %v", f.Name)
+	contract.Assertf(len(f.Args) > 0, "Invoke called with no arguments: %v", f.Name)
 	name := collapseToken(g.expr(f.Args[0]).(*syn.StringNode).Value())
 
 	var arguments syn.Node
 	if len(f.Args) > 1 {
 		_, ok := f.Args[1].(*model.ObjectConsExpression)
-		contract.Assert(ok)
+		contract.Assertf(ok, "Expected ObjectConsExpression as second argument, got %T", f.Args[1])
 		arguments = g.expr(f.Args[1])
 	}
 

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -516,7 +516,7 @@ func (imp *importer) importConfig(kvp ast.ConfigMapEntry) (model.BodyItem, synta
 	}
 
 	configName, ok := imp.configuration[name]
-	contract.Assert(ok)
+	contract.Assertf(ok, "key %q not found in configuration map", name)
 
 	var defaultValue model.Expression
 	if config.Default != nil {
@@ -627,7 +627,7 @@ func (imp *importer) importVariable(kvp ast.VariablesMapEntry, latestPkgInfo map
 	var diags syntax.Diagnostics
 	name, value := kvp.Key.Value, kvp.Value
 	_, ok := imp.variables[name]
-	contract.Assert(ok)
+	contract.Assertf(ok, "variable %q not found", name)
 
 	v, vdiags := imp.importExpr(value, nil)
 	diags.Extend(vdiags...)
@@ -711,8 +711,6 @@ func (imp *importer) getLatestPkgInfoVariable(kvp ast.VariablesMapEntry, pkgInfo
 			}
 		}
 	}
-
-	return
 }
 
 // importResource imports a YAML resource as a PCL resource.
@@ -720,7 +718,7 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry, latestPkgInfo map
 	name, resource := kvp.Key.Value, kvp.Value
 
 	resourceVar, ok := imp.resources[name]
-	contract.Assert(ok)
+	contract.Assertf(ok, "resource %q not found", name)
 
 	var diags syntax.Diagnostics
 
@@ -893,7 +891,7 @@ func (imp *importer) importOutput(kvp ast.PropertyMapEntry) (model.BodyItem, syn
 	name := kvp.Key.Value
 
 	outputVar, ok := imp.outputs[name]
-	contract.Assert(ok)
+	contract.Assertf(ok, "output %q not found", name)
 
 	x, diags := imp.importExpr(kvp.Value, nil)
 
@@ -1068,7 +1066,7 @@ func (imp *importer) importTemplate(file *ast.TemplateDecl) (*model.Body, syntax
 	// TODO: this isn't supported by PCL.
 	for _, name := range imp.referencedStacks {
 		stackVar, ok := imp.stackReferences[name]
-		contract.Assert(ok)
+		contract.Assertf(ok, "stack reference %q not found", name)
 
 		items = append(items, &model.Block{
 			Type:   "stackReference",

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -554,7 +554,6 @@ func (imp *importer) getResourceRefList(optionField ast.Expr, name string, field
 	var diags syntax.Diagnostics
 
 	elems, ok := optionField.(*ast.ListExpr)
-	var resourceNames []string
 	if !ok {
 		diags.Extend(ast.ExprError(optionField, fmt.Sprintf("expected %v of resource '%v' to be a list of resource expressions, got '%v'", field, name, reflect.TypeOf(elems)), ""))
 	}
@@ -566,7 +565,6 @@ func (imp *importer) getResourceRefList(optionField ast.Expr, name string, field
 			continue
 		}
 		resourceName := sym.Property.Accessors[0].(*ast.PropertyName).Name
-		resourceNames = append(resourceNames, resourceName)
 		if resourceVar, ok := imp.resources[resourceName]; ok {
 			refs = append(refs, model.VariableReference(resourceVar))
 		} else {

--- a/pkg/pulumiyaml/diags/diags.go
+++ b/pkg/pulumiyaml/diags/diags.go
@@ -122,7 +122,7 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 	}
 
 	// We have matches but none are exact
-	detail := fmt.Sprintf("Did you mean ")
+	detail := "Did you mean "
 	addBag := func(bag BagOrdering) {
 		if len(bag.BagName) == 1 {
 			detail += fmt.Sprintf("'%s' under '%s'", bag.Property, bag.BagName[0])
@@ -140,7 +140,7 @@ func (e InvalidFieldBagFormatter) MessageWithDetail(field string) (string, strin
 	} else {
 		detail += "one of the following:\n"
 		for _, bag := range bags {
-			detail += fmt.Sprintf("  * ")
+			detail += "  * "
 			addBag(bag)
 			detail += "\n"
 		}

--- a/pkg/pulumiyaml/diags/utils.go
+++ b/pkg/pulumiyaml/diags/utils.go
@@ -44,9 +44,7 @@ func editDistance(a, b string) int {
 
 func sortByEditDistance(words []string, comparedTo string) []string {
 	w := make([]string, len(words))
-	for i := range words {
-		w[i] = words[i]
-	}
+	copy(w, words)
 	m := map[string]int{}
 	v := func(s string) int {
 		d, ok := m[s]

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -158,7 +158,7 @@ func GetReferencedPlugins(tmpl *ast.TemplateDecl) ([]Plugin, syntax.Diagnostics)
 		VisitExpr: func(ctx *evalContext, expr ast.Expr) bool {
 			if expr, ok := expr.(*ast.InvokeExpr); ok {
 				if expr.Token == nil {
-					ctx.Runner.sdiags.Extend(syntax.NodeError(expr.Syntax(), fmt.Sprintf("Invoke declared without a 'function' type"), ""))
+					ctx.Runner.sdiags.Extend(syntax.NodeError(expr.Syntax(), "Invoke declared without a 'function' type", ""))
 					return true
 				}
 				acceptType(ctx.Runner, expr.Token.GetValue(), expr.CallOpts.Version, expr.CallOpts.PluginDownloadURL)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,11 +81,11 @@ func LoadDir(cwd string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 	// Pulumi CLI, which now plays double duty, and allows a Pulumi deployment that uses a single file.
 	var filename string
 	var bs []byte
-	if b, err := ioutil.ReadFile(filepath.Join(cwd, MainTemplate+".json")); err == nil {
+	if b, err := os.ReadFile(filepath.Join(cwd, MainTemplate+".json")); err == nil {
 		filename, bs = MainTemplate+".json", b
-	} else if b, err := ioutil.ReadFile(filepath.Join(cwd, MainTemplate+".yaml")); err == nil {
+	} else if b, err := os.ReadFile(filepath.Join(cwd, MainTemplate+".yaml")); err == nil {
 		filename, bs = MainTemplate+".yaml", b
-	} else if b, err := ioutil.ReadFile(filepath.Join(cwd, "Pulumi.yaml")); err == nil {
+	} else if b, err := os.ReadFile(filepath.Join(cwd, "Pulumi.yaml")); err == nil {
 		filename, bs = "Pulumi.yaml", b
 	} else {
 		return nil, nil, fmt.Errorf("reading template %s: %w", MainTemplate, err)
@@ -108,7 +107,7 @@ func LoadFile(path string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 
 // LoadYAML decodes a YAML template from an io.Reader.
 func LoadYAML(filename string, r io.Reader) (*ast.TemplateDecl, syntax.Diagnostics, error) {
-	bytes, err := ioutil.ReadAll(r)
+	bytes, err := io.ReadAll(r)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2181,7 +2180,7 @@ func (e *programEvaluator) evaluateBuiltinReadFile(s *ast.ReadFileExpr) (interfa
 		if err != nil {
 			return e.error(s, err.Error())
 		}
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			e.error(s.Path, fmt.Sprintf("Error reading file at path %v: %v", path, err))
 		}

--- a/pkg/pulumiyaml/syntax/diags.go
+++ b/pkg/pulumiyaml/syntax/diags.go
@@ -88,7 +88,7 @@ func (d Diagnostics) Error() string {
 			} else {
 				sb.WriteString("\n-warning: ")
 			}
-			sb.WriteString(fmt.Sprintf("%s", diag.Error()))
+			sb.WriteString(diag.Error())
 		}
 		return sb.String()
 	}

--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -84,6 +84,9 @@ func TestExampleStackreference(t *testing.T) {
 			//
 			// See: https://github.com/pulumi/pulumi-yaml/issues/6#issuecomment-1028306579
 			err = filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
 				if path == dir {
 					return nil
 				}
@@ -98,9 +101,9 @@ func TestExampleStackreference(t *testing.T) {
 					return err
 				}
 				template := string(bytes)
-				template = strings.Replace(template, "PLACEHOLDER_ORG_NAME", org, -1)
-				template = strings.Replace(template, "PLACEHOLDER_STACK_NAME", sourceStackName, -1)
-				// nolint:gosec // temporary file, no secrets, non-executable
+				template = strings.ReplaceAll(template, "PLACEHOLDER_ORG_NAME", org)
+				template = strings.ReplaceAll(template, "PLACEHOLDER_STACK_NAME", sourceStackName)
+				//nolint:gosec // temporary file, no secrets, non-executable
 				err = os.WriteFile(path, []byte(template), 0644)
 				if err != nil {
 					return err

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -5,7 +5,6 @@ package tests
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func makeAbs(path string) string {
 func TestGenerateExamples(t *testing.T) {
 	t.Parallel()
 
-	examples, err := ioutil.ReadDir(examplesPath)
+	examples, err := os.ReadDir(examplesPath)
 	require.NoError(t, err)
 	//nolint:paralleltest // not directly using the loop variable, but instead using dir.Name() in subtests
 	for _, dir := range examples {


### PR DESCRIPTION
Enables nearly all the same linters that are used in pulumi/pulumi,
disabling deprecated or unused linters (per pulumi/pulumi).

The following linters were not enabled:

- lll, gofumpt:
  These may cause more code churn than desirable in this commit.
  They may be enabled in the future.
- prealloc:
  This has been a source of many nil-vs-empty-slice bugs.
  Enabling this would increase the risk of this commit.

Fixes the following issues as part of enabling the linters:

```
pkg/pulumiyaml/ast/template.go:67:34: S1019: should use make([]*StringExpr, list.Len()) instead (gosimple)
pkg/pulumiyaml/ast/template.go:102:36: S1019: should use make([]ConfigMapEntry, obj.Len()) instead (gosimple)
pkg/pulumiyaml/ast/template.go:157:39: S1019: should use make([]VariablesMapEntry, obj.Len()) instead (gosimple)
pkg/pulumiyaml/ast/template.go:199:39: S1019: should use make([]ResourcesMapEntry, obj.Len()) instead (gosimple)
pkg/pulumiyaml/ast/template.go:251:38: S1019: should use make([]PropertyMapEntry, obj.Len()) instead (gosimple)
pkg/pulumiyaml/ast/template.go:618:25: SA6005: should use strings.EqualFold instead (staticcheck)
pkg/pulumiyaml/diags/utils.go:47:2: S1001: should use copy(to, from) instead of a loop (gosimple)
pkg/pulumiyaml/diags/diags.go:125:12: S1039: unnecessary use of fmt.Sprintf (gosimple)
pkg/pulumiyaml/diags/diags.go:143:14: S1039: unnecessary use of fmt.Sprintf (gosimple)
pkg/pulumiyaml/syntax/diags.go:91:19: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
pkg/pulumiyaml/packages.go:161:63: S1039: unnecessary use of fmt.Sprintf (gosimple)
pkg/pulumiyaml/analyser.go:1225:2: S1008: should use 'return e.VisitExpr(ctx, x)' instead of 'if !e.VisitExpr(ctx, x) { return false }; return true' (gosimple)
pkg/pulumiyaml/run.go:12:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
pkg/pulumiyaml/analyser.go:800:8: SA6005: should use strings.EqualFold instead (staticcheck)
pkg/pulumiyaml/codegen/load.go:715:2: S1023: redundant `return` statement (gosimple)
pkg/pulumiyaml/codegen/gen_program.go:531:9: nilness: panic with nil value (govet)
pkg/pulumiyaml/codegen/gen_program.go:181:21: SA5009: couldn't parse format string (staticcheck)
pkg/pulumiyaml/codegen/gen_program.go:168:2: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/gen_program.go:203:3: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/gen_program.go:229:4: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/gen_program.go:732:2: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/gen_program.go:733:2: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/gen_program.go:739:3: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/load.go:519:2: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/load.go:630:2: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/load.go:723:2: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/load.go:896:2: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/load.go:1071:3: SA1019: contract.Assert is deprecated: Use Assertf. (staticcheck)
pkg/pulumiyaml/codegen/gen_program.go:10:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
pkg/tests/example_transpile_test.go:8:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
pkg/tests/example_test.go:86:65: SA4009: argument err is overwritten before first use (staticcheck)
pkg/tests/example_test.go:96:5: SA4009(related information): assignment to err (staticcheck)
pkg/tests/example_test.go:103:5: directive `// nolint:gosec // temporary file, no secrets, non-executable` should be written without leading space as `//nolint:gosec // temporary file, no secrets, non-executable` (nolintlint)
```

The following issues were fixed in a separate commit
because they appear to have some bearing on logic
and may represent bugs in pulumi-yaml.

```
pkg/pulumiyaml/codegen/gen_program.go:230:24: SA4010: this result of append is never used, except maybe in other appends (staticcheck)
pkg/pulumiyaml/codegen/load.go:569:19: SA4010: this result of append is never used, except maybe in other appends (staticcheck)
```