### PR TITLE
Handle output receivers in property evaluation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,6 @@
 - Return a useful error message when a resource does not have a 'type' field
   specified, rather than a panic.
   [#468](https://github.com/pulumi/pulumi-yaml/pull/468)
+
+- Fix nested access of unknown properties.
+  [#490](https://github.com/pulumi/pulumi-yaml/pull/490)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1583,6 +1583,15 @@ func (e *programEvaluator) evaluatePropertyAccessTail(expr ast.Expr, receiver in
 	Loop:
 		for {
 			switch x := receiver.(type) {
+			case pulumi.Output:
+				// If the receiver is an output, we need to apply it to get the value.
+				return x.ApplyT(func(v interface{}) (interface{}, error) {
+					result, ok := evaluateAccessF(v, accessors)
+					if !ok {
+						return nil, fmt.Errorf("runtime error")
+					}
+					return result, nil
+				}), true
 			case lateboundResource:
 				// Peak ahead at the next accessor to implement .urn and .id:
 				if len(accessors) >= 1 {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-yaml/issues/489.

These tests could be improved except the Go SDK doesn't actually support using `unknowns` in the mock library (see
https://github.com/pulumi/pulumi/blob/master/sdk/go/pulumi/mocks.go#L192-L195 where we don't set `KeepUnknowns` true so they just get removed).

I'll raise a change for that and we should revisit these tests once a version of pu/pu is released to support proper mocking of previews.