### PR TITLE
Fix unknownOutputs showing up outside of preview.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- Fix unknown outputs showing up outside of preview and causing errors.
+  [#496](https://github.com/pulumi/pulumi-yaml/pull/496)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1603,7 +1603,10 @@ func (e *programEvaluator) evaluatePropertyAccessTail(expr ast.Expr, receiver in
 					}
 
 					outputs := x.GetRawOutputs()
-					if outputs != nil {
+
+					// If we're in a preview, mark missing outputs in the schema as unknown.
+					// unknownOutput values will break in an actual deployment.
+					if outputs != nil && e.pulumiCtx.DryRun() {
 						outputs = outputs.ApplyT(
 							func(rawOutputs interface{}) (interface{}, error) {
 								outputs, ok := rawOutputs.(resource.PropertyMap)


### PR DESCRIPTION
Fixes #492 

This change relegates setting missing outputs to unknowns in preview only.

UnknownOutputs are used to convey that something hasn't been calculated yet, but everything should be calculated in the actual deployment.