### PR TITLE
plugin(language, converter): Respond to SIGINT

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,4 +5,6 @@
 
 - Publish pulumi-converter-yaml.
 
+- Plugins: clean up resources and exit cleanly on receiving SIGINT or CTRL_BREAK.
+
 ### Bug Fixes


### PR DESCRIPTION
Configures the language plugin binary to shut down the plugin RPC server
when SIGINT is received.
This will help the binary exit cleanly when it's time to shut down.

This functionality was added in pulumi/pulumi#13795.
pulumi/pulumi#13809 contains a similar change for Go, Python, and Node.