### PR TITLE
Allow `protect` resource option to be set dynamically.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,3 +8,5 @@
 - Plugins: clean up resources and exit cleanly on receiving SIGINT or CTRL_BREAK.
 
 ### Bug Fixes
+
+- Allow `protect` resource option to be set dynamically.

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -307,7 +307,7 @@ type ResourceOptionsDecl struct {
 	IgnoreChanges           *StringListDecl
 	Import                  *StringExpr
 	Parent                  Expr
-	Protect                 *BooleanExpr
+	Protect                 Expr
 	Provider                Expr
 	Providers               Expr
 	Version                 *StringExpr
@@ -328,7 +328,7 @@ func (d *ResourceOptionsDecl) recordSyntax() *syntax.Node {
 func ResourceOptionsSyntax(node *syntax.ObjectNode,
 	additionalSecretOutputs, aliases *StringListDecl, customTimeouts *CustomTimeoutsDecl,
 	deleteBeforeReplace *BooleanExpr, dependsOn Expr, ignoreChanges *StringListDecl, importID *StringExpr,
-	parent Expr, protect *BooleanExpr, provider, providers Expr, version *StringExpr,
+	parent Expr, protect Expr, provider, providers Expr, version *StringExpr,
 	pluginDownloadURL *StringExpr, replaceOnChanges *StringListDecl,
 	retainOnDelete *BooleanExpr, deletedWith Expr) ResourceOptionsDecl {
 
@@ -355,7 +355,7 @@ func ResourceOptionsSyntax(node *syntax.ObjectNode,
 func ResourceOptions(additionalSecretOutputs, aliases *StringListDecl,
 	customTimeouts *CustomTimeoutsDecl, deleteBeforeReplace *BooleanExpr,
 	dependsOn Expr, ignoreChanges *StringListDecl, importID *StringExpr, parent Expr,
-	protect *BooleanExpr, provider, providers Expr, version *StringExpr, pluginDownloadURL *StringExpr,
+	protect Expr, provider, providers Expr, version *StringExpr, pluginDownloadURL *StringExpr,
 	replaceOnChanges *StringListDecl, retainOnDelete *BooleanExpr, deletedWith Expr) ResourceOptionsDecl {
 
 	return ResourceOptionsSyntax(nil, additionalSecretOutputs, aliases, customTimeouts,

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -794,10 +794,12 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry, latestPkgInfo map
 			})
 		}
 	}
-	if resource.Options.Protect != nil && resource.Options.Protect.Value {
+	if resource.Options.Protect != nil {
+		protectExpr, vdiags := imp.importExpr(resource.Options.Protect, schema.BoolType)
+		diags.Extend(vdiags...)
 		resourceOptions.Body.Items = append(resourceOptions.Body.Items, &model.Attribute{
 			Name:  "protect",
-			Value: &model.LiteralValueExpression{Value: cty.BoolVal(resource.Options.Protect.Value)},
+			Value: protectExpr,
 		})
 	}
 	// latest package settings takes precedence over a set provider/ version/ url

--- a/pkg/pulumiyaml/run_options_test.go
+++ b/pkg/pulumiyaml/run_options_test.go
@@ -60,6 +60,10 @@ func TestResourceOptions(t *testing.T) {
 	const text = `
 name: test-yaml
 runtime: yaml
+configuration:
+  shouldProtect:
+    default: false
+    type: boolean
 resources:
   provider-a:
     type: pulumi:providers:test
@@ -71,6 +75,8 @@ resources:
     type: test:resource:trivial
   res-container:
     type: test:resource:trivial
+    options:
+      protect: ${shouldProtect}
   res-a:
     type: test:component:type
     options:


### PR DESCRIPTION
Fixes #495 

Changes the definition of `Protect` from the concrete `*BooleanExpr` to `Expr` which allows the value to be defined via a config or local variable rather than a literal boolean value. 

> During evaluation we check that it is not an output