### PR TITLE
Allow version to be set dynamically

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,8 @@
 
 - Plugins: clean up resources and exit cleanly on receiving SIGINT or CTRL_BREAK.
 
+- Allow `version` to be set dynamically.
+
 ### Bug Fixes
 
 - Allow `protect` resource option to be set dynamically.

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -563,11 +564,27 @@ func (tc *typeCache) assertTypeAssignable(ctx *evalContext, from ast.Expr, to sc
 func (tc *typeCache) typeResource(r *Runner, node resourceNode) bool {
 	k, v := node.Key.Value, node.Value
 	ctx := r.newContext(node)
-	version, err := ParseVersion(v.Options.Version)
-	if err != nil {
-		ctx.error(v.Type, fmt.Sprintf("unable to parse resource %v provider version: %v", k, err))
-		return true
+
+	var version *semver.Version
+	if v.Options.Version != nil {
+		// compute the type of the version field
+		tc.typeExpr(ctx, v.Options.Version)
+
+		// make sure specified version is typed as a string
+		tc.assertTypeAssignable(ctx, v.Options.Version, schema.StringType)
+
+		// if it happens to be a static string, make sure it parsable as a semver
+		switch versionValue := v.Options.Version.(type) {
+		case *ast.StringExpr:
+			parsedVersion, err := semver.ParseTolerant(versionValue.Value)
+			if err != nil {
+				ctx.error(v.Type, fmt.Sprintf("unable to parse resource %v provider version: %v", k, err))
+				return true
+			}
+			version = &parsedVersion
+		}
 	}
+
 	pkg, typ, err := ResolveResource(ctx.pkgLoader, v.Type.Value, version)
 	if err != nil {
 		ctx.error(v.Type, fmt.Sprintf("error resolving type of resource %v: %v", k, err))
@@ -740,6 +757,11 @@ func (tc *typeCache) typePropertyEntries(ctx *evalContext, resourceName, resourc
 }
 
 func (tc *typeCache) typeInvoke(ctx *evalContext, t *ast.InvokeExpr) bool {
+	if t.CallOpts.Version != nil {
+		tc.typeExpr(ctx, t.CallOpts.Version)
+		tc.assertTypeAssignable(ctx, t.CallOpts.Version, schema.StringType)
+	}
+
 	version, err := ParseVersion(t.CallOpts.Version)
 	if err != nil {
 		ctx.error(t.CallOpts.Version, fmt.Sprintf("unable to parse function provider version: %v", err))

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -310,7 +310,7 @@ type ResourceOptionsDecl struct {
 	Protect                 Expr
 	Provider                Expr
 	Providers               Expr
-	Version                 *StringExpr
+	Version                 Expr
 	PluginDownloadURL       *StringExpr
 	ReplaceOnChanges        *StringListDecl
 	RetainOnDelete          *BooleanExpr
@@ -328,7 +328,7 @@ func (d *ResourceOptionsDecl) recordSyntax() *syntax.Node {
 func ResourceOptionsSyntax(node *syntax.ObjectNode,
 	additionalSecretOutputs, aliases *StringListDecl, customTimeouts *CustomTimeoutsDecl,
 	deleteBeforeReplace *BooleanExpr, dependsOn Expr, ignoreChanges *StringListDecl, importID *StringExpr,
-	parent Expr, protect Expr, provider, providers Expr, version *StringExpr,
+	parent Expr, protect Expr, provider, providers Expr, version Expr,
 	pluginDownloadURL *StringExpr, replaceOnChanges *StringListDecl,
 	retainOnDelete *BooleanExpr, deletedWith Expr) ResourceOptionsDecl {
 
@@ -355,7 +355,7 @@ func ResourceOptionsSyntax(node *syntax.ObjectNode,
 func ResourceOptions(additionalSecretOutputs, aliases *StringListDecl,
 	customTimeouts *CustomTimeoutsDecl, deleteBeforeReplace *BooleanExpr,
 	dependsOn Expr, ignoreChanges *StringListDecl, importID *StringExpr, parent Expr,
-	protect Expr, provider, providers Expr, version *StringExpr, pluginDownloadURL *StringExpr,
+	protect Expr, provider, providers Expr, version Expr, pluginDownloadURL *StringExpr,
 	replaceOnChanges *StringListDecl, retainOnDelete *BooleanExpr, deletedWith Expr) ResourceOptionsDecl {
 
 	return ResourceOptionsSyntax(nil, additionalSecretOutputs, aliases, customTimeouts,
@@ -368,7 +368,7 @@ type InvokeOptionsDecl struct {
 
 	Parent            Expr
 	Provider          Expr
-	Version           *StringExpr
+	Version           Expr
 	PluginDownloadURL *StringExpr
 }
 

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -113,15 +113,23 @@ type pluginEntry struct {
 	pluginDownloadURL string
 }
 
+func getVersionValue(versionExpr ast.Expr) string {
+	switch version := versionExpr.(type) {
+	case *ast.StringExpr:
+		return version.Value
+	}
+
+	return ""
+}
+
 // GetReferencedPlugins returns the packages and (if provided) versions for each referenced provider
 // used in the program.
 func GetReferencedPlugins(tmpl *ast.TemplateDecl) ([]Plugin, syntax.Diagnostics) {
 	pluginMap := map[string]*pluginEntry{}
-
-	acceptType := func(r *Runner, typeName string, version, pluginDownloadURL *ast.StringExpr) {
+	acceptType := func(r *Runner, typeName string, version ast.Expr, pluginDownloadURL *ast.StringExpr) {
 		pkg := ResolvePkgName(typeName)
 		if entry, found := pluginMap[pkg]; found {
-			if v := version.GetValue(); v != "" && entry.version != v {
+			if v := getVersionValue(version); v != "" && entry.version != v {
 				if entry.version == "" {
 					entry.version = v
 				} else {
@@ -137,7 +145,7 @@ func GetReferencedPlugins(tmpl *ast.TemplateDecl) ([]Plugin, syntax.Diagnostics)
 			}
 		} else {
 			pluginMap[pkg] = &pluginEntry{
-				version:           version.GetValue(),
+				version:           getVersionValue(version),
 				pluginDownloadURL: pluginDownloadURL.GetValue(),
 			}
 		}

--- a/pkg/pulumiyaml/semver.go
+++ b/pkg/pulumiyaml/semver.go
@@ -7,15 +7,20 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/ast"
 )
 
-func ParseVersion(v *ast.StringExpr) (*semver.Version, error) {
-	if v == nil || v.Value == "" {
-		return nil, nil
+func ParseVersion(expr ast.Expr) (*semver.Version, error) {
+	switch v := expr.(type) {
+	case *ast.StringExpr:
+		if v == nil || v.Value == "" {
+			return nil, nil
+		}
+
+		version, err := semver.ParseTolerant(v.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return &version, nil
 	}
 
-	version, err := semver.ParseTolerant(v.Value)
-	if err != nil {
-		return nil, err
-	}
-
-	return &version, nil
+	return nil, nil
 }


### PR DESCRIPTION
Fixes pulumi/pulumi-yaml#508

This PR changes the definition of `Version` from a static `*ast.StringExpr` to `ast.Expr` so that it can a value which can be evaluated at runtime when running the program rather than just static strings. Anywhere else where want to know the version and we don't have an evaluator yet, we check if the version is a static string and get its value, otherwise we skip it.