### PR TITLE
avoid flakyness in config nodes test

### DIFF
--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -1865,21 +1864,6 @@ resources:
 	})
 }
 
-func sortConfigNodes(nodes []configNode) []configNode {
-	for _, n := range nodes {
-		switch n := n.(type) {
-		case configNodeProp:
-			continue
-		default:
-			panic(fmt.Sprintf("sorting not implemented for %T", n))
-		}
-	}
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].(configNodeProp).k < nodes[j].(configNodeProp).k
-	})
-	return nodes
-}
-
 func TestGetConfNodesFromMap(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -1991,7 +1975,7 @@ func TestGetConfNodesFromMap(t *testing.T) {
 		t.Run(tt.project, func(t *testing.T) {
 			t.Parallel()
 			result := getConfNodesFromMap(tt.project, tt.propertymap)
-			assert.Equal(t, sortConfigNodes(tt.expected), sortConfigNodes(result))
+			assert.ElementsMatch(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -1864,6 +1865,21 @@ resources:
 	})
 }
 
+func sortConfigNodes(nodes []configNode) []configNode {
+	for _, n := range nodes {
+		switch n := n.(type) {
+		case configNodeProp:
+			continue
+		default:
+			panic(fmt.Sprintf("sorting not implemented for %T", n))
+		}
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].(configNodeProp).k < nodes[j].(configNodeProp).k
+	})
+	return nodes
+}
+
 func TestGetConfNodesFromMap(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -1975,7 +1991,7 @@ func TestGetConfNodesFromMap(t *testing.T) {
 		t.Run(tt.project, func(t *testing.T) {
 			t.Parallel()
 			result := getConfNodesFromMap(tt.project, tt.propertymap)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, sortConfigNodes(tt.expected), sortConfigNodes(result))
 		})
 	}
 }


### PR DESCRIPTION
The ordering of the nodes we get back from getConfNodesFromMap is not guaranteed to be stable.  Let's make sure we don't have a flaky test by sorting the result before comparing it to our expected result.