### PR TITLE
fix secrets when config property map is passed

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+
+- Fix a regression where secret values were not handled correctly. #518

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -935,10 +935,11 @@ func (e *programEvaluator) registerConfig(intm configNode) (interface{}, bool) {
 			markSecret = true
 		}
 	case configNodeProp:
+		v := intm.value()
 		if intm.v.IsSecret() {
-			return pulumi.ToSecret(intm.v.SecretValue().Element.V), true
+			v = pulumi.ToSecret(intm.v)
 		}
-		return intm.value(), true
+		return v, true
 	default:
 		v := intm.value()
 		if e.pulumiCtx.IsConfigSecret(intm.key().GetValue()) {

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -935,6 +935,9 @@ func (e *programEvaluator) registerConfig(intm configNode) (interface{}, bool) {
 			markSecret = true
 		}
 	case configNodeProp:
+		if intm.v.IsSecret() {
+			return pulumi.ToSecret(intm.v.SecretValue().Element.V), true
+		}
 		return intm.value(), true
 	default:
 		v := intm.value()

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,4 +49,33 @@ func TestProjectConfigRef(t *testing.T) {
 				`resource, variable, or config value "project-config-ref:foo" not found`))
 		},
 	})
+}
+
+//nolint:paralleltest // uses parallel programtest
+func TestProjectConfigWithSecret(t *testing.T) {
+	testOptions := integration.ProgramTestOptions{
+		Dir:             filepath.Join(getCwd(t), "testdata", "project-config-with-secret"),
+		PrepareProject:  prepareYamlProject,
+		StackName:       "dev",
+		SecretsProvider: "default",
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			assert.NotEmpty(t, stack.Outputs["my-secret"].(map[string]interface{})["ciphertext"])
+		},
+	}
+	integration.ProgramTest(t, &testOptions)
+}
+
+//nolint:paralleltest // uses parallel programtest
+func TestProjectConfigWithSecretDecrypted(t *testing.T) {
+	testOptions := integration.ProgramTestOptions{
+		Dir:                    filepath.Join(getCwd(t), "testdata", "project-config-with-secret"),
+		PrepareProject:         prepareYamlProject,
+		StackName:              "dev",
+		SecretsProvider:        "default",
+		DecryptSecretsInOutput: true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			assert.Equal(t, stack.Outputs["my-secret"].(map[string]interface{})["plaintext"], "\"password\"")
+		},
+	}
+	integration.ProgramTest(t, &testOptions)
 }

--- a/pkg/tests/testdata/project-config-with-secret/Pulumi.dev.yaml
+++ b/pkg/tests/testdata/project-config-with-secret/Pulumi.dev.yaml
@@ -1,0 +1,4 @@
+encryptionsalt: v1:PwAjZw3iFh4=:v1:qNWGvxiJl5aKXRWE:Pq93QCJNE63m/ez6iqvhpQnsTrG60Q==
+config:
+  project-config-with-secret:password:
+    secure: v1:h3/0x/chFHt6XyhE:d05YbhoNRULvz66Qmq5kNzsazCBmUXRy

--- a/pkg/tests/testdata/project-config-with-secret/Pulumi.yaml
+++ b/pkg/tests/testdata/project-config-with-secret/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: project-config-with-secret
+runtime: yaml
+description: A minimal Pulumi YAML program
+config:
+  password:
+    type: string
+outputs:
+  my-secret: ${password}


### PR DESCRIPTION
Currently we're not treating secrets that are passed through a property map correctly.  Fix this by extracting them from the property map, and then wrapping them again in the format the yaml library expects internally.

Fixes https://github.com/pulumi/pulumi-yaml/issues/518