### PR TITLE
empty CHANGELOG_PENDING file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,3 @@
 ### Improvements
 
 ### Bug Fixes
-
-- Fix a regression where secret values were not handled correctly.
-  [#519](https://github.com/pulumi/pulumi-yaml/pull/519)


### PR DESCRIPTION
Pulumi 1.4.1 has been released with these bugfixes, so we can empty out the CHANGELOG_PENDING file.