### PR TITLE
Skip TestExampleGettingStarted

### DIFF
--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -58,6 +58,7 @@ func TestExampleAzureAppService(t *testing.T) {
 
 //nolint:paralleltest // uses parallel programtest
 func TestExampleGettingStarted(t *testing.T) {
+	t.Skip("https://github.com/pulumi/pulumi-yaml/issues/523")
 	testWrapper(t, exampleDir("getting-started"), RequireLiveRun, awsConfig)
 }
 


### PR DESCRIPTION
This is currently failing in CI. Issue raised, but until its fixed skip it so CI is green.