### PR TITLE
pass through additional secret outputs from the provider schema

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+
+- Fields marked as secret in the provider schema are now correctly handled as secrets. [#526](https://github.com/pulumi/pulumi-yaml/pull/526)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1075,9 +1075,6 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 		return p, isPoison
 	}
 
-	if v.Options.AdditionalSecretOutputs != nil {
-		opts = append(opts, pulumi.AdditionalSecretOutputs(listStrings(v.Options.AdditionalSecretOutputs)))
-	}
 	if v.Options.Aliases != nil {
 		var aliases []pulumi.Alias
 		for _, s := range v.Options.Aliases.Elements {
@@ -1235,6 +1232,14 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 		r := lateboundCustomResourceState{name: k, resourceSchema: resourceSchema}
 		state = &r
 		res = &r
+	}
+	if v.Options.AdditionalSecretOutputs != nil {
+		opts = append(opts, pulumi.AdditionalSecretOutputs(listStrings(v.Options.AdditionalSecretOutputs)))
+	}
+	for _, prop := range resourceSchema.Properties {
+		if prop.Secret {
+			opts = append(opts, pulumi.AdditionalSecretOutputs([]string{prop.Name}))
+		}
 	}
 
 	if !overallOk || e.sdiags.HasErrors() {

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -1896,7 +1896,9 @@ resources:
 	}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		runner := newRunner(tmpl, newMockPackageMap())
-		runner.Evaluate(ctx)
+		err := runner.Evaluate(ctx)
+		assert.Len(t, err, 0)
+		assert.Equal(t, err.Error(), "no diagnostics")
 		return nil
 	}, pulumi.WithMocks("project", "stack", mocks))
 	assert.NoError(t, err)


### PR DESCRIPTION
Currently when the provider marks any outputs as secrets, the yaml language provider does not forward that information to the engine.

Read the secret outputs from the schema and append them as additional secret outputs to tell the engine what needs to be kept secret.

Fixes #521 