### PR TITLE
stackreferences should always be read

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### Bug Fixes
 
 - Fields marked as secret in the provider schema are now correctly handled as secrets. [#526](https://github.com/pulumi/pulumi-yaml/pull/526)
+
+- Fixes StackReference resources so that they are always read. [#529](https://github.com/pulumi/pulumi-yaml/pull/529)


### PR DESCRIPTION
StackReference resources should always be read. Fixes #462