### PR TITLE
Apply aliases from schema

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,4 @@
 
 ### Bug Fixes
 
+- Apply aliases from schema [#533](https://github.com/pulumi/pulumi-yaml/pull/533)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1241,6 +1241,13 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 			opts = append(opts, pulumi.AdditionalSecretOutputs([]string{prop.Name}))
 		}
 	}
+	for _, alias := range resourceSchema.Aliases {
+		if alias.Type != nil {
+			opts = append(opts, pulumi.Aliases([]pulumi.Alias{
+				{Type: pulumi.String(*alias.Type)},
+			}))
+		}
+	}
 
 	if !overallOk || e.sdiags.HasErrors() {
 		return nil, false


### PR DESCRIPTION
A schema for a resource can specify a list of aliases for the resource. This change makes it so that such aliases from the schema are applied for a given resource.

Fixes #532