### PR TITLE
Support (logical) name for resources and config variables

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- Support (logical) name for resources and config variables
+ [#546](https://github.com/pulumi/pulumi-yaml/pull/546)
+
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ variables:
       arguments:
         filters:
           - name: name
-            values: ["amzn-ami-hvm-*-x86_64-ebs"]
+            values: ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"]
         owners: ["137112412989"]
         mostRecent: true
       return: id

--- a/examples/webserver-json/Main.json
+++ b/examples/webserver-json/Main.json
@@ -31,7 +31,7 @@
             "function": "aws:getAmi",
             "arguments": {
               "filters": [
-                { "name": "name", "values": ["amzn-ami-hvm-*-x86_64-ebs"] }
+                { "name": "name", "values": ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"] }
               ],
               "owners": ["137112412989"],
               "mostRecent": true

--- a/examples/webserver/Pulumi.yaml
+++ b/examples/webserver/Pulumi.yaml
@@ -12,7 +12,7 @@ variables:
       arguments:
         filters:
           - name: name
-            values: ["amzn-ami-hvm-*-x86_64-ebs"]
+            values: ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"]
         owners: ["137112412989"]
         mostRecent: true
       return: id

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -272,6 +272,7 @@ type ConfigParamDecl struct {
 	declNode
 
 	Type    *StringExpr
+	Name    *StringExpr
 	Secret  *BooleanExpr
 	Default Expr
 	Value   Expr
@@ -281,19 +282,20 @@ func (d *ConfigParamDecl) recordSyntax() *syntax.Node {
 	return &d.syntax
 }
 
-func ConfigParamSyntax(node *syntax.ObjectNode, typ *StringExpr,
+func ConfigParamSyntax(node *syntax.ObjectNode, typ *StringExpr, name *StringExpr,
 	secret *BooleanExpr, defaultValue Expr) *ConfigParamDecl {
 
 	return &ConfigParamDecl{
 		declNode: decl(node),
 		Type:     typ,
+		Name:     name,
 		Secret:   secret,
 		Default:  defaultValue,
 	}
 }
 
-func ConfigParam(typ *StringExpr, defaultValue Expr, secret *BooleanExpr) *ConfigParamDecl {
-	return ConfigParamSyntax(nil, typ, secret, defaultValue)
+func ConfigParam(typ *StringExpr, name *StringExpr, defaultValue Expr, secret *BooleanExpr) *ConfigParamDecl {
+	return ConfigParamSyntax(nil, typ, name, secret, defaultValue)
 }
 
 type ResourceOptionsDecl struct {
@@ -411,6 +413,7 @@ type ResourceDecl struct {
 	declNode
 
 	Type            *StringExpr
+	Name            *StringExpr
 	DefaultProvider *BooleanExpr
 	Properties      PropertyMapDecl
 	Options         ResourceOptionsDecl
@@ -423,14 +426,15 @@ func (d *ResourceDecl) recordSyntax() *syntax.Node {
 
 // The names of exported fields.
 func (*ResourceDecl) Fields() []string {
-	return []string{"type", "defaultprovider", "properties", "options", "get"}
+	return []string{"type", "name", "defaultprovider", "properties", "options", "get"}
 }
 
-func ResourceSyntax(node *syntax.ObjectNode, typ *StringExpr, defaultProvider *BooleanExpr,
+func ResourceSyntax(node *syntax.ObjectNode, typ *StringExpr, name *StringExpr, defaultProvider *BooleanExpr,
 	properties PropertyMapDecl, options ResourceOptionsDecl, get GetResourceDecl) *ResourceDecl {
 	return &ResourceDecl{
 		declNode:        decl(node),
 		Type:            typ,
+		Name:            name,
 		DefaultProvider: defaultProvider,
 		Properties:      properties,
 		Options:         options,
@@ -438,8 +442,14 @@ func ResourceSyntax(node *syntax.ObjectNode, typ *StringExpr, defaultProvider *B
 	}
 }
 
-func Resource(typ *StringExpr, defaultProvider *BooleanExpr, properties PropertyMapDecl, options ResourceOptionsDecl, get GetResourceDecl) *ResourceDecl {
-	return ResourceSyntax(nil, typ, defaultProvider, properties, options, get)
+func Resource(
+	typ *StringExpr,
+	name *StringExpr,
+	defaultProvider *BooleanExpr,
+	properties PropertyMapDecl,
+	options ResourceOptionsDecl,
+	get GetResourceDecl) *ResourceDecl {
+	return ResourceSyntax(nil, typ, name, defaultProvider, properties, options, get)
 }
 
 type CustomTimeoutsDecl struct {

--- a/pkg/pulumiyaml/codegen/gen_program_test.go
+++ b/pkg/pulumiyaml/codegen/gen_program_test.go
@@ -172,8 +172,6 @@ func TestGenerateProgram(t *testing.T) {
 				// But the actual error is that it is using a Splat operator.
 			case "components":
 				// https://github.com/pulumi/pulumi-yaml/issues/476
-			case "logical-name":
-				// https://github.com/pulumi/pulumi-yaml/issues/477
 			case "unknown-resource":
 				// https://github.com/pulumi/pulumi-yaml/issues/478
 			case "optional-complex-config":
@@ -201,6 +199,7 @@ func TestGenerateProgram(t *testing.T) {
 			case "regress-node-12507":
 				// https://github.com/pulumi/pulumi-yaml/issues/494
 			case "config-variables":
+			case "logical-name":
 				// Needs config set in order to compile/run.
 				tt.SkipCompile = codegen.NewStringSet("yaml")
 				l = append(l, tt)
@@ -218,6 +217,7 @@ func TestGenerateProgram(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Falsef(t, diags.HasErrors(), "%s", diags.Error())
 		err = pulumi.RunErr(func(ctx *pulumi.Context) error {
+
 			return pulumiyaml.RunTemplate(ctx, templateDecl, nil, nil, testPackageLoader{t})
 		}, pulumi.WithMocks("test", "gen", &testMonitor{}), func(ri *pulumi.RunInfo) { ri.DryRun = true })
 		assert.NoError(t, err)

--- a/pkg/pulumiyaml/run_plugin_version_test.go
+++ b/pkg/pulumiyaml/run_plugin_version_test.go
@@ -127,7 +127,7 @@ resources:
           arguments:
             filters:
               - name: name
-                values: ["amzn-ami-hvm-*-x86_64-ebs"]
+                values: ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"]
             owners: ["137112412989"]
             mostRecent: true
           Return: id

--- a/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/aws-webserver.pp
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/aws-webserver.pp
@@ -12,7 +12,7 @@ resource securityGroup "aws:ec2:SecurityGroup" {
 ami = invoke("aws:index:getAmi", {
 	filters = [{
 		name = "name"
-		values = ["amzn-ami-hvm-*-x86_64-ebs"]
+		values = ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"]
 	}]
 	owners = ["137112412989"] // Amazon
 	mostRecent = true

--- a/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/yaml/aws-webserver.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-webserver-pp/yaml/aws-webserver.yaml
@@ -32,7 +32,7 @@ variables:
         filters:
           - name: name
             values:
-              - amzn-ami-hvm-*-x86_64-ebs
+              - amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs
         owners:
           - '137112412989'
         mostRecent: true

--- a/pkg/pulumiyaml/testing/test/testdata/logical-name-pp/yaml/logical-name.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/logical-name-pp/yaml/logical-name.yaml
@@ -1,5 +1,12 @@
+configuration:
+  configLexicalName:
+    type: string
+    name: "cC-Charlie_charlie.\U0001F603⁉️"
 resources:
-  "aA-Alpha_alpha.\U0001F92F⁉️":
+  resourceLexicalName:
     type: random:RandomPet
+    name: "aA-Alpha_alpha.\U0001F92F⁉️"
+    properties:
+      prefix: ${configLexicalName}
 outputs:
-  "bB-Beta_beta.\U0001F49C⁉": "${[\"aA-Alpha_alpha.\U0001F92F⁉️\"].id}"
+  "bB-Beta_beta.\U0001F49C⁉": ${resourceLexicalName.id}

--- a/pkg/tests/transpiled_examples/webserver-json-pp/webserver-json.pp
+++ b/pkg/tests/transpiled_examples/webserver-json-pp/webserver-json.pp
@@ -23,7 +23,7 @@ resource webServer "aws:ec2/instance:Instance" {
 	ami = invoke("aws:index/getAmi:getAmi", {
 		filters = [{
 			name = "name",
-			values = ["amzn-ami-hvm-*-x86_64-ebs"]
+			values = ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"]
 		}],
 		owners = ["137112412989"],
 		mostRecent = true

--- a/pkg/tests/transpiled_examples/webserver-pp/webserver.pp
+++ b/pkg/tests/transpiled_examples/webserver-pp/webserver.pp
@@ -6,7 +6,7 @@ config instanceType string {
 ec2Ami = invoke("aws:index/getAmi:getAmi", {
 	filters = [{
 		name = "name",
-		values = ["amzn-ami-hvm-*-x86_64-ebs"]
+		values = ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"]
 	}],
 	owners = ["137112412989"],
 	mostRecent = true


### PR DESCRIPTION
### Description

Fixes #539, #477 

This PR adds support for resources and config variables to have a _logical name_ other than their lexical name which is used to reference the resources or variables in the YAML program. 

Added as a top-level field:

```yaml
name: simple-yaml
runtime: yaml
resources:
  bucket:
    type: aws:s3:Bucket
    name: my-bucket
    properties:
      website:
        indexDocument: index.html
```

Where the `bucket` is the lexical name that is used for the program evaluator and `my-bucket` is the name that is used when registering the resource. In TypeScript it would look like this:
```typescript
const bucket = new Bucket("my-bucket", ...)
```

Similarly, configuration variables can now have a _logical_ name as well where at runtime, it will be the key used to query the config data provided by Pulumi CLI whereas their lexical name is just how they are defined and referenced in the program. 

Program-gen for YAML has been updated. Take this PCL:
```
config configLexicalName string {
  __logicalName = "cC-Charlie_charlie.😃⁉️"
}

resource resourceLexicalName "random:index/randomPet:RandomPet" {
  // not necessarily a valid logical name, just testing that it passes through to codegen unmodified
  __logicalName = "aA-Alpha_alpha.🤯⁉️"

  prefix = configLexicalName
}

output outputLexicalName {
  __logicalName = "bB-Beta_beta.💜⁉"
  value = resourceLexicalName.id
}
```
Becomes:
```yaml
configuration:
  configLexicalName:
    type: string
    name: "cC-Charlie_charlie.\U0001F603⁉️"
resources:
  resourceLexicalName:
    type: random:RandomPet
    name: "aA-Alpha_alpha.\U0001F92F⁉️"
    properties:
      prefix: ${configLexicalName}
outputs:
  "bB-Beta_beta.\U0001F49C⁉": ${resourceLexicalName.id}
```
> Outputs just keep using their logical name because their lexical name cannot be referenced anywhere