### PR TITLE
Allow ID to be dynamic

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- Allow the `Resource.get.id` field to be dynamically set.
+ [#563](https://github.com/pulumi/pulumi-yaml/pull/563)
+
 ### Bug Fixes

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -244,16 +244,21 @@ func testInvokeDiags(t *testing.T, template *ast.TemplateDecl, callback func(*Ru
 		},
 		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 			if args.ReadRPC != nil {
+				isRight := "yes"
 				switch args.TypeToken {
 				case "test:read:Resource":
-					if args.ID != "no-state" {
+					switch args.ID {
+					case "no-state":
+					case "eventual-yes":
+						isRight = "definitely"
+					default:
 						assert.Equal(t, "bucket-123456", args.ID)
 						assert.Equal(t, `string_value:"bar"`, args.ReadRPC.Properties.Fields["foo"].String())
 						assert.Len(t, args.ReadRPC.Properties.Fields, 1)
 					}
 					return "arn:aws:s3:::" + args.ID, resource.PropertyMap{
 						"tags": resource.NewObjectProperty(resource.PropertyMap{
-							"isRight": resource.NewStringProperty("yes"),
+							"isRight": resource.NewStringProperty(isRight),
 						}),
 					}, nil
 				}

--- a/pkg/pulumiyaml/sort_test.go
+++ b/pkg/pulumiyaml/sort_test.go
@@ -15,12 +15,20 @@ import (
 )
 
 func diagString(d *syntax.Diagnostic) string {
-	if d.Subject != nil {
-		return fmt.Sprintf("%v:%v:%v: %s", d.Subject.Filename, d.Subject.Start.Line, d.Subject.Start.Column, d.Summary)
-	} else if d.Context != nil {
-		return fmt.Sprintf("%v:%v:%v: %s", d.Context.Filename, d.Context.Start.Line, d.Context.End.Line, d.Summary)
+	var s string
+	switch {
+	case d.Subject != nil:
+		s = fmt.Sprintf("%v:%v:%v: %s", d.Subject.Filename, d.Subject.Start.Line, d.Subject.Start.Column, d.Summary)
+	case d.Context != nil:
+		s = fmt.Sprintf("%v:%v:%v: %s", d.Context.Filename, d.Context.Start.Line, d.Context.End.Line, d.Summary)
+	default:
+		s = fmt.Sprintf("%v", d.Summary)
 	}
-	return fmt.Sprintf("%v", d.Summary)
+
+	if d.Detail != "" {
+		s += fmt.Sprintf("; %v", d.Detail)
+	}
+	return s
 }
 
 func requireNoErrors(t *testing.T, tmpl *ast.TemplateDecl, diags syntax.Diagnostics) {


### PR DESCRIPTION
Teach Pulumi YAML how to handle dynamic `get.id` values.

My goal is to enable fixing https://github.com/pulumi/pulumi-cloudflare/issues/709 by adding a Pulumi YAML check, since we are standardizing on writing test programs in YAML when possible.

Fixes https://github.com/pulumi/pulumi-yaml/issues/562