### PR TITLE
Support negative literals when generating YAML

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+
+- Support negative literals [#565](https://github.com/pulumi/pulumi-yaml/pull/565)

--- a/pkg/pulumiyaml/codegen/gen_program_test.go
+++ b/pkg/pulumiyaml/codegen/gen_program_test.go
@@ -239,7 +239,13 @@ func TestGenerateProgram(t *testing.T) {
 			OutputFile: "Main.yaml",
 			Check:      check,
 			GenProgram: GenerateProgram,
-			TestCases:  filter(test.PulumiPulumiProgramTests),
+			TestCases: append(
+				filter(test.PulumiPulumiProgramTests),
+				test.ProgramTest{
+					Directory:   "negative-literals",
+					Description: "Negative literals in Pulumi Programs",
+				},
+			),
 		},
 	)
 }

--- a/pkg/pulumiyaml/testing/test/testdata/negative-literals-pp/negative-literals.pp
+++ b/pkg/pulumiyaml/testing/test/testdata/negative-literals-pp/negative-literals.pp
@@ -1,0 +1,57 @@
+resource ecsTarget1 "aws:appautoscaling:Target" {
+  maxCapacity = 4
+  minCapacity = 1
+  resourceId = "service/clustername/serviceName"
+  scalableDimension = "ecs:service:DesiredCount"
+  serviceNamespace = "ecs"
+}
+
+resource ecsPolicy1 "aws:appautoscaling:Policy" {
+  name = "scale-down-integers"
+  policyType = "StepScaling"
+  resourceId = ecsTarget1.resourceId
+  scalableDimension = ecsTarget1.scalableDimension
+  serviceNamespace = ecsTarget1.serviceNamespace
+
+  stepScalingPolicyConfiguration = {
+    adjustmentType = "ChangeInCapacity"
+    cooldown = 60
+    metricAggregationType = "Maximum"
+
+    stepAdjustments = [
+      {
+        metricIntervalUpperBound = 0
+        scalingAdjustment = -1
+      }
+    ]
+  }
+}
+
+resource ecsTarget2 "aws:appautoscaling:Target" {
+  maxCapacity = 4
+  minCapacity = 1
+  resourceId = "service/clustername/serviceName"
+  scalableDimension = "ecs:service:DesiredCount"
+  serviceNamespace = "ecs"
+}
+
+resource ecsPolicy2 "aws:appautoscaling:Policy" {
+  name = "scale-down-floats"
+  policyType = "StepScaling"
+  resourceId = ecsTarget2.resourceId
+  scalableDimension = ecsTarget2.scalableDimension
+  serviceNamespace = ecsTarget2.serviceNamespace
+
+  stepScalingPolicyConfiguration = {
+    adjustmentType = "ChangeInCapacity"
+    cooldown = 60
+    metricAggregationType = "Maximum"
+
+    stepAdjustments = [
+      {
+        metricIntervalUpperBound = 0
+        scalingAdjustment = -2.0
+      }
+    ]
+  }
+}

--- a/pkg/pulumiyaml/testing/test/testdata/negative-literals-pp/yaml/negative-literals.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/negative-literals-pp/yaml/negative-literals.yaml
@@ -1,0 +1,47 @@
+resources:
+  ecsTarget1:
+    type: aws:appautoscaling:Target
+    properties:
+      maxCapacity: 4
+      minCapacity: 1
+      resourceId: service/clustername/serviceName
+      scalableDimension: ecs:service:DesiredCount
+      serviceNamespace: ecs
+  ecsPolicy1:
+    type: aws:appautoscaling:Policy
+    properties:
+      name: scale-down-integers
+      policyType: StepScaling
+      resourceId: ${ecsTarget1.resourceId}
+      scalableDimension: ${ecsTarget1.scalableDimension}
+      serviceNamespace: ${ecsTarget1.serviceNamespace}
+      stepScalingPolicyConfiguration:
+        adjustmentType: ChangeInCapacity
+        cooldown: 60
+        metricAggregationType: Maximum
+        stepAdjustments:
+          - metricIntervalUpperBound: 0
+            scalingAdjustment: -1
+  ecsTarget2:
+    type: aws:appautoscaling:Target
+    properties:
+      maxCapacity: 4
+      minCapacity: 1
+      resourceId: service/clustername/serviceName
+      scalableDimension: ecs:service:DesiredCount
+      serviceNamespace: ecs
+  ecsPolicy2:
+    type: aws:appautoscaling:Policy
+    properties:
+      name: scale-down-floats
+      policyType: StepScaling
+      resourceId: ${ecsTarget2.resourceId}
+      scalableDimension: ${ecsTarget2.scalableDimension}
+      serviceNamespace: ${ecsTarget2.serviceNamespace}
+      stepScalingPolicyConfiguration:
+        adjustmentType: ChangeInCapacity
+        cooldown: 60
+        metricAggregationType: Maximum
+        stepAdjustments:
+          - metricIntervalUpperBound: 0
+            scalingAdjustment: -2


### PR DESCRIPTION
This commit adds support for generating YAML that contains negative literals, which are a special case of unary applications of the negate operator to numbers. Fixes #564.