### PR TITLE
empty CHANGELOG_PENDING file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,11 +1,3 @@
 ### Improvements
 
-- Allow the `Resource.get.id` field to be dynamically set.
- [#563](https://github.com/pulumi/pulumi-yaml/pull/563)
-
-- Upgrade pulumi dependency to the latest version.
- [#566](https://github.com/pulumi/pulumi-yaml/pull/566), [#571](https://github.com/pulumi/pulumi-yaml/pull/571)
-
 ### Bug Fixes
-
-- Support negative literals [#565](https://github.com/pulumi/pulumi-yaml/pull/565)


### PR DESCRIPTION
We just released pulumi-yaml 1.7.0.  Empty out the CHANGELOG_PENDING file to reflect that.