### PR TITLE
Add built-in function to convert RFC3339 to Unix timestamps

### DIFF
--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -735,6 +735,19 @@ func ReadFileSyntax(node syntax.Node, name *StringExpr, path Expr) *ReadFileExpr
 	}
 }
 
+type RFC3339ToUnixExpr struct {
+	builtinNode
+
+	Value Expr
+}
+
+func RFC3339ToUnixSyntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *RFC3339ToUnixExpr {
+	return &RFC3339ToUnixExpr{
+		builtinNode: builtin(node, name, args),
+		Value:       args,
+	}
+}
+
 func parseReadFile(node *syntax.ObjectNode, name *StringExpr, path Expr) (Expr, syntax.Diagnostics) {
 	return ReadFileSyntax(node, name, path), nil
 }
@@ -783,6 +796,8 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		set("fn::secret", parseSecret)
 	case "fn::readfile":
 		set("fn::readFile", parseReadFile)
+	case "fn::rfc3339ToUnix":
+		set("fn::rfc3339ToUnix", parseRFC3339ToUnix)
 	default:
 		k := kvp.Key.Value()
 		// fn::invoke can be called as fn::${pkg}:${module}(:${name})?
@@ -989,4 +1004,8 @@ func parseAssetArchive(node *syntax.ObjectNode, name *StringExpr, args Expr) (Ex
 		diags.Extend(tdiags...)
 	}
 	return AssetArchiveSyntax(node, name, obj, assetOrArchives), diags
+}
+
+func parseRFC3339ToUnix(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
+	return RFC3339ToUnixSyntax(node, name, args), nil
 }

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -709,6 +709,8 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return wrapFn("select", syn.List(args[1], args[0]))
 	case "readFile":
 		return wrapFn("readFile", g.expr(f.Args[0]))
+	case "rfc3339ToUnix":
+		return wrapFn("rfc3339ToUnix", g.expr(f.Args[0]))
 	case pcl.IntrinsicConvert:
 		// We can't perform the convert, but it might happen automatically.
 		// This works for enums, as well as number -> strings.

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -401,6 +401,12 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 			Name: "fromBase64",
 			Args: []model.Expression{path},
 		}, pdiags
+	case *ast.RFC3339ToUnixExpr:
+		path, pdiags := imp.importExpr(node.Args(), nil)
+		return &model.FunctionCallExpression{
+			Name: "rfc3339ToUnix",
+			Args: []model.Expression{path},
+		}, pdiags
 	default:
 		contract.Failf("unexpected builtin type %T", node)
 		return nil, nil
@@ -937,6 +943,7 @@ func (imp *importer) assignNames() {
 		"split",
 		"toBase64",
 		"toJSON",
+		"rfc3339ToUnix",
 		"sha1",
 		"stack",
 		"project",


### PR DESCRIPTION
Some providers outputs unix timestamps and some other RFC 3339 where some providers input unix and others RFC 3339 and I need to convert between the 2 formats when passing outputs to inputs. I am using YAML only as I want to keep using declarative syntax. Hence, based on the discussion I had in the community slack (ref: https://pulumi-community.slack.com/archives/C037PV12W6L/p1715335945150989) with @t0yv0 .

I don't have much experience with the inner workings of this repo and am mostly using `toBase64` as an example to write this.