### PR TITLE
feat: add PULUMI_STACK for compiler run enviroment

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
+- Pass `PULUMI_STACK`, `PULUMI_ORGANIZATION`, `PULUMI_PROJECT` and `PULUMI_CONFIG` as environment variable to compiler process. 
+
 ### Bug Fixes

--- a/pkg/pulumiyaml/codegen/eject.go
+++ b/pkg/pulumiyaml/codegen/eject.go
@@ -114,7 +114,7 @@ func LoadTemplate(dir string) (*workspace.Project, *ast.TemplateDecl, hcl.Diagno
 		if !ok {
 			return nil, nil, nil, fmt.Errorf("compiler option must be a string, got %v", reflect.TypeOf(compilerOpt))
 		}
-		t, diags, err = pulumiyaml.LoadFromCompiler(compiler, main)
+		t, diags, err = pulumiyaml.LoadFromCompiler(compiler, main, nil)
 	} else {
 		t, diags, err = pulumiyaml.LoadDir(main)
 	}

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -2412,3 +2412,50 @@ func TestUnknownsDuringPreviewNotUpdate(t *testing.T) {
 	assert.NoError(t, runProgram(true))
 	assert.Error(t, runProgram(false))
 }
+
+func TestConflictingEnvVarsNoDuplicates(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"FOO=bar", "BAZ=qux"}
+	conflicts := conflictingEnvVars(env)
+	assert.Empty(t, conflicts)
+}
+
+func TestConflictingEnvVarsWithDuplicates(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"FOO=bar", "FOO=baz"}
+	conflicts := conflictingEnvVars(env)
+	assert.Equal(t, []string{"FOO"}, conflicts)
+}
+
+func TestConflictingEnvVarsEmptyEnv(t *testing.T) {
+	t.Parallel()
+
+	env := []string{}
+	conflicts := conflictingEnvVars(env)
+	assert.Empty(t, conflicts)
+}
+
+func TestConflictingEnvVarsNilEnv(t *testing.T) {
+	t.Parallel()
+
+	conflicts := conflictingEnvVars(nil)
+	assert.Empty(t, conflicts)
+}
+
+func TestConflictingEnvVarsInvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"FOO", "BAR=qux"}
+	conflicts := conflictingEnvVars(env)
+	assert.Empty(t, conflicts)
+}
+
+func TestConflictingEnvVarsMultipleDuplicates(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"FOO=bar", "FOO=baz", "BAR=qux", "BAR=quux", "FOO=foobar"}
+	conflicts := conflictingEnvVars(env)
+	assert.ElementsMatch(t, []string{"FOO", "BAR"}, conflicts)
+}

--- a/pkg/tests/testdata/env-vars/Pulumi.yaml
+++ b/pkg/tests/testdata/env-vars/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: project-env-vars
+runtime:
+  name: yaml
+  options:
+    compiler: |
+      sh -c "cat Pulumi.yaml;
+      echo \"\";
+      echo \"outputs:\";
+      echo \"  TEST_ENV_VAR: $TEST_ENV_VAR\";
+      echo \"  PULUMI_STACK: $PULUMI_STACK\";
+      echo \"  PULUMI_PROJECT: $PULUMI_PROJECT\";
+      echo \"  PULUMI_ORGANIZATION: $PULUMI_ORGANIZATION\";
+      echo \"  PULUMI_CONFIG: $PULUMI_CONFIG\";
+      echo \"\";"
+config:
+  foo: "hello world"


### PR DESCRIPTION
This PR adds a new environment variable `PULUMI_STACK` to the compiler run. 

The possibility to determine the stack from the compiler makes it a lot more flexibel when dealing with stack specific resources.

Here an example (I'm using Jinja2 though the issue itself is not compiler specific):
```yaml
# Pulumi.yaml
runtime:
  name: yaml
  options:
    compiler: jinja2 --format=yaml Pulumi.yaml values.yaml
    
 resources:
  # stack specific resources for stage
  # {% if 'stage' == 'PULUMI_STACK'|getenv %}{% include 'templates/mailcatcher.yaml.j2' %}{% endif %}
  
  # common resources
```
A more complex scenario would be to add HA resources to a production stack where an integration system is zonal set up to reduce cloud costs.

My approach seems a bit naive to be honest, but I couldn't figure out a better way without breaking interfaces. Also this solution only works from the `Run`-call context, so `GetRequiredPlugins` might not be accurate when plugins are stack specific.

WDYT? 
 
