### PR TITLE
goreleaser: replace deprecated --skip-validate flag

### DIFF
--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -28,4 +28,4 @@ jobs:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml
     with:
-      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -29,4 +29,4 @@ jobs:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml
     with:
-      goreleaser-args: -p 10 -f .goreleaser.yml --clean --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -31,4 +31,4 @@ jobs:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml
     with:
-      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md


### PR DESCRIPTION
This is anothre flag that has been deprecated and removed in v2.0. Replace it with the non-deprecated version.