### PR TITLE
update goreleaser yml files to version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ obj/
 __pycache__/
 node_modules/
 /coverage
+
+dist/

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,7 +1,6 @@
 dist: goreleaser
 project_name: pulumi-yaml
-changelog:
-  skip: true
+version: 2
 release:
   disable: true
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 dist: goreleaser
 project_name: pulumi-yaml
+version: 2
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"
 checksum:


### PR DESCRIPTION
This was the latest issue in
https://github.com/pulumi/pulumi-yaml/actions/runs/9381802513/job/25832183565. Updating the config files to version 2 should hopefully fix this.

I've run `goreleaser check` on them as well, and that passes, so hopefully this the last of it.  The v1.8.0 release went through in the meantime.