### PR TITLE
prepare CHANGELOG_PENDING for the next release

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,3 @@
 ### Improvements
 
-- Pass `PULUMI_STACK`, `PULUMI_ORGANIZATION`, `PULUMI_PROJECT` and `PULUMI_CONFIG` as environment variable to compiler process.
-
 ### Bug Fixes


### PR DESCRIPTION
Empty this file out after 1.8.0 was released, so we can start accumulating new changelog entries for the next release.