### PR TITLE
Fix module.cue in test so it can work with cue v0.9.0

### DIFF
--- a/examples/cue-eks/cue.mod/module.cue
+++ b/examples/cue-eks/cue.mod/module.cue
@@ -1,1 +1,4 @@
-module: "examples.pulumi.com/yaml-eks"
+module: "examples.pulumi.com/yaml-eks@v0"
+language: {
+	version: "v0.9.0"
+}


### PR DESCRIPTION
cue v0.9.0 was just released a couple days ago and now requires a version to be specified in `module.cue`. To fix, I ran `cue mod fix` per the v0.9.0 release notes: https://github.com/cue-lang/cue/releases/tag/v0.9.0

Fixes https://github.com/pulumi/pulumi-yaml/issues/588