### PR TITLE
Don't error on eventual IDs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- When importing, don't error on ID expressions that are themselves unknown during preview.
+  [#591](https://github.com/pulumi/pulumi-yaml/pull/591)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1351,6 +1351,8 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 			return s, true
 		case string:
 			id = pulumi.ID(s)
+		case pulumi.StringOutput:
+			id = s.ApplyT(convertID).(pulumi.IDOutput)
 		case pulumi.AnyOutput:
 			id = s.ApplyT(convertID).(pulumi.IDOutput)
 		default:

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -244,13 +244,17 @@ func testInvokeDiags(t *testing.T, template *ast.TemplateDecl, callback func(*Ru
 		},
 		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 			if args.ReadRPC != nil {
-				isRight := "yes"
+				isRight := resource.NewProperty("yes")
 				switch args.TypeToken {
 				case "test:read:Resource":
 					switch args.ID {
 					case "no-state":
 					case "eventual-yes":
-						isRight = "definitely"
+						isRight = resource.NewProperty("definitely")
+					case "unknown-state":
+						isRight = resource.MakeComputed(resource.NewStringProperty(""))
+					case "eventual-<nil>": // An unknown ID - not represent-able with mocks
+						return "", resource.PropertyMap{}, nil
 					default:
 						assert.Equal(t, "bucket-123456", args.ID)
 						assert.Equal(t, `string_value:"bar"`, args.ReadRPC.Properties.Fields["foo"].String())
@@ -258,7 +262,7 @@ func testInvokeDiags(t *testing.T, template *ast.TemplateDecl, callback func(*Ru
 					}
 					return "arn:aws:s3:::" + args.ID, resource.PropertyMap{
 						"tags": resource.NewObjectProperty(resource.PropertyMap{
-							"isRight": resource.NewStringProperty(isRight),
+							"isRight": isRight,
 						}),
 					}, nil
 				}

--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -62,6 +62,11 @@ func TestExampleGettingStarted(t *testing.T) {
 	testWrapper(t, exampleDir("getting-started"), RequireLiveRun, awsConfig)
 }
 
+//nolint:paralleltest // uses parallel programtest
+func TestImportComputedID(t *testing.T) {
+	testWrapper(t, "./testdata/import-computed-id", RequireLiveRun, awsConfig)
+}
+
 func TestExampleStackreference(t *testing.T) {
 	skipOnDryRun(t)
 

--- a/pkg/tests/testdata/import-computed-id/Pulumi.yaml
+++ b/pkg/tests/testdata/import-computed-id/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: dev-yaml
+runtime: yaml
+description: |
+  Assert that we can safely use a computed ID to import a resource.
+resources:
+  b1:
+    type: aws:s3:Bucket
+  b2:
+    type: aws:s3:Bucket
+    get:
+      id: ${b1.id}
+    options:
+      retainOnDelete: true


### PR DESCRIPTION
Right now, this program errors:

```yaml
name: dev-yaml
runtime: yaml
resources:
  b1:
    type: aws:s3:Bucket
  b2:
    type: aws:s3:Bucket
    get:
      id: ${b1.id}
```

```console
$ pulumi preview
Previewing update (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/pulumi/dev-yaml/dev/previews/0e23b0b3-33f3-4a5d-abf9-15fb7fb9f23e

Loading policy packs...

     Type                 Name          Plan       Info
 +   pulumi:pulumi:Stack  dev-yaml-dev  create     2 errors
 +   └─ aws:s3:Bucket     b1            create

Policies:
    ⚠️ pulumi-internal-policies@v0.0.6
        - [advisory]  s3-bucket-replication-enabled  (aws:s3/bucket:Bucket: b1)
          Encourages use of cross-region replication for S3 buckets.
          S3 buckets should have cross-region replication.

Diagnostics:
  pulumi:pulumi:Stack (dev-yaml-dev):
    error: ${b1.id} must be a string, instead got type pulumi.StringOutput

      on Pulumi.yaml line 9:
       9:       id: ${b1.id}

    This indicates a bug in the Pulumi YAML type checker. Please open an issue at https://github.com/pulumi/pulumi-yaml/issues/new/choose
    error: Error registering resource [b2]: no diagnostics

```

This PR addresses the problem.