### PR TITLE
Validate that resource import ids are not outputs

### DIFF
--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1141,7 +1141,18 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 		}
 	}
 	if v.Options.Import != nil {
-		opts = append(opts, pulumi.Import(pulumi.ID(v.Options.Import.Value)))
+		importValue, ok := e.evaluateExpr(v.Options.Import)
+		if ok {
+			if !hasOutputs(importValue) {
+				opts = append(opts, pulumi.Import(pulumi.ID(v.Options.Import.Value)))
+			} else {
+				e.error(v.Options.Import, "import must be not be an output")
+				overallOk = false
+			}
+		} else {
+			e.error(v.Options.Import, "couldn't evaluate the 'import' resource option")
+			overallOk = false
+		}
 	}
 	if v.Options.IgnoreChanges != nil {
 		opts = append(opts, pulumi.IgnoreChanges(listStrings(v.Options.IgnoreChanges)))


### PR DESCRIPTION
A program that uses the resource [import option](https://www.pulumi.com/docs/concepts/options/import/) with an `Output` as the import id:

```yaml
config:
  azure-native:location: westus2
  rgId:
    type: string
resources:
  resourceGroup:
    type: azure-native:resources:ResourceGroup
    options:
      import: "${rgId}"
```

currently fails like this: `error: failed to discover plugin requirements: Pulumi.yaml:15,15-22: import must be a string.` This error message is somewhat misleading, although correct in a narrow sense (outputs are not strings).

This PR adds a check to detect that case and fail with a better message.

TODO: The added test does **not** work as intended so far: it doesn't even get to the new code in `registerResource` but fails earlier in `LoadYAMLBytes`, with the previous "import must be a string" error.
