### PR TITLE
include name from original project if the compiler doesn't return it

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+
+- Fix a panic when the compiler doesn't include the name attribute from the Pulumi.yaml.

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -72,9 +72,18 @@ func LoadFromCompiler(compiler string, workingDirectory string, env []string) (*
 	if stdout.Len() != 0 {
 		diags = append(diags, syntax.Warning(nil, fmt.Sprintf("compiler %v warnings: %v", name, stdout.String()), ""))
 	}
+
 	templateStr := stdout.String()
 	template, tdiags, err := LoadYAMLBytes(fmt.Sprintf("<stdout from compiler %v>", name), []byte(templateStr))
 	diags.Extend(tdiags...)
+
+	if template.Name == nil {
+		uncompiledTemplate, _, err := LoadDir(workingDirectory)
+		if err != nil || uncompiledTemplate.Name == nil {
+			return nil, diags, errors.New("compiler did not produce a valid template")
+		}
+		template.Name = uncompiledTemplate.Name
+	}
 
 	return template, tdiags, err
 }


### PR DESCRIPTION
The pulumi-yaml runtime expects the compiler to return a complete yaml project, including the `name` attribute. The compiler might not return this however, even when it returns a valid yaml program otherwise.

This leads to issues down the line, as the rest of the runtime expects the name to be set in the template, and might panic if it isn't.  We do however have the name from the original Pulumi.yaml, so we can fill that in for the user, even if the compiler doesn't return it in the template.

Fixes https://github.com/pulumi/pulumi-yaml/issues/609