### PR TITLE
empty CHANGELOG_PENDING past release

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,3 @@
 ### Improvements
 
 ### Bug Fixes
-
-- Fix a panic when the compiler doesn't include the name attribute from the Pulumi.yaml.
-  [#610](https://github.com/pulumi/pulumi-yaml/pull/610)


### PR DESCRIPTION
v1.9.2 was released, so we can clean this out to be ready for the next release.