### PR TITLE
Parse the items property on config type declarations

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 - [features] add "pulumi.organiztion" to the built-in "pulumi" variable to obtain the current organization.
 
 ### Bug Fixes
+
+- Parse the items property on config type declarations to prevent diagnostic messages about
+  unknown fields [#615](https://github.com/pulumi/pulumi-yaml/pull/615)

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -276,6 +276,7 @@ type ConfigParamDecl struct {
 	Secret  *BooleanExpr
 	Default Expr
 	Value   Expr
+	Items   *ConfigParamDecl
 }
 
 func (d *ConfigParamDecl) recordSyntax() *syntax.Node {

--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -16,6 +16,23 @@ import (
 const example = `
 name: simple-yaml
 runtime: yaml
+config:
+  some-string-array:
+    type: array
+    value:
+      - subnet1
+      - subnet2
+      - subnet3
+    items:
+      type: string
+  some-nested-array:
+    type: array
+    items:
+      type: array
+      items:
+        type: string
+  some-boolean:
+    type: boolean
 resources:
   my-bucket:
     type: aws:s3/bucket:Bucket


### PR DESCRIPTION
When parsing a template, parse the `items` property on configuration type declarations to avoid a diagnostic for an unknown field coming from the reflection code. The config section is parsed as part of the template, but not actually used, the config validation is performed by the engine instead.

Fixes https://github.com/pulumi/pulumi-yaml/issues/606
