### PR TITLE
Add support for the stack, project, and organization builtins

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,5 @@
 
 ### Bug Fixes
  - Fix handling invokes that error out when the response contains secrets [#619](https://github.com/pulumi/pulumi-yaml/pull/619)
+
+ - Add support for the stack, project, and organization builtins [#625](https://github.com/pulumi/pulumi-yaml/pull/625)

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -682,6 +682,8 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return rng
 	}
 	switch f.Name {
+	case "stack", "project", "organization":
+		return syn.String(fmt.Sprintf("${pulumi.%s}", f.Name))
 	case pcl.Invoke:
 		return g.MustInvoke(f, "")
 	case "fileArchive", "remoteArchive", "assetArchive",


### PR DESCRIPTION
I noticed this while working on brining up conformance tests. I haven't added tests in this PR because this will get covered by those conformance tests when we bring them online.

But this fix was small and simple enough I thought worthwhile just getting merged.