### PR TITLE
Add environment variable for disabling YAML type checking

### DIFF
--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -36,6 +36,7 @@ import (
 // Launches the language host RPC endpoint, which in turn fires up an RPC server implementing the
 // LanguageRuntimeServer RPC endpoint.
 func main() {
+	panic("HERE!")
 	// Parse the flags and initialize some boilerplate.
 	var tracing string
 	var root string

--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -36,7 +36,6 @@ import (
 // Launches the language host RPC endpoint, which in turn fires up an RPC server implementing the
 // LanguageRuntimeServer RPC endpoint.
 func main() {
-	panic("HERE!")
 	// Parse the flags and initialize some boilerplate.
 	var tracing string
 	var root string

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -4,6 +4,7 @@ package pulumiyaml
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/ast"
 	ctypes "github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/config"
@@ -532,10 +534,15 @@ func hasValidEnumValue(from ast.Expr, to []*schema.Enum) *notAssignable {
 	}
 }
 
+var disableTypeChecking = cmdutil.IsTruthy(os.Getenv("PULUMI_YAML_DISABLE_TYPE_CHECKING"))
+
 // Provides an appropriate diagnostic message if it is illegal to assign `from`
 // to `to`.
 func (tc *typeCache) assertTypeAssignable(ctx *evalContext, from ast.Expr, to schema.Type) {
-	return
+	if disableTypeChecking {
+		return
+	}
+
 	if to == nil {
 		return
 	}

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -535,6 +535,7 @@ func hasValidEnumValue(from ast.Expr, to []*schema.Enum) *notAssignable {
 // Provides an appropriate diagnostic message if it is illegal to assign `from`
 // to `to`.
 func (tc *typeCache) assertTypeAssignable(ctx *evalContext, from ast.Expr, to schema.Type) {
+	return
 	if to == nil {
 		return
 	}

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -540,6 +540,11 @@ var disableTypeChecking = cmdutil.IsTruthy(os.Getenv("PULUMI_DEBUG_YAML_DISABLE_
 // to `to`.
 func (tc *typeCache) assertTypeAssignable(ctx *evalContext, from ast.Expr, to schema.Type) {
 	if disableTypeChecking {
+		ctx.addWarnDiag(
+			from.Syntax().Syntax().Range(),
+			"Running with type checking disabled. This is not recommended for production use.",
+			"This is a test feature and should not be used in production. Unexpected behavior may occur.",
+		)
 		return
 	}
 

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -534,7 +534,7 @@ func hasValidEnumValue(from ast.Expr, to []*schema.Enum) *notAssignable {
 	}
 }
 
-var disableTypeChecking = cmdutil.IsTruthy(os.Getenv("PULUMI_YAML_DISABLE_TYPE_CHECKING"))
+var disableTypeChecking = cmdutil.IsTruthy(os.Getenv("PULUMI_DEBUG_YAML_DISABLE_TYPE_CHECKING"))
 
 // Provides an appropriate diagnostic message if it is illegal to assign `from`
 // to `to`.


### PR DESCRIPTION
This adds an option to the YAML runtime to disable the type checking. This is controlled by the `PULUMI_YAML_DISABLE_TYPE_CHECKING` environment variable.

This is useful for tests where we need to test type mismatches which could happen in other languages, like Python or Typescript.

Can use some guidance on how to add tests here.

Required for https://github.com/pulumi/pulumi-terraform-bridge/issues/2418