### PR TITLE
Fix GenerateProgram not using the Strict flag

### DIFF
--- a/.changes/unreleased/Bug Fixes-635.yaml
+++ b/.changes/unreleased/Bug Fixes-635.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: Bug Fixes
+body: Fix GenerateProgram not using the Strict flag
+time: 2024-09-18T14:11:14.985045+02:00
+custom:
+    PR: "635"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -309,9 +309,16 @@ func (host *yamlLanguageHost) GenerateProgram(
 		}
 	}
 
-	program, diags, err := pcl.BindProgram(parser.Files,
+	bindOptions := []pcl.BindOption{
 		pcl.Loader(schema.NewCachedLoader(loader)),
-		pcl.PreferOutputVersionedInvokes)
+		pcl.PreferOutputVersionedInvokes,
+	}
+
+	if !req.Strict {
+		bindOptions = append(bindOptions, pcl.NonStrictBindOptions()...)
+	}
+
+	program, diags, err := pcl.BindProgram(parser.Files, bindOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

When using `pulumi import` from the CLI, we call `GenerateProgram` over the gRPC protocol. However, we weren't using the `Strict` flag to check if we should loosen type-checking when binding the program so it caused issues like https://github.com/pulumi/pulumi/issues/17290. 

This PR fixes the problem such that when `Strict=false` (the default) then we add the non-strict bind options to the bind options in GenerateProgram