### PR TITLE
Fix topological sort to take into account defaultProvider.

### DIFF
--- a/.changes/unreleased/Bug Fixes-643.yaml
+++ b/.changes/unreleased/Bug Fixes-643.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Fix default component detection when declared later in file
+time: 2024-09-24T15:31:34.068526213+09:00
+custom:
+  PR: "643"

--- a/pkg/pulumiyaml/sort.go
+++ b/pkg/pulumiyaml/sort.go
@@ -138,9 +138,16 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 			sorted = append(sorted, node)
 		}
 	}
+
+	var defaultProvider *ast.StringExpr
 	for _, kvp := range t.Resources.Entries {
 		rname, r := kvp.Key.Value, kvp.Value
 		node := resourceNode(kvp)
+
+		// Check if the resource is a default provider
+		if resourceIsDefaultProvider(node) {
+			defaultProvider = node.key()
+		}
 
 		cdiags := checkUniqueNode(intermediates, node)
 		diags = append(diags, cdiags...)
@@ -198,6 +205,7 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 		}
 		if !visited[name.Value] {
 			visiting[name.Value] = true
+
 			for _, mname := range dependencies[name.Value] {
 				if mname.Value == PulumiVarName {
 					continue
@@ -206,6 +214,17 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 					return false
 				}
 			}
+
+			if resourceNodeHasNoExplicitProvider(e) && defaultProvider != name {
+				// If the resource has no explicit provider and the default provider is not set, then the
+				// (implicit) dependency is not yet met.
+				if defaultProvider != nil && !visit(defaultProvider) {
+					return false
+				}
+
+				// if the defaultProviderForPackage is not set, then it may not be needed.
+			}
+
 			visited[name.Value] = true
 			visiting[name.Value] = false
 
@@ -232,13 +251,29 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 	return sorted, diags
 }
 
+// resourceIsDefaultProvider returns true if the node is a default provider, otherwise false.
+func resourceIsDefaultProvider(res resourceNode) bool {
+	return res.Value.DefaultProvider != nil && res.Value.DefaultProvider.Value
+}
+
+// resourceNodeHasNoExplicitProvider returns true if the node is a resource
+// node and has no explicit provider set, otherwise false.
+func resourceNodeHasNoExplicitProvider(graphNode graphNode) bool {
+	if res, ok := graphNode.(resourceNode); ok {
+		return res.Value.Options.Provider == nil
+	}
+
+	return false
+}
+
 func checkUniqueNode(intermediates map[string]graphNode, node graphNode) syntax.Diagnostics {
 	var diags syntax.Diagnostics
 
 	key := node.key()
 	name := key.Value
 	if name == PulumiVarName {
-		return syntax.Diagnostics{ast.ExprError(key, fmt.Sprintf("%s %s uses the reserved name pulumi", node.valueKind(), name), "")}
+		return syntax.Diagnostics{ast.ExprError(key,
+			fmt.Sprintf("%s %s uses the reserved name pulumi", node.valueKind(), name), "")}
 	}
 
 	if other, found := intermediates[name]; found {
@@ -249,7 +284,8 @@ func checkUniqueNode(intermediates map[string]graphNode, node graphNode) syntax.
 		if node.valueKind() == other.valueKind() {
 			diags.Extend(ast.ExprError(key, fmt.Sprintf("found duplicate %s %s", node.valueKind(), name), ""))
 		} else {
-			diags.Extend(ast.ExprError(key, fmt.Sprintf("%s %s cannot have the same name as %s %s", node.valueKind(), name, other.valueKind(), name), ""))
+			diags.Extend(ast.ExprError(key, fmt.Sprintf(
+				"%s %s cannot have the same name as %s %s", node.valueKind(), name, other.valueKind(), name), ""))
 		}
 		return diags
 	}

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -133,3 +133,13 @@ func TestLocalPlugin(t *testing.T) {
 		},
 	})
 }
+
+//nolint:paralleltest // uses parallel programtest
+func TestResourceOrderingWithDefaultProvider(t *testing.T) {
+	integration.ProgramTest(t,
+		&integration.ProgramTestOptions{
+			Dir:                    filepath.Join("testdata", "resource-ordering"),
+			SkipUpdate:             true,
+			SkipEmptyPreviewUpdate: true,
+		})
+}

--- a/pkg/tests/testdata/resource-ordering/Pulumi.yaml
+++ b/pkg/tests/testdata/resource-ordering/Pulumi.yaml
@@ -1,0 +1,17 @@
+name: aws-yaml
+runtime: yaml
+resources:
+  alb:
+    type: aws:alb:LoadBalancer
+    properties:
+      tags: 
+        Name: test-lb
+      name: testing
+      subnets: 
+        - subnet-eacf3697
+        - subnet-939b18f8
+  provider:
+    defaultProvider: true
+    type: pulumi:providers:aws
+    properties:
+      region: us-west-2


### PR DESCRIPTION
[//]: # (BEGIN GIT-PR FOOTER)

The topological sort will not sort default providers first as is, so
this adds in a check to detect it and not allow implicit providers to be
complete until the default provider is declared.

---

* 🐹 #648 (👉[7abd4bf5](https://github.com/pulumi/pulumi-yaml/commit/7abd4bf5))
* ◻️ #650
