### PR TITLE
Make TestInvokeReturningSecrets no longer flaky

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-yaml
 
-go 1.23.0
+go 1.23
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-yaml
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
### Description

Fixes #653. The problem was that sometimes the test finishes executing before the apply function finished running and it became a race. Fixed using channels that signal when the apply function is done and waiting for it. If it takes longer than 2 seconds, it times out. 