### PR TITLE
build statically linked binaries with CGO disabled

### DIFF
--- a/.changes/unreleased/Bug Fixes-657.yaml
+++ b/.changes/unreleased/Bug Fixes-657.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Build statically linked release binary with CGO disabled
+time: 2024-10-08T16:41:00.728884753+02:00
+custom:
+  PR: "657"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,8 @@ archives:
 builds:
 - id: pulumi-language-yaml
   binary: pulumi-language-yaml
+  env:
+    - CGO_ENABLED=0
   goarch:
   - amd64
   - arm64
@@ -31,6 +33,8 @@ builds:
   main: ./cmd/pulumi-language-yaml/
 - id: pulumi-converter-yaml
   binary: pulumi-converter-yaml
+  env:
+    - CGO_ENABLED=0
   goarch:
   - amd64
   - arm64


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-yaml/pull/632 we switched the build from running on MacOS to Ubuntu.  On MacOS CGO is disabled by default, and switching to Ubuntu means this is turned on.  We however want to build statically linked binaries since they are easier to deal with.  Set that up in the goreleaser.yml explicitly.