### PR TITLE
Use the workflow's GITHUB_TOKEN to create the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,10 @@ on:
   push:
     branches: [ main ]
     paths: [ CHANGELOG.md ]
+  workflow_dispatch: {}
 
-env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+permissions:
+  contents: write
 
 jobs:
   release-pulumi-language-yaml:
@@ -56,3 +57,5 @@ jobs:
         with:
           version: latest
           args: -p 10 -f .goreleaser.yml --clean --skip=validate --timeout 60m0s --release-notes=${{ env.RELEASE_NOTES_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release failed with the following error:

> 403 The 'Pulumi' enterprise forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 365 days.

Rather than rotating `PULUMI_BOT_TOKEN`, I think we can avoid this going forward by using the workflow's `secrets.GITHUB_TOKEN` with `contents:write` permissions.

Additionally, this change allows dispatching the workflow manually, to allow the workflow to be re-run easily after this is merged.