### PR TITLE
Revert `go.mod` back to `go 1.21`

### DIFF
--- a/.changes/unreleased/Bug Fixes-662.yaml
+++ b/.changes/unreleased/Bug Fixes-662.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Revert go version in go.mod back to 1.21
+time: 2024-10-09T15:05:26.676777-07:00
+custom:
+    PR: "662"

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -8,7 +8,7 @@ permissions: read-all
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOLANGCI_LINT_VERSION: v1.60
-  GO_VERSION: v1.23.x
+  GO_VERSION: v1.22.x
 
 jobs:
   lint:
@@ -22,7 +22,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: |
             **/go.sum
-      - run: go mod tidy -go=1.23
+      - run: go mod tidy -go=1.21
       - name: Fail if go mod tidy changed go.mod
         run: |
           if [ -n "$(git status --porcelain)" ]; then
@@ -50,6 +50,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.22.x
       - name: Lint
         run: make lint-copyright

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -146,4 +146,4 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.22.x]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-yaml
 
-go 1.23
+go 1.21
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
To match pulumi/pulumi's `pkg/go.mod` which is also set to `go 1.21`.

Also, use go 1.22 in CI rather than go 1.23, since we still want pulumi/pulumi's pkg to be usable with go 1.22 without requiring another toolchain version.