### PR TITLE
return correct element types for latebound resources

### DIFF
--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -582,7 +582,7 @@ func (st *lateboundCustomResourceState) ProviderResource() *pulumi.ProviderResou
 }
 
 func (*lateboundCustomResourceState) ElementType() reflect.Type {
-	return reflect.TypeOf((*lateboundResource)(nil)).Elem()
+	return reflect.TypeOf((**lateboundCustomResourceState)(nil)).Elem()
 }
 
 func (st *lateboundCustomResourceState) GetRawOutputs() pulumi.Output {
@@ -625,7 +625,7 @@ func (st *lateboundProviderResourceState) ProviderResource() *pulumi.ProviderRes
 }
 
 func (*lateboundProviderResourceState) ElementType() reflect.Type {
-	return reflect.TypeOf((*lateboundResource)(nil)).Elem()
+	return reflect.TypeOf((**lateboundProviderResourceState)(nil)).Elem()
 }
 
 func (st *lateboundProviderResourceState) GetRawOutputs() pulumi.Output {
@@ -866,7 +866,8 @@ func (r *Runner) Evaluate(ctx *pulumi.Context) syntax.Diagnostics {
 	return r.Run(programEvaluator{
 		evalContext: eCtx,
 		pulumiCtx:   ctx,
-		packageRefs: packageRefs})
+		packageRefs: packageRefs,
+	})
 }
 
 func getConfNodesFromMap(project string, configPropertyMap resource.PropertyMap) []configNode {

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -170,3 +170,10 @@ func TestResourceOrderingWithDefaultProvider(t *testing.T) {
 			SkipEmptyPreviewUpdate: true,
 		})
 }
+
+//nolint:paralleltest // uses parallel programtest
+func TestResourceSecret(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("testdata", "resource-secret"),
+	})
+}

--- a/pkg/tests/testdata/resource-secret/Pulumi.yaml
+++ b/pkg/tests/testdata/resource-secret/Pulumi.yaml
@@ -1,0 +1,15 @@
+name: resource-secret
+runtime:
+  name: yaml
+resources:
+  randomPassword:
+    type: random:RandomPassword
+    properties:
+      length: 16
+      lower: true
+      upper: true
+      numeric: true
+      special: true
+outputs:
+  superSecret:
+    fn::secret: ${randomPassword}


### PR DESCRIPTION
We currently return a pointer to the interface for latebound resources from their ElementType methods.  However pulumi expects pointers to the concrete type here, so it can create it and assign values to the created object.  Fix that.

In particular this can happen when calling `fn::secret` on a created resource.  Currently that will panic because the internals get confused by this wrong `ElementType`. I'm not sure it makes all that much sense to even call `fn::secret` on this, but we shouldn't panic either.