### PR TITLE
Enable l1-main test

### DIFF
--- a/.changes/unreleased/Bug Fixes-672.yaml
+++ b/.changes/unreleased/Bug Fixes-672.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: Bug Fixes
+body: Program generation now respects the 'main' option from input Pulumi.yaml
+time: 2024-11-13T19:42:32.376005908Z
+custom:
+  PR: "672"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -172,7 +172,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
-	"l1-main":                               "TODO",
 	"l1-output-array":                       "TODO",
 	"l1-stack-reference":                    "TODO",
 	"l1-output-string":                      "TODO",

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-main/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-main/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: l1-main
+runtime: yaml
+main: subdir

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-main/subdir/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-main/subdir/Main.yaml
@@ -1,0 +1,2 @@
+outputs:
+  output_true: true

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -71,13 +71,26 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 	if err != nil {
 		return err
 	}
-	files["Pulumi.yaml"] = projectBytes
+	// Pulumi.yaml always needs to be written to the root directory
+	err = os.WriteFile(path.Join(directory, "Pulumi.yaml"), projectBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("write output project: %w", err)
+	}
+
+	// If main is set the Main.yaml file should be in a subdirectory
+	if project.Main != "" {
+		directory = path.Join(directory, project.Main)
+		err := os.MkdirAll(directory, 0700)
+		if err != nil {
+			return fmt.Errorf("create output directory: %w", err)
+		}
+	}
 
 	for filename, data := range files {
 		outPath := path.Join(directory, filename)
 		err := os.WriteFile(outPath, data, 0600)
 		if err != nil {
-			return fmt.Errorf("could not write output program: %w", err)
+			return fmt.Errorf("write output program: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This enables the l1-main test. It required a small fix in program generation to look at the main option in the incoming Pulumi.yaml and place the generated yamls in a sub directory if set.