### PR TITLE
Enable l1-output-string

### DIFF
--- a/.changes/unreleased/Bug Fixes-675.yaml
+++ b/.changes/unreleased/Bug Fixes-675.yaml
@@ -1,0 +1,7 @@
+component: codegen
+kind: Bug Fixes
+body: Maintain empty strings in converted programs to still be string literals in
+  YAML
+time: 2024-11-14T15:15:07.587566353Z
+custom:
+  PR: "675"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -173,7 +173,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l1-stack-reference":                    "TODO",
-	"l1-output-string":                      "TODO",
 	"l2-destroy":                            "TODO",
 	"l2-invoke-options":                     "TODO",
 	"l2-map-keys":                           "TODO",

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-output-string/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-output-string/Main.yaml
@@ -1,9 +1,9 @@
 outputs:
-  empty:
+  empty: ""
   small: Hello world!
   emoji: "\U0001F44B \"Hello \U0001019B!\" \U0001F60A"
-  escape: "Some ${common} \"characters\" 'that' need escaping: \\ (backslash), \t (tab), \e (escape), \a (bell), \0 (null), \U000E0021 (tag space)"
-  escapeNewline: "Some ${common} \"characters\" 'that' need escaping: \\ (backslash), \n (newline), \t (tab), \e (escape), \a (bell), \0 (null), \U000E0021 (tag space)"
+  escape: "Some $${common} \"characters\" 'that' need escaping: \\ (backslash), \t (tab), \e (escape), \a (bell), \0 (null), \U000E0021 (tag space)"
+  escapeNewline: "Some $${common} \"characters\" 'that' need escaping: \\ (backslash), \n (newline), \t (tab), \e (escape), \a (bell), \0 (null), \U000E0021 (tag space)"
   large: |
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -525,6 +525,8 @@ func (g *generator) expr(e model.Expression) syn.Node {
 			return syn.Null()
 		case t.Equals(cty.String):
 			v := e.Value.AsString()
+			// This is a literal string so escape any ${ sequences in it
+			v = strings.ReplaceAll(v, "${", "$${")
 			return syn.String(v)
 		case t.Equals(cty.Number):
 			v := e.Value.AsBigFloat()

--- a/pkg/pulumiyaml/syntax/encoding/yaml.go
+++ b/pkg/pulumiyaml/syntax/encoding/yaml.go
@@ -232,6 +232,10 @@ func MarshalYAML(n syntax.Node) (*yaml.Node, syntax.Diagnostics) {
 		if originalValue != value {
 			yamlNode.Value = value
 		}
+		// if the empty string use double quotes so we get "" instead of nothing
+		if yamlNode.Value == "" {
+			yamlNode.Style = yaml.DoubleQuotedStyle
+		}
 	case *syntax.ListNode:
 		if yamlNode.Kind != yaml.SequenceNode && yamlNode.Kind != yaml.DocumentNode {
 			yamlNode.Kind = yaml.SequenceNode

--- a/pkg/pulumiyaml/testing/test/testdata/aws-fargate-output-versioned-pp/yaml/aws-fargate-output-versioned.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-fargate-output-versioned-pp/yaml/aws-fargate-output-versioned.yaml
@@ -27,7 +27,7 @@ resources:
         fn::toJSON:
           Version: 2008-10-17
           Statement:
-            - Sid:
+            - Sid: ""
               Effect: Allow
               Principal:
                 Service: ecs-tasks.amazonaws.com

--- a/pkg/pulumiyaml/testing/test/testdata/aws-fargate-pp/yaml/aws-fargate.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-fargate-pp/yaml/aws-fargate.yaml
@@ -27,7 +27,7 @@ resources:
         fn::toJSON:
           Version: 2008-10-17
           Statement:
-            - Sid:
+            - Sid: ""
               Effect: Allow
               Principal:
                 Service: ecs-tasks.amazonaws.com

--- a/pkg/pulumiyaml/testing/test/testdata/join-template-pp/yaml/join-template.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/join-template-pp/yaml/join-template.yaml
@@ -4,7 +4,7 @@ resources:
     properties:
       name:
         fn::join:
-          -
+          - ""
           - - fn::select:
                 - 0
                 - - foo

--- a/pkg/pulumiyaml/testing/test/testdata/kubernetes-operator-pp/yaml/kubernetes-operator.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/kubernetes-operator-pp/yaml/kubernetes-operator.yaml
@@ -48,7 +48,7 @@ resources:
         name: pulumi-kubernetes-operator
       rules:
         - apiGroups:
-            -
+            - ""
           resources:
             - pods
             - services
@@ -97,7 +97,7 @@ resources:
           verbs:
             - update
         - apiGroups:
-            -
+            - ""
           resources:
             - pods
           verbs:


### PR DESCRIPTION
This required two fixes.

Firstly when reading in a literal string from PCL we need to re-escape any `$${` escape sequences.

Secondly it's valid to have an empty string as a stack export. We fix this by making sure empty strings from PCL write out as `""` rather than nothing, as the latter caused the yaml runtime to think it was an empty/null/missing key rather than an empty string.