### PR TITLE
Enable l2-resource-simple

### DIFF
--- a/.changes/unreleased/Improvements-676.yaml
+++ b/.changes/unreleased/Improvements-676.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: '`GetProgramDependencies` now returns packages used to show in `pulumi about`'
+time: 2024-11-14T17:39:33.889564362Z
+custom:
+  PR: "676"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -187,7 +187,6 @@ var expectedFailures = map[string]string{
 	"l2-invoke-simple":                      "TODO",
 	"l2-plain":                              "TODO",
 	"l2-ref-ref":                            "TODO",
-	"l2-resource-simple":                    "TODO",
 	"l2-failed-create-continue-on-error":    "TODO",
 	"l2-invoke-variants":                    "TODO",
 	"l2-primitive-ref":                      "TODO",
@@ -212,7 +211,7 @@ func TestLanguage(t *testing.T) {
 	// Run the language plugin
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
-			host := server.NewLanguageHost(engineAddress, "", "")
+			host := server.NewLanguageHost(engineAddress, "", "", true /* useRPCLoader */)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},

--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -64,7 +64,7 @@ func main() {
 	// Fire up a gRPC server, letting the kernel choose a free port.
 	port, done, err := rpcutil.Serve(0, cancelChannel, []func(*grpc.Server) error{
 		func(srv *grpc.Server) error {
-			host := server.NewLanguageHost(engineAddress, tracing, compiler)
+			host := server.NewLanguageHost(engineAddress, tracing, compiler, false /* useRPCLoader */)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-simple/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-simple/Main.yaml
@@ -1,0 +1,5 @@
+resources:
+  res:
+    type: simple:Resource
+    properties:
+      value: true

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-simple/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-simple
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-simple/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-simple/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/sdks/simple-2.0.0/simple-2.0.0.yaml
+++ b/cmd/pulumi-language-yaml/testdata/sdks/simple-2.0.0/simple-2.0.0.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0


### PR DESCRIPTION
This enables the l2-resource-simple test.

This required a few fixes. 
Firstly in `GetReferencedPlugins` we look at any package declarations to get package versions. This is so we can return the plugin info with the right version.

Secondly we add `GetReferencePackages` method to use from `GetProgramDependencies` so that we can actually return something from `GetProgramDependencies` rather than nothing. Conformance testing tests this so we have to fill it in.

Thirdly we implement `Pack`, it doesn't do much just copies the generated package declaration yaml file.