### PR TITLE
Fix panic when resource shape is invalid

### DIFF
--- a/.changes/unreleased/Bug Fixes-677.yaml
+++ b/.changes/unreleased/Bug Fixes-677.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Fix panic when resource shape is invalid
+time: 2024-11-15T00:51:03.499599+01:00
+custom:
+    PR: "677"

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -133,6 +133,10 @@ func LoadDir(directory string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 		return nil, diags, err
 	}
 
+	if diags.HasErrors() {
+		return nil, diags, diags
+	}
+
 	packages, err := packages.SearchPackageDecls(directory)
 	if err != nil {
 		diags.Extend(syntax.Error(nil, err.Error(), ""))

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -1786,6 +1786,23 @@ resources:
 	requireNoErrors(t, tmpl, diags)
 }
 
+func TestUnknownResource(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+runtime: yaml
+config: {}
+variables:     {}
+resources:     {badResource}
+outputs:       {}`
+
+	pt, diags, _ := LoadYAMLBytes("<stdin>", []byte(text))
+	assert.Nil(t, pt)
+	assert.Len(t, diags, 1)
+	assert.True(t, diags.HasErrors())
+	assert.Contains(t, diags[0].Error(), "resources.badResource must be an object")
+}
+
 func TestPoisonResult(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -34,6 +34,15 @@ func TestTypeCheckError(t *testing.T) {
 }
 
 //nolint:paralleltest // uses parallel programtest
+func TestInvalidResourceObject(t *testing.T) {
+	testWrapper(t, integrationDir("invalid-resource-object"), ExpectFailure, StderrValidator{
+		f: func(t *testing.T, stderr string) {
+			assert.Contains(t, stderr, "resources.badResource must be an object")
+		},
+	})
+}
+
+//nolint:paralleltest // uses parallel programtest
 func TestMismatchedConfigType(t *testing.T) {
 	testWrapper(t, integrationDir("mismatched-config-type"), ExpectFailure, StderrValidator{
 		f: func(t *testing.T, stderr string) {

--- a/pkg/tests/testdata/invalid-resource-object/Pulumi.yaml
+++ b/pkg/tests/testdata/invalid-resource-object/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: myymltest
+description: A minimal Pulumi YAML program
+runtime: yaml
+variables: {}
+resources: {badResource}
+outputs: {}


### PR DESCRIPTION
Fixes #668 

I believe the issue is that we assign packages to the parsed template without checking diagnostics:
```
packages, err := packages.SearchPackageDecls(directory)
template.Packages = packages
```