### PR TITLE
Fix the language plugin to return a version

### DIFF
--- a/.changes/unreleased/Bug Fixes-682.yaml
+++ b/.changes/unreleased/Bug Fixes-682.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Fix the language plugin to return a version
+time: 2024-11-15T00:43:58.301401-08:00
+custom:
+    PR: "682"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ GO                          := go
 
 BUILD_FLAGS ?=
 
+# Try to get the dev version using changie, otherwise fall back
+FALLBACK_DEV_VERSION := 1.0.0-dev.0
+DEV_VERSION := $(shell if command -v changie > /dev/null; then changie next patch -p dev.0; else echo "$(FALLBACK_DEV_VERSION)"; fi)
+
 .phony: .EXPORT_ALL_VARIABLES
 .EXPORT_ALL_VARIABLES:
 
@@ -60,7 +64,8 @@ lint-copyright:
 
 build:: ensure
 	mkdir -p ./bin
-	${GO} build $(BUILD_FLAGS) -o ./bin -p ${CONCURRENCY} ./cmd/...
+	${GO} build $(BUILD_FLAGS) -o ./bin -p ${CONCURRENCY} \
+		-ldflags "-X github.com/pulumi/pulumi-yaml/pkg/version.Version=$(DEV_VERSION)" ./cmd/...
 
 # Ensure that in tests, the language server is accessible
 test:: build get_plugins get_schemas

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -42,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/codegen"
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/packages"
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
+	"github.com/pulumi/pulumi-yaml/pkg/version"
 
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -18,6 +18,20 @@ func integrationDir(dir string) string {
 	return filepath.Join("./testdata", dir)
 }
 
+func TestAbout(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.ImportDirectory(integrationDir("about"))
+
+	stdout, stderr := e.RunCommand("pulumi", "about")
+	// There should be no "unknown" plugin versions.
+	assert.NotContains(t, stdout, "unknown")
+	assert.NotContains(t, stderr, "unknown")
+}
+
 //nolint:paralleltest // uses parallel programtest
 func TestTypeCheckError(t *testing.T) {
 	testWrapper(t, integrationDir("type-fail"), ExpectFailure, StderrValidator{

--- a/pkg/tests/testdata/about/Pulumi.yaml
+++ b/pkg/tests/testdata/about/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: about
+description: An empty program
+runtime: yaml


### PR DESCRIPTION
This change fixes `pulumi about` to show the real version instead of `unknown` for the yaml language plugin.

The fix updates `GetPluginInfo` to return the `Version` from the right `version` Go package&mdash;the one that's actually being set during build via `ldflags` (`"github.com/pulumi/pulumi-yaml/pkg/version"` instead of `"github.com/pulumi/pulumi/sdk/v3/go/common/version"`).

Fixes #680