### PR TITLE
Enable the l2-invoke-secrets test

### DIFF
--- a/.changes/unreleased/Bug Fixes-683.yaml
+++ b/.changes/unreleased/Bug Fixes-683.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: Bug Fixes
+body: Recognize the PCL fn::secret function
+time: 2024-11-15T13:03:54.975607828Z
+custom:
+  PR: "683"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -176,7 +176,6 @@ var expectedFailures = map[string]string{
 	"l2-invoke-options":                     "cannot assign expression",
 	"l2-map-keys":                           "missing expected dependency primitive",
 	"l2-provider-grpc-config-schema-secret": "Detected a secret leak in state",
-	"l2-invoke-secrets":                     "YAML does not support fn::secret",
 	"l2-parameterized-resource":             "could not load schema for subpackage, provider not known",
 	"l2-failed-create-continue-on-error":    "missing expected dependency fail_on_create",
 	"l2-invoke-dependencies":                "missing expected dependency simple-invoke",

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/Main.yaml
@@ -1,0 +1,32 @@
+resources:
+  res:
+    type: simple:Resource
+    properties:
+      value: true
+outputs:
+  # inputs are plain and the invoke response is plain
+  nonSecret:
+    fn::invoke:
+      Function: simple-invoke:secretInvoke
+      Arguments:
+        value: hello
+        secretResponse: false
+      Return: response
+  # referencing value from resource
+  # // invoke response is secret => whole output is secret
+  firstSecret:
+    fn::invoke:
+      Function: simple-invoke:secretInvoke
+      Arguments:
+        value: hello
+        secretResponse: ${res.value}
+      Return: response
+  # inputs are secret, invoke response is plain => whole output is secret
+  secondSecret:
+    fn::invoke:
+      Function: simple-invoke:secretInvoke
+      Arguments:
+        value:
+          fn::secret: goodbye
+        secretResponse: false
+      Return: response

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-secrets
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/sdks/simple-invoke.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/sdks/simple-invoke.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple-invoke
+version: 10.0.0

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-secrets/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -735,6 +735,8 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return wrapFn("select", syn.List(args[1], args[0]))
 	case "readFile":
 		return wrapFn("readFile", g.expr(f.Args[0]))
+	case "secret":
+		return wrapFn("secret", g.expr(f.Args[0]))
 	case pcl.IntrinsicConvert:
 		// We can't perform the convert, but it might happen automatically.
 		// This works for enums, as well as number -> strings.


### PR DESCRIPTION
Fixes program generation to recognize "fn::secret" from PCL and turn it into "fn::secret" in YAML.