### PR TITLE
Allow specifying dependencies for output invokes

### DIFF
--- a/.changes/unreleased/Improvements-693.yaml
+++ b/.changes/unreleased/Improvements-693.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Allow specifiying dependencies for output invokes
+time: 2024-11-20T14:58:17.346265+01:00
+custom:
+    PR: "693"

--- a/.changes/unreleased/Improvements-693.yaml
+++ b/.changes/unreleased/Improvements-693.yaml
@@ -1,6 +1,6 @@
 component: runtime
 kind: Improvements
-body: Allow specifiying dependencies for output invokes
+body: Allow specifying dependencies for output invokes
 time: 2024-11-20T14:58:17.346265+01:00
 custom:
     PR: "693"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -173,7 +173,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l2-provider-grpc-config-schema-secret": "Detected a secret leak in state",
-	"l2-invoke-options-depends-on":          "Invoke dependency not propagated",
 	"l2-explicit-parameterized-provider":    "unexpected provider request with no version",
 }
 

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-options-depends-on/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-options-depends-on/Main.yaml
@@ -1,0 +1,22 @@
+resources:
+  explicitProvider:
+    type: pulumi:providers:simple-invoke
+  first:
+    type: simple-invoke:StringResource
+    properties:
+      text: first hello
+  second:
+    type: simple-invoke:StringResource
+    properties:
+      text: ${data.result}
+variables:
+  data:
+    fn::invoke:
+      function: simple-invoke:myInvoke
+      arguments:
+        value: hello
+      options:
+        dependsOn:
+          - ${first}
+outputs:
+  hello: ${data.result}

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-options-depends-on/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-options-depends-on/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-options-depends-on
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-options-depends-on/sdks/simple-invoke.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-invoke-options-depends-on/sdks/simple-invoke.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple-invoke
+version: 10.0.0

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -807,6 +807,9 @@ func (tc *typeCache) typeInvoke(ctx *evalContext, t *ast.InvokeExpr) bool {
 	if t.CallOpts.PluginDownloadURL != nil {
 		tc.typeExpr(ctx, t.CallOpts.PluginDownloadURL)
 	}
+	if t.CallOpts.DependsOn != nil {
+		tc.typeExpr(ctx, t.CallOpts.DependsOn)
+	}
 	if t.Return != nil {
 		fields := []string{}
 		var (

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -370,6 +370,7 @@ func ResourceOptions(additionalSecretOutputs, aliases *StringListDecl,
 type InvokeOptionsDecl struct {
 	declNode
 
+	DependsOn         Expr
 	Parent            Expr
 	Provider          Expr
 	Version           *StringExpr

--- a/pkg/pulumiyaml/codegen/gen_program_test.go
+++ b/pkg/pulumiyaml/codegen/gen_program_test.go
@@ -218,7 +218,7 @@ func TestGenerateProgram(t *testing.T) {
 				tt.SkipCompile = codegen.NewStringSet("yaml")
 				l = append(l, tt)
 			case "deferred-outputs":
-				// Not yet supported in Pulumi YAML
+				// Reason: Pulumi YAML does not support deferred outputs.
 			default:
 				l = append(l, tt)
 			}

--- a/pkg/pulumiyaml/expr.go
+++ b/pkg/pulumiyaml/expr.go
@@ -70,6 +70,9 @@ func getExpressionDependencies(deps *[]*ast.StringExpr, x ast.Expr) {
 		if x.CallOpts.Provider != nil {
 			getExpressionDependencies(deps, x.CallOpts.Provider)
 		}
+		if x.CallOpts.DependsOn != nil {
+			getExpressionDependencies(deps, x.CallOpts.DependsOn)
+		}
 	case ast.BuiltinExpr:
 		getExpressionDependencies(deps, x.Args())
 	}

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -2042,7 +2042,7 @@ func (e *programEvaluator) evaluateBuiltinInvoke(t *ast.InvokeExpr) (interface{}
 			e.error(t.CallOpts.Version, fmt.Sprintf("unable to parse function provider version: %v", err))
 			return nil, true
 		}
-		_, functionName, err := ResolveFunction(context.TODO(), e.pkgLoader, e.packageDescriptors, t.Token.Value, version)
+		_, functionName, err := ResolveFunction(e.pulumiCtx.Context(), e.pkgLoader, e.packageDescriptors, t.Token.Value, version)
 		if err != nil {
 			return e.error(t, err.Error())
 		}
@@ -2054,7 +2054,7 @@ func (e *programEvaluator) evaluateBuiltinInvoke(t *ast.InvokeExpr) (interface{}
 		}
 
 		if t.Return.GetValue() == "" {
-			output := pulumi.OutputWithDependencies(context.TODO(), pulumi.Any(result), deps...)
+			output := pulumi.OutputWithDependencies(e.pulumiCtx.Context(), pulumi.Any(result), deps...)
 			if secret {
 				return pulumi.ToSecret(output), true
 			}
@@ -2067,7 +2067,7 @@ func (e *programEvaluator) evaluateBuiltinInvoke(t *ast.InvokeExpr) (interface{}
 			return e.error(t.Return, fmt.Sprintf("fn::invoke of %s did not contain a property '%s' in the returned value", t.Token.Value, t.Return.Value))
 		}
 
-		output := pulumi.OutputWithDependencies(context.TODO(), pulumi.Any(retv), deps...)
+		output := pulumi.OutputWithDependencies(e.pulumiCtx.Context(), pulumi.Any(retv), deps...)
 		if secret {
 			return pulumi.ToSecret(output), true
 		}

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -2060,7 +2060,7 @@ func (e *programEvaluator) evaluateBuiltinInvoke(t *ast.InvokeExpr) (interface{}
 			if secret {
 				return pulumi.ToSecret(output), true
 			}
-			return result, true
+			return output, true
 		}
 
 		retv, ok := result[t.Return.Value]

--- a/pkg/pulumiyaml/run_invoke_test.go
+++ b/pkg/pulumiyaml/run_invoke_test.go
@@ -233,7 +233,7 @@ outputs:
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
 	var innerValue string
-	done := make(chan bool)
+	done := make(chan bool, 1)
 	diags := testInvokeDiags(t, tmpl, func(r *Runner) {
 		cipher, ok := r.variables["cipher"].(pulumi.AnyOutput)
 		assert.True(t, ok)
@@ -269,7 +269,7 @@ outputs:
 
 	tmpl := yamlTemplate(t, strings.TrimSpace(text))
 	var response map[string]any
-	done := make(chan bool)
+	done := make(chan bool, 1)
 	diags := testInvokeDiags(t, tmpl, func(r *Runner) {
 		cipher, ok := r.variables["cipher"].(pulumi.AnyOutput)
 		assert.True(t, ok)


### PR DESCRIPTION
Provider functions that take inputs as arguments, and return an output (aka output invokes), now allow specifying a `dependsOn` option. This allows programs to ensure that invokes are executed after things they depend on, similar to the [`depdendsOn` resource option](https://www.pulumi.com/docs/iac/concepts/options/dependson/).

https://github.com/pulumi/pulumi/discussions/17710

Fixes https://github.com/pulumi/pulumi/issues/17755
