### PR TITLE
[convert] Emit invoke options to PCL when ejecting YAML templates

### DIFF
--- a/.changes/unreleased/Bug Fixes-697.yaml
+++ b/.changes/unreleased/Bug Fixes-697.yaml
@@ -1,0 +1,6 @@
+component: convert
+kind: Bug Fixes
+body: Emit invoke options to PCL when ejecting YAML templates
+time: 2024-12-11T11:32:19.093828+01:00
+custom:
+    PR: "697"

--- a/pkg/pulumiyaml/codegen/load_test.go
+++ b/pkg/pulumiyaml/codegen/load_test.go
@@ -141,6 +141,37 @@ variables:
 noRet = invoke("test:mod:fn", {})
 `,
 		},
+		{
+			name: "invoke options",
+			input: `resources:
+  provider:
+    type: pulumi:providers:aws
+    properties:
+      region: us-west-2
+
+variables:
+  cur-region:
+    fn::invoke:
+      arguments: {}
+      function: test:mod:fn
+      options:
+        version: "1.0.0"
+        parent: ${provider}
+        pluginDownloadURL: http://example.com
+        provider: ${provider}`,
+			expected: `curRegion = invoke("test:mod:fn", {}, {
+	parent = provider,
+	provider = provider,
+	version = "1.0.0",
+	pluginDownloadUrl = "http://example.com"
+})
+
+resource provider "pulumi:providers:aws" {
+	__logicalName = "provider"
+	region = "us-west-2"
+}
+`,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
### Description

Resolves https://github.com/pulumi/pulumi/issues/17525 

When converting YAML templates to PCL, emits invoke options as third argument to the `invoke` function