### PR TITLE
Don't parse runtime options at startup

### DIFF
--- a/.changes/unreleased/Bug Fixes-451.yaml
+++ b/.changes/unreleased/Bug Fixes-451.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Don't parse runtime options at startup, defer to the options sent for specific methods
+time: 2025-01-31T22:43:32.326053Z
+custom:
+    PR: "451"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -189,7 +189,7 @@ func TestLanguage(t *testing.T) {
 	// Run the language plugin
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
-			host := server.NewLanguageHost(engineAddress, "", "", true /* useRPCLoader */)
+			host := server.NewLanguageHost(engineAddress, "", true /* useRPCLoader */)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},

--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -42,7 +42,7 @@ func main() {
 	var compiler string
 	flag.StringVar(&tracing, "tracing", "", "Emit tracing to a Zipkin-compatible tracing endpoint")
 	flag.StringVar(&root, "root", "", "Root of the program execution")
-	flag.StringVar(&compiler, "compiler", "", "Compiler to use to pre-process YAML")
+	flag.StringVar(&compiler, "compiler", "", "[obsolete] Compiler to use to pre-process YAML")
 	flag.Parse()
 	var cancelChannel chan bool
 	args := flag.Args()
@@ -64,7 +64,7 @@ func main() {
 	// Fire up a gRPC server, letting the kernel choose a free port.
 	port, done, err := rpcutil.Serve(0, cancelChannel, []func(*grpc.Server) error{
 		func(srv *grpc.Server) error {
-			host := server.NewLanguageHost(engineAddress, tracing, compiler, false /* useRPCLoader */)
+			host := server.NewLanguageHost(engineAddress, tracing, false /* useRPCLoader */)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},


### PR DESCRIPTION
Same fix as for dotnet in https://github.com/pulumi/pulumi-dotnet/pull/451.