### PR TITLE
recurse submodules on lint.

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This is needed so go.mod can point to the /pulumi dir
