### PR TITLE
Add a Mise setup

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,15 @@
+[env]
+PULUMI_ROOT = "{{env.PWD}}/.root"
+
+_.path = [
+  "{{env.PULUMI_ROOT}}/bin",
+]
+
+[tools]
+go = "1.23"
+golangci-lint = "latest"
+jq = "latest"
+"ubi:cue-lang/cue" = "v0.12.0"
+"ubi:pulumi/pulumictl" = "v0.0.48"
+
+[plugins]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 # Contributing
 
+## Getting started
+
+The tools for this repository can be installed using [`mise`][mise]. Once your
+shell has been configured to [activate `mise`][activate-mise], navigate to the
+repository, run `mise trust` to allow the installation of the tools listed in
+`.mise.toml`, and then `mise install` to install anything missing.
+
 ## Changelog
 
 Changelog management is done via [`changie`](https://changie.dev/).
@@ -27,3 +34,6 @@ $ git commit -m "Changelog for $(changie latest)"
 ```
 
 After the release, also bump the version in `pulumi/pulumi`.  Do this by updating the version in the [get-language-providers.sh script](https://github.com/pulumi/pulumi/blob/master/scripts/get-language-providers.sh#L35) in the pulumi/pulumi repository.
+
+[mise]: https://mise.jdx.dev/getting-started.html#installing-mise-cli
+[activate-mise]: https://mise.jdx.dev/getting-started.html#activate-mise


### PR DESCRIPTION
While I'm installing everything, I thought I'd try to make things consistent.
This mirrors the `pulumi/pulumi` PR here: https://github.com/pulumi/pulumi/pull/18626/

This commit adds a quick intro for `mise` as a tool for building the repository, and a minimal `.mise.toml` to include all the dependencies required to run the `make` commands.