### PR TITLE
fix gitmodules indentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pulumi"]
 	path = pulumi
 	url = git@github.com:pulumi/pulumi.git
-  branch = master
+	branch = master


### PR DESCRIPTION
Just a tiny cleanup that was missed in https://github.com/pulumi/pulumi-yaml/pull/727#discussion_r1963259374. (probably force pushed over accidentally)

/cc @brandonpollack23 