### PR TITLE
Fix package naming for git plugins

### DIFF
--- a/.changes/unreleased/Bug Fixes-734.yaml
+++ b/.changes/unreleased/Bug Fixes-734.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Fix package name passed to the engine
+time: 2025-03-06T17:19:08.936114671+01:00
+custom:
+  PR: "734"

--- a/pkg/pulumiyaml/packages/file.go
+++ b/pkg/pulumiyaml/packages/file.go
@@ -9,10 +9,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"gopkg.in/yaml.v3"
 )
 
@@ -159,8 +162,17 @@ func ToPackageDescriptors(packages []PackageDecl) (map[tokens.Package]*schema.Pa
 			version = &v
 		}
 
+		internalName := pkg.Name
+		if strings.HasPrefix(pkg.DownloadURL, "git://") {
+			spec, err := workspace.NewPluginSpec(strings.TrimPrefix(pkg.DownloadURL, "git://"), apitype.ResourcePlugin, nil, "", nil)
+			if err != nil {
+				return nil, err
+			}
+			internalName = spec.Name
+		}
+
 		packageDescriptors[tokens.Package(name)] = &schema.PackageDescriptor{
-			Name:             pkg.Name,
+			Name:             internalName,
 			Version:          version,
 			DownloadURL:      pkg.DownloadURL,
 			Parameterization: parameterization,

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -830,12 +830,12 @@ func (r *Runner) Evaluate(ctx *pulumi.Context) syntax.Diagnostics {
 
 	// Register package refs for all packages we know upfront
 	packageRefs := make(map[tokens.Package]string)
-	for _, pkg := range r.packageDescriptors {
+	for key, pkg := range r.packageDescriptors {
 		name := pkg.Name
 		// If parametrized use the parametrized name
 		var parameterization *pulumirpc.Parameterization
 		if pkg.Parameterization != nil {
-			name = pkg.Parameterization.Name
+			key = tokens.Package(pkg.Parameterization.Name)
 
 			parameterization = &pulumirpc.Parameterization{
 				Name:    pkg.Parameterization.Name,
@@ -859,7 +859,7 @@ func (r *Runner) Evaluate(ctx *pulumi.Context) syntax.Diagnostics {
 			err = fmt.Errorf("registering package %s: %w", name, err)
 			return syntax.Diagnostics{syntax.Error(nil, err.Error(), "")}
 		}
-		packageRefs[tokens.Package(name)] = resp.Ref
+		packageRefs[key] = resp.Ref
 	}
 
 	return r.Run(programEvaluator{


### PR DESCRIPTION
Currently package references in YAML are not correctly dealing with names for Git plugins.  Package references are supposed to use the fully qualified name for the package, which for Git plugins includes the whole URL slightly mangled.  Use that.

Fixes https://github.com/pulumi/pulumi/issues/18805