### PR TITLE
gofumpt yaml repository

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters:
   enable-all: false
   enable:
     - errcheck
-    - gofmt
+    - gofumpt
     - revive
     - gosec
     - govet

--- a/cmd/pulumi-converter-yaml/main.go
+++ b/cmd/pulumi-converter-yaml/main.go
@@ -37,8 +37,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-type yamlConverter struct {
-}
+type yamlConverter struct{}
 
 func (*yamlConverter) Close() error {
 	return nil

--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -98,7 +98,6 @@ func setupHealthChecks(engineAddress string) (chan bool, error) {
 		close(cancelChannel)
 	}()
 	err := rpcutil.Healthcheck(ctx, engineAddress, 5*time.Minute, cancel)
-
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -55,7 +55,6 @@ func main() {
 		engineAddress = args[0]
 		var err error
 		cancelChannel, err = setupHealthChecks(engineAddress)
-
 		if err != nil {
 			cmdutil.Exit(errors.Wrapf(err, "could not start health check host RPC server"))
 		}

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -285,8 +285,8 @@ func (d *ConfigParamDecl) recordSyntax() *syntax.Node {
 }
 
 func ConfigParamSyntax(node *syntax.ObjectNode, typ *StringExpr, name *StringExpr,
-	secret *BooleanExpr, defaultValue Expr) *ConfigParamDecl {
-
+	secret *BooleanExpr, defaultValue Expr,
+) *ConfigParamDecl {
 	return &ConfigParamDecl{
 		declNode: decl(node),
 		Type:     typ,
@@ -334,8 +334,8 @@ func ResourceOptionsSyntax(node *syntax.ObjectNode,
 	deleteBeforeReplace *BooleanExpr, dependsOn Expr, ignoreChanges *StringListDecl, importID *StringExpr,
 	parent Expr, protect Expr, provider, providers Expr, version *StringExpr,
 	pluginDownloadURL *StringExpr, replaceOnChanges *StringListDecl,
-	retainOnDelete *BooleanExpr, deletedWith Expr) ResourceOptionsDecl {
-
+	retainOnDelete *BooleanExpr, deletedWith Expr,
+) ResourceOptionsDecl {
 	return ResourceOptionsDecl{
 		declNode:                decl(node),
 		AdditionalSecretOutputs: additionalSecretOutputs,
@@ -360,8 +360,8 @@ func ResourceOptions(additionalSecretOutputs, aliases *StringListDecl,
 	customTimeouts *CustomTimeoutsDecl, deleteBeforeReplace *BooleanExpr,
 	dependsOn Expr, ignoreChanges *StringListDecl, importID *StringExpr, parent Expr,
 	protect Expr, provider, providers Expr, version *StringExpr, pluginDownloadURL *StringExpr,
-	replaceOnChanges *StringListDecl, retainOnDelete *BooleanExpr, deletedWith Expr) ResourceOptionsDecl {
-
+	replaceOnChanges *StringListDecl, retainOnDelete *BooleanExpr, deletedWith Expr,
+) ResourceOptionsDecl {
 	return ResourceOptionsSyntax(nil, additionalSecretOutputs, aliases, customTimeouts,
 		deleteBeforeReplace, dependsOn, ignoreChanges, importID, parent, protect, provider, providers,
 		version, pluginDownloadURL, replaceOnChanges, retainOnDelete, deletedWith)
@@ -433,7 +433,8 @@ func (*ResourceDecl) Fields() []string {
 }
 
 func ResourceSyntax(node *syntax.ObjectNode, typ *StringExpr, name *StringExpr, defaultProvider *BooleanExpr,
-	properties PropertyMapDecl, options ResourceOptionsDecl, get GetResourceDecl) *ResourceDecl {
+	properties PropertyMapDecl, options ResourceOptionsDecl, get GetResourceDecl,
+) *ResourceDecl {
 	return &ResourceDecl{
 		declNode:        decl(node),
 		Type:            typ,
@@ -451,7 +452,8 @@ func Resource(
 	defaultProvider *BooleanExpr,
 	properties PropertyMapDecl,
 	options ResourceOptionsDecl,
-	get GetResourceDecl) *ResourceDecl {
+	get GetResourceDecl,
+) *ResourceDecl {
 	return ResourceSyntax(nil, typ, name, defaultProvider, properties, options, get)
 }
 
@@ -520,8 +522,8 @@ func (d *TemplateDecl) NewDiagnosticWriter(w io.Writer, width uint, color bool) 
 }
 
 func TemplateSyntax(node *syntax.ObjectNode, description *StringExpr, configuration ConfigMapDecl,
-	variables VariablesMapDecl, resources ResourcesMapDecl, outputs PropertyMapDecl) *TemplateDecl {
-
+	variables VariablesMapDecl, resources ResourcesMapDecl, outputs PropertyMapDecl,
+) *TemplateDecl {
 	return &TemplateDecl{
 		syntax:        node,
 		Description:   description,
@@ -533,8 +535,8 @@ func TemplateSyntax(node *syntax.ObjectNode, description *StringExpr, configurat
 }
 
 func Template(description *StringExpr, configuration ConfigMapDecl, variables VariablesMapDecl, resources ResourcesMapDecl,
-	outputs PropertyMapDecl) *TemplateDecl {
-
+	outputs PropertyMapDecl,
+) *TemplateDecl {
 	return TemplateSyntax(nil, description, configuration, variables, resources, outputs)
 }
 
@@ -547,10 +549,12 @@ func ParseTemplate(source []byte, node syntax.Node) (*TemplateDecl, syntax.Diagn
 	return &template, diags
 }
 
-var parseDeclType = reflect.TypeOf((*parseDecl)(nil)).Elem()
-var nonNilDeclType = reflect.TypeOf((*nonNilDecl)(nil)).Elem()
-var recordDeclType = reflect.TypeOf((*recordDecl)(nil)).Elem()
-var exprType = reflect.TypeOf((*Expr)(nil)).Elem()
+var (
+	parseDeclType  = reflect.TypeOf((*parseDecl)(nil)).Elem()
+	nonNilDeclType = reflect.TypeOf((*nonNilDecl)(nil)).Elem()
+	recordDeclType = reflect.TypeOf((*recordDecl)(nil)).Elem()
+	exprType       = reflect.TypeOf((*Expr)(nil)).Elem()
+)
 
 func parseField(name string, dest reflect.Value, node syntax.Node) syntax.Diagnostics {
 	if node == nil {

--- a/pkg/pulumiyaml/codegen/eject.go
+++ b/pkg/pulumiyaml/codegen/eject.go
@@ -22,7 +22,6 @@ var ProjectKeysToOmit = []string{"configuration", "resources", "outputs", "varia
 // Eject on a YAML program directory returns a Pulumi Project and a YAML program which has been
 // parsed and converted to the intermediate PCL language
 func Eject(dir string, loader schema.ReferenceLoader) (*workspace.Project, *pcl.Program, error) {
-
 	// `*pcl.Program`'s maintains an internal reference to the loader that was used during
 	// its creation. This means the lifetime of the returned program is tied to the
 	// lifetime of the loader passed to EjectProgram and ultimately to the host that
@@ -74,7 +73,6 @@ func getProjectPath(dir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to find current Pulumi project because of "+
 			"an error when searching for the Pulumi.yaml file (searching upwards from %s)"+": %w", dir, err)
-
 	} else if path == "" {
 		return "", fmt.Errorf(
 			"no Pulumi.yaml project file found (searching upwards from %s). If you have not "+

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -73,7 +73,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 		return err
 	}
 	// Pulumi.yaml always needs to be written to the root directory
-	err = os.WriteFile(path.Join(directory, "Pulumi.yaml"), projectBytes, 0600)
+	err = os.WriteFile(path.Join(directory, "Pulumi.yaml"), projectBytes, 0o600)
 	if err != nil {
 		return fmt.Errorf("write output project: %w", err)
 	}
@@ -81,7 +81,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 	// If main is set the Main.yaml file should be in a subdirectory
 	if project.Main != "" {
 		directory = path.Join(directory, project.Main)
-		err := os.MkdirAll(directory, 0700)
+		err := os.MkdirAll(directory, 0o700)
 		if err != nil {
 			return fmt.Errorf("create output directory: %w", err)
 		}
@@ -89,7 +89,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 
 	for filename, data := range files {
 		outPath := path.Join(directory, filename)
-		err := os.WriteFile(outPath, data, 0600)
+		err := os.WriteFile(outPath, data, 0o600)
 		if err != nil {
 			return fmt.Errorf("write output program: %w", err)
 		}
@@ -331,7 +331,6 @@ func AppendTraversal(tl TraversalList, t Traversal) TraversalList {
 // - "foo"bar"
 // - "foo\\"bar"
 func isEscapedString(s string) bool {
-
 	if !strings.HasPrefix(s, `"`) {
 		return false
 	}
@@ -361,7 +360,6 @@ func isEscapedString(s string) bool {
 }
 
 func (g *generator) Traversal(traversal hcl.Traversal) Traversal {
-
 	var segments []TraversalSegment
 	if !traversal.IsRelative() {
 		traversal = traversal.SimpleSplit().Rel

--- a/pkg/pulumiyaml/codegen/gen_program_test.go
+++ b/pkg/pulumiyaml/codegen/gen_program_test.go
@@ -233,7 +233,6 @@ func TestGenerateProgram(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Falsef(t, diags.HasErrors(), "%s", diags.Error())
 		err = pulumi.RunErr(func(ctx *pulumi.Context) error {
-
 			return pulumiyaml.RunTemplate(ctx, templateDecl, nil, nil, testPackageLoader{t})
 		}, pulumi.WithMocks("test", "gen", &testMonitor{}), func(ri *pulumi.RunInfo) { ri.DryRun = true })
 		assert.NoError(t, err)

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -996,7 +996,6 @@ func (imp *importer) assignNames() {
 
 	assign := func(name, suffix string) *model.Variable {
 		assignName := func(name, suffix string) string {
-
 			name = camel(makeLegalIdentifier(name))
 			if !assigned.Has(name) {
 				assigned.Add(name)
@@ -1149,7 +1148,6 @@ func (imp *importer) importTemplate(file *ast.TemplateDecl) (*model.Body, syntax
 	body := &model.Body{Items: items}
 	formatBody(body)
 	return body, diags
-
 }
 
 // ImportTemplate converts a YAML template to a PCL definition.

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -289,7 +289,8 @@ var helmResourceNames = map[string]struct{}{
 // both the package and the canonical name.
 func ResolveResource(ctx context.Context, loader PackageLoader,
 	descriptors map[tokens.Package]*schema.PackageDescriptor,
-	typeString string, version *semver.Version) (Package, ResourceTypeToken, error) {
+	typeString string, version *semver.Version,
+) (Package, ResourceTypeToken, error) {
 	if issue, found := kubernetesResourceNames[typeString]; found {
 		return nil, "", fmt.Errorf("The resource type [%v] is not supported in YAML at this time, see: %v", typeString, issue)
 	}
@@ -325,7 +326,8 @@ func ResolveResource(ctx context.Context, loader PackageLoader,
 // both the package and the canonical name.
 func ResolveFunction(ctx context.Context, loader PackageLoader,
 	descriptors map[tokens.Package]*schema.PackageDescriptor,
-	typeString string, version *semver.Version) (Package, FunctionTypeToken, error) {
+	typeString string, version *semver.Version,
+) (Package, FunctionTypeToken, error) {
 	pkg, err := loadPackage(ctx, loader, descriptors, typeString, version)
 	if err != nil {
 		return nil, "", err

--- a/pkg/pulumiyaml/run_async_diags_test.go
+++ b/pkg/pulumiyaml/run_async_diags_test.go
@@ -28,14 +28,17 @@ func (l *interceptingLog) Debug(msg string, args *pulumi.LogArgs) error {
 	l.debugMessages = append(l.debugMessages, msg)
 	return nil
 }
+
 func (l *interceptingLog) Info(msg string, args *pulumi.LogArgs) error {
 	l.infoMessages = append(l.infoMessages, msg)
 	return nil
 }
+
 func (l *interceptingLog) Warn(msg string, args *pulumi.LogArgs) error {
 	l.warnMessages = append(l.warnMessages, msg)
 	return nil
 }
+
 func (l *interceptingLog) Error(msg string, args *pulumi.LogArgs) error {
 	l.errorMessages = append(l.errorMessages, msg)
 	return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -541,7 +541,7 @@ func (host *yamlLanguageHost) GeneratePackage(ctx context.Context, req *pulumirp
 
 func (host *yamlLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackRequest) (*pulumirpc.PackResponse, error) {
 	// Yaml "SDKs" are just files, we can just copy the file
-	if err := os.MkdirAll(req.DestinationDirectory, 0700); err != nil {
+	if err := os.MkdirAll(req.DestinationDirectory, 0o700); err != nil {
 		return nil, err
 	}
 

--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -117,7 +117,6 @@ func TestExampleStackreference(t *testing.T) {
 
 				return nil
 			})
-
 			if err != nil {
 				return err
 			}

--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -110,7 +110,7 @@ func TestExampleStackreference(t *testing.T) {
 				template = strings.ReplaceAll(template, "PLACEHOLDER_ORG_NAME", org)
 				template = strings.ReplaceAll(template, "PLACEHOLDER_STACK_NAME", sourceStackName)
 				//nolint:gosec // temporary file, no secrets, non-executable
-				err = os.WriteFile(path, []byte(template), 0644)
+				err = os.WriteFile(path, []byte(template), 0o644)
 				if err != nil {
 					return err
 				}

--- a/pkg/tests/example_transpile_test.go
+++ b/pkg/tests/example_transpile_test.go
@@ -176,20 +176,21 @@ func getValidPCLFile(t *testing.T, file *ast.TemplateDecl, fileName string) ([]b
 		return []byte(program), diags, nil
 	}
 	return []byte(program), diags, nil
-
 }
 
-type ConvertFunc = func(t *testing.T, projectDir string)
-type CheckFunc = func(t *testing.T, projectDir string, deps pcodegen.StringSet)
+type (
+	ConvertFunc = func(t *testing.T, projectDir string)
+	CheckFunc   = func(t *testing.T, projectDir string, deps pcodegen.StringSet)
+)
 
 func writeOrCompare(t *testing.T, dir string, files map[string][]byte) {
 	pulumiAccept := cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT"))
 	for path, bytes := range files {
 		path = filepath.Join(dir, filepath.FromSlash(path))
 		if pulumiAccept {
-			err := os.MkdirAll(filepath.Dir(path), 0700)
+			err := os.MkdirAll(filepath.Dir(path), 0o700)
 			require.NoError(t, err)
-			err = os.WriteFile(path, bytes, 0600)
+			err = os.WriteFile(path, bytes, 0o600)
 			require.NoError(t, err)
 		} else {
 			expected, err := os.ReadFile(path)

--- a/scripts/gocov/main.go
+++ b/scripts/gocov/main.go
@@ -232,7 +232,7 @@ func (cmd *mainCmd) run(p *params) (err error) {
 	if !filepath.IsAbs(p.CoverDir) {
 		p.CoverDir = filepath.Join(cwd, p.CoverDir)
 	}
-	if err := os.MkdirAll(p.CoverDir, 0755); err != nil {
+	if err := os.MkdirAll(p.CoverDir, 0o755); err != nil {
 		return fmt.Errorf("set up coverage dir: %w", err)
 	}
 
@@ -343,7 +343,8 @@ func (cmd *mainCmd) buildPackage(r buildPackageRequest) (string, error) {
 		}
 	}
 
-	args := []string{"test", "-c",
+	args := []string{
+		"test", "-c",
 		"-cover",
 		"-coverpkg=" + strings.Join(r.CoverPkgs, ","),
 		"-o", binPath,


### PR DESCRIPTION
`pulumi/pulumi` requires all files to be formatted with `gofumpt`, and enforces that with a linter.  Do the same for the YAML repository for consistency.

Not having this `gofumpt`ed is especially annoying as I have an editor extension that does just that on every save, so I'd need to treat this repo specially in my editor.  Having it `gofumpt`ed seems like a good change either way, so do that, and make my life a bit easier for further changes that are going to be introduced.

No functional changes intended.