### PR TITLE
factor out a `Template` interface and use it in the runner

### DIFF
--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -482,6 +482,18 @@ func CustomTimeouts(create, update, delete *StringExpr) *CustomTimeoutsDecl {
 	return CustomTimeoutsSyntax(nil, create, update, delete)
 }
 
+type Template interface {
+	GetName() *StringExpr
+	GetDescription() *StringExpr
+	GetConfig() ConfigMapDecl
+	GetVariables() VariablesMapDecl
+	GetResources() ResourcesMapDecl
+	GetOutputs() PropertyMapDecl
+	GetPackages() []packages.PackageDecl
+
+	NewDiagnosticWriter(w io.Writer, width uint, color bool) hcl.DiagnosticWriter
+}
+
 // A TemplateDecl represents a Pulumi YAML template.
 type TemplateDecl struct {
 	source []byte
@@ -496,6 +508,56 @@ type TemplateDecl struct {
 	Resources     ResourcesMapDecl
 	Outputs       PropertyMapDecl
 	Packages      []packages.PackageDecl
+}
+
+func (d *TemplateDecl) GetName() *StringExpr {
+	if d == nil {
+		return nil
+	}
+	return d.Name
+}
+
+func (d *TemplateDecl) GetDescription() *StringExpr {
+	if d == nil {
+		return nil
+	}
+	return d.Description
+}
+
+func (d *TemplateDecl) GetConfig() ConfigMapDecl {
+	if d == nil {
+		return ConfigMapDecl{}
+	}
+	// TODO: merge config and configuration (?)
+	return d.Configuration
+}
+
+func (d *TemplateDecl) GetVariables() VariablesMapDecl {
+	if d == nil {
+		return VariablesMapDecl{}
+	}
+	return d.Variables
+}
+
+func (d *TemplateDecl) GetResources() ResourcesMapDecl {
+	if d == nil {
+		return ResourcesMapDecl{}
+	}
+	return d.Resources
+}
+
+func (d *TemplateDecl) GetOutputs() PropertyMapDecl {
+	if d == nil {
+		return PropertyMapDecl{}
+	}
+	return d.Outputs
+}
+
+func (d *TemplateDecl) GetPackages() []packages.PackageDecl {
+	if d == nil {
+		return nil
+	}
+	return d.Packages
 }
 
 func (d *TemplateDecl) Syntax() syntax.Node {
@@ -532,12 +594,6 @@ func TemplateSyntax(node *syntax.ObjectNode, description *StringExpr, configurat
 		Resources:     resources,
 		Outputs:       outputs,
 	}
-}
-
-func Template(description *StringExpr, configuration ConfigMapDecl, variables VariablesMapDecl, resources ResourcesMapDecl,
-	outputs PropertyMapDecl,
-) *TemplateDecl {
-	return TemplateSyntax(nil, description, configuration, variables, resources, outputs)
 }
 
 // ParseTemplate parses a template from the given syntax node. The source text is optional, and is only used to print

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -245,7 +245,7 @@ func HasDiagnostics(err error) (syntax.Diagnostics, bool) {
 // validateResources does some basic validation of each resource to provide
 // error messages for any missing required fields.
 func (r *Runner) validateResources() {
-	for _, resource := range r.t.Resources.Entries {
+	for _, resource := range r.t.GetResources().Entries {
 		v := resource.Value
 		if v.Type == nil {
 			r.sdiags.Extend(syntax.NodeError(
@@ -262,7 +262,7 @@ func (r *Runner) validateResources() {
 // that should prevent proceeding.
 func (r *Runner) setDefaultProviders() {
 	defaultProviderInfoMap := make(map[string]*providerInfo)
-	for _, resource := range r.t.Resources.Entries {
+	for _, resource := range r.t.GetResources().Entries {
 		v := resource.Value
 		// check if this is a provider resource
 		if v.Type != nil && strings.HasPrefix(v.Type.Value, "pulumi:providers:") {
@@ -380,7 +380,7 @@ func (r *Runner) setDefaultProviders() {
 // Set the runner's package descriptors from the templates package decls.
 func (r *Runner) setPackageDesciptors() error {
 	// Register package refs for all packages we know upfront
-	packageDescriptors, err := packages.ToPackageDescriptors(r.t.Packages)
+	packageDescriptors, err := packages.ToPackageDescriptors(r.t.GetPackages())
 	if err != nil {
 		return err
 	}
@@ -478,7 +478,7 @@ type providerInfo struct {
 }
 
 type Runner struct {
-	t                  *ast.TemplateDecl
+	t                  ast.Template
 	packageDescriptors map[tokens.Package]*schema.PackageDescriptor
 
 	pkgLoader PackageLoader
@@ -689,7 +689,7 @@ func isPoisoned(v interface{}) (poisonMarker, bool) {
 	return poisonMarker{}, false
 }
 
-func newRunner(t *ast.TemplateDecl, p PackageLoader) *Runner {
+func newRunner(t ast.Template, p PackageLoader) *Runner {
 	return &Runner{
 		t:         t,
 		pkgLoader: p,
@@ -993,7 +993,7 @@ func (r *Runner) Run(e Evaluator) syntax.Diagnostics {
 		}
 	}
 
-	for _, kvp := range r.t.Outputs.Entries {
+	for _, kvp := range r.t.GetOutputs().Entries {
 		if !e.EvalOutput(r, kvp) {
 			return returnDiags()
 		}

--- a/pkg/pulumiyaml/sort.go
+++ b/pkg/pulumiyaml/sort.go
@@ -87,7 +87,7 @@ func (missingNode) valueKind() string {
 	return "missing node"
 }
 
-func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNode) ([]graphNode, syntax.Diagnostics) {
+func topologicallySortedResources(t ast.Template, externalConfig []configNode) ([]graphNode, syntax.Diagnostics) {
 	var diags syntax.Diagnostics
 
 	var sorted []graphNode        // will hold the sorted vertices.
@@ -120,8 +120,8 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 
 	dependencies := map[string][]*ast.StringExpr{}
 
-	templateConfig := make([]configNode, len(t.Configuration.Entries))
-	for i, kvp := range t.Configuration.Entries {
+	templateConfig := make([]configNode, len(t.GetConfig().Entries))
+	for i, kvp := range t.GetConfig().Entries {
 		templateConfig[i] = configNode(configNodeYaml(kvp))
 	}
 	for _, node := range append(templateConfig, externalConfig...) {
@@ -141,7 +141,7 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 
 	// Map of package name to default provider resource and it's key.
 	defaultProviders := map[string]*ast.StringExpr{}
-	for _, kvp := range t.Resources.Entries {
+	for _, kvp := range t.GetResources().Entries {
 		rname, r := kvp.Key.Value, kvp.Value
 		node := resourceNode(kvp)
 
@@ -159,7 +159,7 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 			dependencies[rname] = GetResourceDependencies(r)
 		}
 	}
-	for _, kvp := range t.Variables.Entries {
+	for _, kvp := range t.GetVariables().Entries {
 		vname := kvp.Key.Value
 		node := variableNode(kvp)
 
@@ -187,7 +187,7 @@ func topologicallySortedResources(t *ast.TemplateDecl, externalConfig []configNo
 
 		e, ok := intermediates[name.Value]
 		if !ok {
-			s := stripConfigNamespace(t.Name.Value, name.Value)
+			s := stripConfigNamespace(t.GetName().Value, name.Value)
 			if e2, ok := intermediates[s]; ok {
 				e = e2
 			} else {


### PR DESCRIPTION
In subsequent PRs we're going to introduce components into yaml.  A YAML program will be able to have multiple components, that will be run similar to programs, but won't have all the parts of programs. E.g. a YAML template will be able to include components, but components won't be able to have further components.  Or components won't have packages just for the component itself (but will respect the global packages).

To be able to reuse the runner for running components, factor out a template interface and use it.

No functional changes intended.

Depends on https://github.com/pulumi/pulumi-yaml/pull/739.