### PR TITLE
log only part of stdout in conformance tests

### DIFF
--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -182,6 +182,16 @@ var expectedFailures = map[string]string{
 	"l2-explicit-parameterized-provider":    "unexpected provider request with no version",
 }
 
+func log(t *testing.T, name, message string) {
+	if os.Getenv("PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT") != "true" {
+		// Cut down logs so they don't overwhelm the test output
+		if len(message) > 1024 {
+			message = message[:1024] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
+		}
+	}
+	t.Logf("%s: %s", name, message)
+}
+
 func TestLanguage(t *testing.T) {
 	t.Parallel()
 
@@ -234,8 +244,8 @@ func TestLanguage(t *testing.T) {
 			for _, msg := range result.Messages {
 				t.Log(msg)
 			}
-			t.Logf("stdout: %s", result.Stdout)
-			t.Logf("stderr: %s", result.Stderr)
+			log(t, "stdout", result.Stdout)
+			log(t, "stderr", result.Stderr)
 			assert.True(t, result.Success)
 		})
 	}


### PR DESCRIPTION
The output of these conformance tests can become huge in some cases. We always log the whole stdout and stderr here, which includes all the outputs for conformance tests.

In this repo we run the tests with `-v`, so if any test fails, we print the output of all conformance tests in full.  This can become so big that GitHub actions can no longer handle the text, and just gives a generic "Error: " message, which is useless for debugging what's happening, or even seeing which test failed.

Similar to how we already clamp down the logs sent to the engine, also clamp down this log, with the option of showing the full log if desired.

Arguably we could run the tests without passing `-v` to `go test`, but that just means that if a conformance test with such a long output fails we end up in the same position again, struggling to debug.

We should probably implement the same in other languages as well, but it's less noticable there because we don't run the tests in `pulumi/pulumi` with `-v`.

Will hopefully help debug https://github.com/pulumi/pulumi-yaml/issues/738, as CI in this repo is currently completely broken.