### PR TITLE
remove PULUMI_STACK from test to check if we keep conflicting values

### DIFF
--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -130,7 +130,6 @@ func TestEnvVarsKeepConflictingValues(t *testing.T) {
 	testOptions := integration.ProgramTestOptions{
 		Dir: filepath.Join(getCwd(t), "testdata", "env-vars"),
 		Env: []string{
-			"PULUMI_STACK=foo",
 			"PULUMI_PROJECT=bar",
 			"PULUMI_ORGANIZATION=foobar",
 			"PULUMI_CONFIG=bazz",
@@ -139,7 +138,6 @@ func TestEnvVarsKeepConflictingValues(t *testing.T) {
 		StackName:       "dev",
 		SecretsProvider: "default",
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			assert.Equal(t, `foo`, stack.Outputs["PULUMI_STACK"])
 			assert.Equal(t, `bar`, stack.Outputs["PULUMI_PROJECT"])
 			assert.Equal(t, `foobar`, stack.Outputs["PULUMI_ORGANIZATION"])
 			assert.EqualValues(t, "bazz", stack.Outputs["PULUMI_CONFIG"])


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/18717, PULUMI_STACK is used to select the stack we're using.  Therefore it is now impossible for the env var to conflict with the stack we're using.  Just remove the test for `PULUMI_STACK` from this test, as it's impossible to make it conflict with the stack that's actually going to be used, which is what the test is testing.

There are other tests that check that `PULUMI_STACK` is set correctly.

Fixes https://github.com/pulumi/pulumi-yaml/issues/738