### PR TITLE
implement schema generation for yaml components

### DIFF
--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -3,6 +3,7 @@
 package ast
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -165,56 +166,118 @@ func TestComponentSchemaGeneration(t *testing.T) {
 	spec, err := template.GenerateSchema()
 	require.NoError(t, err)
 
-	require.Equal(t, "yaml-plugin", spec.Name)
-	require.Equal(t, "A YAML plugin", spec.Description)
+	marshalled, err := json.Marshal(spec)
+	require.NoError(t, err)
 
-	require.Equal(t, 1, len(spec.Resources))
-	res, ok := spec.Resources["yaml-plugin:index:aComponent"]
-	require.True(t, ok, "expected resource yaml-plugin:index:aComponent")
-
-	require.True(t, res.IsComponent, "expected resource to be a component")
-	require.Equal(t, "A component", res.Description)
-
-	inputs := res.InputProperties
-	require.Equal(t, 7, len(inputs))
-
-	stringArray, ok := inputs["someStringArray"]
-	require.True(t, ok, "expected input someStringArray")
-	require.Equal(t, "array", stringArray.Type)
-	require.Equal(t, "string", stringArray.Items.Type)
-
-	aString, ok := inputs["aString"]
-	require.True(t, ok, "expected input aString")
-	require.Equal(t, "string", aString.Type)
-
-	aNumber, ok := inputs["aNumber"]
-	require.True(t, ok, "expected input aNumber")
-	require.Equal(t, "integer", aNumber.Type)
-
-	aBoolean, ok := inputs["aBoolean"]
-	require.True(t, ok, "expected input aBoolean")
-	require.Equal(t, "boolean", aBoolean.Type)
-
-	aStringWithDefault, ok := inputs["aStringWithDefault"]
-	require.True(t, ok, "expected input aStringWithDefault")
-	require.Equal(t, "string", aStringWithDefault.Type)
-
-	aNumberWithDefault, ok := inputs["aNumberWithDefault"]
-	require.True(t, ok, "expected input aNumberWithDefault")
-	require.Equal(t, "integer", aNumberWithDefault.Type)
-
-	aBooleanWithDefault, ok := inputs["aBooleanWithDefault"]
-	require.True(t, ok, "expected input aBooleanWithDefault")
-	require.Equal(t, "boolean", aBooleanWithDefault.Type)
-
-	require.EqualValues(t, []string{"someStringArray", "aString", "aNumber", "aBoolean"}, res.RequiredInputs)
-
-	outputs := res.Properties
-	require.Equal(t, 1, len(outputs))
-
-	someOutput, ok := outputs["someOutput"]
-	require.True(t, ok, "expected output someOutput")
-	require.Equal(t, "pulumi.json#/Any", someOutput.Ref)
-
-	require.EqualValues(t, []string{"someOutput"}, res.Required)
+	expectedSchema := `
+{
+  "name": "yaml-plugin",
+  "description": "A YAML plugin",
+  "language": {
+    "cshap": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "respectSchemaVersion": true
+    },
+    "java": {
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
+  },
+  "config": {},
+  "provider": {},
+  "resources": {
+    "yaml-plugin:index:aComponent": {
+      "description": "A component",
+      "properties": {
+        "someOutput": {
+          "$ref": "pulumi.json#/Any"
+        }
+      },
+      "type": "yaml-plugin:index:aComponent",
+      "required": [
+        "someOutput"
+      ],
+      "inputProperties": {
+        "aBoolean": {
+          "type": "boolean",
+          "defaultInfo": {
+            "environment": [
+              "aBoolean"
+            ]
+          }
+        },
+        "aBooleanWithDefault": {
+          "type": "boolean",
+          "default": true,
+          "defaultInfo": {
+            "environment": [
+              "aBooleanWithDefault"
+            ]
+          }
+        },
+        "aNumber": {
+          "type": "integer",
+          "defaultInfo": {
+            "environment": [
+              "aNumber"
+            ]
+          }
+        },
+        "aNumberWithDefault": {
+          "type": "integer",
+          "default": 42,
+          "defaultInfo": {
+            "environment": [
+              "aNumberWithDefault"
+            ]
+          }
+        },
+        "aString": {
+          "type": "string",
+          "defaultInfo": {
+            "environment": [
+              "aString"
+            ]
+          }
+        },
+        "aStringWithDefault": {
+          "type": "string",
+          "default": "default",
+          "defaultInfo": {
+            "environment": [
+              "aStringWithDefault"
+            ]
+          }
+        },
+        "someStringArray": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "defaultInfo": {
+            "environment": [
+              "someStringArray"
+            ]
+          }
+        }
+      },
+      "requiredInputs": [
+        "someStringArray",
+        "aString",
+        "aNumber",
+        "aBoolean"
+      ],
+      "isComponent": true
+    }
+  }
+}
+`
+	require.JSONEq(t, expectedSchema, string(marshalled))
 }


### PR DESCRIPTION
For components to work we need to generate their schema.  In YAML we currently only support strings, integers, booleans and arrays as types for config declarations, so let's support the same thing for YAML components for now.

Outputs types are not super straightforward to infer, so right now we're sticking to `pulumi.json/#Any`.  In future revisions we can support more accurate types here.

The schema generation is still not visible to the user in any way, exposing things will be the next step.

Fixes https://github.com/pulumi/pulumi-yaml/issues/745