### PR TITLE
implement YAML plugin running

### DIFF
--- a/.changes/unreleased/Improvements-749.yaml
+++ b/.changes/unreleased/Improvements-749.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Allow authoring components in YAML
+time: 2025-03-14T10:16:05.555834834+01:00
+custom:
+  PR: "749"

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -178,19 +178,19 @@ func LoadPluginTemplate(directory string) (*ast.TemplateDecl, syntax.Diagnostics
 				continue
 			}
 			if len(t.Configuration.Entries) > 0 {
-				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `configuration` is not supported in plugins", ""))
+				diags.Extend(syntax.Error(nil, "PulumiPlugin.yaml: root-level `configuration` is not supported in plugins", ""))
 			}
 			if len(t.Config.Entries) > 0 {
-				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `config` is not supported in plugins", ""))
+				diags.Extend(syntax.Error(nil, "PulumiPlugin.yaml: root-level `config` is not supported in plugins", ""))
 			}
 			if len(t.Variables.Entries) > 0 {
-				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `variables` field is not supported in plugins.", ""))
+				diags.Extend(syntax.Error(nil, "PulumiPlugin.yaml: root-level `variables` field is not supported in plugins.", ""))
 			}
 			if len(t.Resources.Entries) > 0 {
-				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `resources` field is not supported in plugins.", ""))
+				diags.Extend(syntax.Error(nil, "PulumiPlugin.yaml: root-level `resources` field is not supported in plugins.", ""))
 			}
 			if len(t.Outputs.Entries) > 0 {
-				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `outputs` field is not supported in plugins.", ""))
+				diags.Extend(syntax.Error(nil, "PulumiPlugin.yaml: root-level `outputs` field is not supported in plugins.", ""))
 			}
 
 			err = template.Merge(t)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -146,6 +146,76 @@ func LoadDir(directory string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 	return template, diags, nil
 }
 
+// Load a plugin template from the given directory.
+func LoadPluginTemplate(directory string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
+	// Get all yaml files in the directory, load them and merge them into a single template.
+	files, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, nil, err
+	}
+	var template *ast.TemplateDecl
+	for _, file := range files {
+		if file.IsDir() || filepath.Ext(file.Name()) != ".yaml" {
+			continue
+		}
+
+		f, err := os.Open(filepath.Join(directory, file.Name()))
+		if err != nil {
+			return nil, nil, err
+		}
+		t, diags, err := LoadYAML(file.Name(), f)
+		if err != nil {
+			return nil, diags, err
+		}
+		if diags.HasErrors() {
+			return nil, diags, diags
+		}
+		if template == nil {
+			template = t
+		} else {
+			if t == nil {
+				diags.Extend(syntax.Error(nil, "failed to load template", ""))
+				continue
+			}
+			if len(t.Configuration.Entries) > 0 {
+				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `configuration` is not supported in plugins", ""))
+			}
+			if len(t.Config.Entries) > 0 {
+				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `config` is not supported in plugins", ""))
+			}
+			if len(t.Variables.Entries) > 0 {
+				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `variables` field is not supported in plugins.", ""))
+			}
+			if len(t.Resources.Entries) > 0 {
+				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `resources` field is not supported in plugins.", ""))
+			}
+			if len(t.Outputs.Entries) > 0 {
+				diags.Extend(syntax.Error(nil, "Pulumi.yaml: root-level `outputs` field is not supported in plugins.", ""))
+			}
+
+			err = template.Merge(t)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	componentNames := make(map[string]bool)
+	for _, entry := range template.Components.Entries {
+		if _, ok := componentNames[entry.Value.Name.Value]; ok {
+			return nil, nil, fmt.Errorf("duplicate component name %s", entry.Value.Name.Value)
+		}
+		componentNames[entry.Value.Name.Value] = true
+	}
+	packages, err := packages.SearchPackageDecls(directory)
+	if err != nil {
+		return nil, nil, err
+	}
+	template.Packages = packages
+
+	return template, nil, nil
+}
+
 // Load a template from the current working directory
 func LoadFile(path string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 	f, err := os.Open(path)
@@ -449,6 +519,114 @@ func RunTemplate(ctx *pulumi.Context, t *ast.TemplateDecl, config map[string]str
 		return diags
 	}
 	return nil
+}
+
+func RunComponentTemplate(ctx *pulumi.Context,
+	typ, name string, options pulumi.ResourceOption,
+	t *ast.TemplateDecl, inputs pulumi.Map, loader PackageLoader,
+) (pulumi.URNOutput, pulumi.Map, error) {
+	var templ ast.Template
+	typSplit := strings.Split(typ, ":")
+	if len(typSplit) != 3 {
+		return pulumi.URNOutput{}, nil, errors.New("invalid component type")
+	}
+	for _, comp := range t.Components.Entries {
+		if comp.Key.Value == typSplit[2] {
+			templ = comp.Value
+			break
+		}
+	}
+	runner := newRunner(templ, loader)
+
+	_, diags := TypeCheck(runner)
+	if diags.HasErrors() {
+		return pulumi.URNOutput{}, nil, diags
+	}
+
+	packageRefs, diags := findPackageRefs(ctx, runner)
+	if diags != nil {
+		return pulumi.URNOutput{}, nil, errors.New(diags.Error())
+	}
+
+	component := &componentEvaluator{
+		inputs:  inputs,
+		outputs: pulumi.Map{},
+		evaluator: &programEvaluator{
+			evalContext: runner.newContext(t),
+			pulumiCtx:   ctx,
+			packageRefs: packageRefs,
+		},
+	}
+
+	if err := ctx.RegisterComponentResource(typ, name, component, options); err != nil {
+		return pulumi.URNOutput{}, nil, err
+	}
+
+	diags.Extend(runner.Run(component)...)
+	if diags.HasErrors() {
+		return pulumi.URNOutput{}, nil, diags
+	}
+	if err := ctx.RegisterResourceOutputs(component, component.outputs); err != nil {
+		return pulumi.URNOutput{}, nil, err
+	}
+	return component.URN(), component.outputs, nil
+}
+
+type componentEvaluator struct {
+	pulumi.ResourceState
+
+	inputs  pulumi.Map
+	outputs pulumi.Map
+
+	evaluator *programEvaluator
+}
+
+func (m *componentEvaluator) EvalConfig(r *Runner, node configNode) bool {
+	k := node.key().Value
+	v, ok := m.inputs[k]
+	if ok {
+		r.config[k] = v
+		return true
+	}
+	return m.evaluator.EvalConfig(r, node)
+}
+
+func (m *componentEvaluator) EvalVariable(r *Runner, node variableNode) bool {
+	return m.evaluator.EvalVariable(r, node)
+}
+
+func (m *componentEvaluator) EvalResource(r *Runner, node resourceNode) bool {
+	ctx := r.newContext(node)
+	res, ok := m.evaluator.registerResourceWithParent(node, m)
+	if !ok {
+		msg := fmt.Sprintf("Error registering resource [%v]: %v", node.Key.Value, ctx.sdiags.Error())
+		err := m.evaluator.pulumiCtx.Log.Error(msg, &pulumi.LogArgs{})
+		if err != nil {
+			return false
+		}
+		return false
+	}
+	r.resources[node.Key.Value] = res
+	return true
+}
+
+func (m *componentEvaluator) EvalOutput(r *Runner, node ast.PropertyMapEntry) bool {
+	ctx := r.newContext(node)
+	out, ok := m.evaluator.registerOutput(node)
+	if !ok {
+		msg := fmt.Sprintf("Error registering output [%v]: %v", node.Key.Value, ctx.sdiags.Error())
+		err := m.evaluator.pulumiCtx.Log.Error(msg, &pulumi.LogArgs{})
+		if err != nil {
+			return false
+		}
+	} else {
+		m.outputs[node.Key.Value] = out
+	}
+	return true
+}
+
+func (m *componentEvaluator) EvalMissing(r *Runner, node missingNode) bool {
+	return m.evaluator.EvalMissing(r, node)
 }
 
 type syncDiags struct {
@@ -828,9 +1006,7 @@ func (e programEvaluator) EvalOutput(r *Runner, node ast.PropertyMapEntry) bool 
 	return true
 }
 
-func (r *Runner) Evaluate(ctx *pulumi.Context) syntax.Diagnostics {
-	eCtx := r.newContext(nil)
-
+func findPackageRefs(ctx *pulumi.Context, r *Runner) (map[tokens.Package]string, syntax.Diagnostics) {
 	// Register package refs for all packages we know upfront
 	packageRefs := make(map[tokens.Package]string)
 	for key, pkg := range r.packageDescriptors {
@@ -860,9 +1036,19 @@ func (r *Runner) Evaluate(ctx *pulumi.Context) syntax.Diagnostics {
 		})
 		if err != nil {
 			err = fmt.Errorf("registering package %s: %w", name, err)
-			return syntax.Diagnostics{syntax.Error(nil, err.Error(), "")}
+			return nil, syntax.Diagnostics{syntax.Error(nil, err.Error(), "")}
 		}
 		packageRefs[key] = resp.Ref
+	}
+	return packageRefs, nil
+}
+
+func (r *Runner) Evaluate(ctx *pulumi.Context) syntax.Diagnostics {
+	eCtx := r.newContext(nil)
+
+	packageRefs, diags := findPackageRefs(ctx, r)
+	if diags != nil {
+		return diags
 	}
 
 	return r.Run(programEvaluator{
@@ -1177,6 +1363,10 @@ func (e *programEvaluator) registerConfig(intm configNode) (interface{}, bool) {
 }
 
 func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource, bool) {
+	return e.registerResourceWithParent(kvp, nil)
+}
+
+func (e *programEvaluator) registerResourceWithParent(kvp resourceNode, parent pulumi.Resource) (lateboundResource, bool) {
 	k, v := kvp.Key.Value, kvp.Value
 
 	// Read the properties and then evaluate them in case there are expressions contained inside.
@@ -1226,6 +1416,10 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 
 	if p, isPoison := readIntoProperties(v.Properties); isPoison {
 		return p, isPoison
+	}
+
+	if v.Options.Parent == nil && parent != nil {
+		opts = append(opts, pulumi.Parent(parent))
 	}
 
 	if v.Options.Aliases != nil {

--- a/pkg/server/component_provider.go
+++ b/pkg/server/component_provider.go
@@ -1,0 +1,103 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type componentProvider struct {
+	pulumirpc.UnimplementedResourceProviderServer
+
+	host      *grpc.ClientConn
+	name      string
+	schema    []byte
+	construct provider.ConstructFunc
+}
+
+// GetPluginInfo returns generic information about this plugin, like its version.
+func (p *componentProvider) GetPluginInfo(context.Context, *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
+	// We fill in the version on the engine side for components.
+	return &pulumirpc.PluginInfo{
+		Version: "",
+	}, nil
+}
+
+// GetSchema returns the JSON-encoded schema for this provider's package.
+func (p *componentProvider) GetSchema(ctx context.Context,
+	req *pulumirpc.GetSchemaRequest,
+) (*pulumirpc.GetSchemaResponse, error) {
+	if v := req.GetVersion(); v != 0 {
+		return nil, fmt.Errorf("unsupported schema version %d", v)
+	}
+	return &pulumirpc.GetSchemaResponse{Schema: string(p.schema)}, nil
+}
+
+// Configure configures the resource provider with "globals" that control its behavior.
+func (p *componentProvider) Configure(ctx context.Context,
+	req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	return &pulumirpc.ConfigureResponse{
+		AcceptSecrets:   true,
+		SupportsPreview: true,
+		AcceptResources: true,
+		AcceptOutputs:   true,
+	}, nil
+}
+
+// Construct creates a new instance of the provided component resource and returns its state.
+func (p *componentProvider) Construct(ctx context.Context,
+	req *pulumirpc.ConstructRequest,
+) (*pulumirpc.ConstructResponse, error) {
+	return provider.Construct(ctx, req, p.host, p.construct)
+}
+
+// Call dynamically executes a method in the provider associated with a component resource.
+func (p *componentProvider) Call(ctx context.Context,
+	req *pulumirpc.CallRequest,
+) (*pulumirpc.CallResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "Call is not yet implemented")
+}
+
+// Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
+// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either a
+// creation error or an initialization error). Since Cancel is advisory and non-blocking, it is up
+// to the host to decide how long to wait after Cancel is called before (e.g.)
+// hard-closing any gRPC connection.
+func (p *componentProvider) Cancel(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// Attach attaches to the engine for an already running provider.
+func (p *componentProvider) Attach(ctx context.Context,
+	req *pulumirpc.PluginAttach,
+) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "Attach is not yet implemented")
+}
+
+// GetMapping fetches the conversion mapping (if any) for this resource provider.
+func (p *componentProvider) GetMapping(ctx context.Context,
+	req *pulumirpc.GetMappingRequest,
+) (*pulumirpc.GetMappingResponse, error) {
+	return &pulumirpc.GetMappingResponse{Provider: "", Data: nil}, nil
+}

--- a/pkg/tests/testdata/component/program/Pulumi.yaml
+++ b/pkg/tests/testdata/component/program/Pulumi.yaml
@@ -1,0 +1,19 @@
+name: component-consumer
+runtime: yaml
+plugins:
+  providers:
+    - name: random-plugin-component
+      path: ../provider
+resources:
+  randomPet:
+    type: random-plugin-component:index:randomPetGenerator
+    properties:
+      length: 3
+      prefix: "test"
+  randomString:
+    type: random-plugin-component:index:randomStringGenerator
+    properties:
+      length: 8
+outputs:
+  randomPet: ${randomPet.pet}
+  randomString: ${randomString.string}

--- a/pkg/tests/testdata/component/provider/PulumiPlugin.yaml
+++ b/pkg/tests/testdata/component/provider/PulumiPlugin.yaml
@@ -1,0 +1,18 @@
+name: random-plugin-component
+description: A random pulumi plugin
+runtime: yaml
+components:
+  randomPetGenerator:
+    inputs:
+      length:
+        type: integer
+      prefix:
+        type: string
+    resources:
+      randomPet:
+        type: random:RandomPet
+        properties:
+          length: ${length}
+          prefix: ${prefix}
+    outputs:
+      pet: ${randomPet.id}

--- a/pkg/tests/testdata/component/provider/anotherPlugin.yaml
+++ b/pkg/tests/testdata/component/provider/anotherPlugin.yaml
@@ -1,0 +1,12 @@
+components:
+  randomStringGenerator:
+    inputs:
+      length:
+        type: integer
+    resources:
+      randomString:
+        type: random:RandomString
+        properties:
+          length: ${length}
+    outputs:
+      string: ${randomString.id}


### PR DESCRIPTION
Allow YAML provider plugins to be run.  Note that this is slightly different than YAML programs in that it natively slurps in all yaml files in the directory, rather than just running the main file.  It merges all `*.yaml` files in the plugin directory instead.

Fixes https://github.com/pulumi/pulumi-yaml/issues/746
Depends on https://github.com/pulumi/pulumi-yaml/pull/748