### PR TITLE
rename config to inputs for components

### DIFF
--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -507,7 +507,7 @@ type ComponentParamDecl struct {
 
 	Name        *StringExpr
 	Description *StringExpr
-	Config      ConfigMapDecl
+	Inputs      ConfigMapDecl
 	Variables   VariablesMapDecl
 	Resources   ResourcesMapDecl
 	Outputs     PropertyMapDecl
@@ -532,7 +532,7 @@ func (d *ComponentParamDecl) GetConfig() ConfigMapDecl {
 	if d == nil {
 		return ConfigMapDecl{}
 	}
-	return d.Config
+	return d.Inputs
 }
 
 func (d *ComponentParamDecl) GetVariables() VariablesMapDecl {
@@ -760,7 +760,7 @@ func (d *TemplateDecl) GenerateSchema() (schema.PackageSpec, error) {
 			resourceDef.Description = component.Value.Description.Value
 		}
 
-		for _, input := range component.Value.Config.Entries {
+		for _, input := range component.Value.Inputs.Entries {
 			k, v := input.Key.Value, input.Value
 			typeSpec, err := parseTypeSpec(input.Value)
 			if err != nil {

--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -70,7 +70,7 @@ name: yaml-plugin
 runtime: yaml
 components:
   aComponent:
-    config:
+    inputs:
       someStringArray:
         type: array
         items:
@@ -103,17 +103,17 @@ func TestComponentParsing(t *testing.T) {
 
 	require.Len(t, template.Components.Entries, 2)
 	require.Equal(t, "aComponent", template.Components.Entries[0].Value.Name.Value)
-	require.Len(t, template.Components.Entries[0].Value.Config.Entries, 1)
-	require.Equal(t, "someStringArray", template.Components.Entries[0].Value.Config.Entries[0].Key.Value)
-	require.Equal(t, "array", template.Components.Entries[0].Value.Config.Entries[0].Value.Type.Value)
-	require.Equal(t, "string", template.Components.Entries[0].Value.Config.Entries[0].Value.Items.Type.Value)
+	require.Len(t, template.Components.Entries[0].Value.Inputs.Entries, 1)
+	require.Equal(t, "someStringArray", template.Components.Entries[0].Value.Inputs.Entries[0].Key.Value)
+	require.Equal(t, "array", template.Components.Entries[0].Value.Inputs.Entries[0].Value.Type.Value)
+	require.Equal(t, "string", template.Components.Entries[0].Value.Inputs.Entries[0].Value.Items.Type.Value)
 	require.Len(t, template.Components.Entries[0].Value.Resources.Entries, 1)
 	require.Equal(t, "myBucket", template.Components.Entries[0].Value.Resources.Entries[0].Key.Value)
 	require.Len(t, template.Components.Entries[0].Value.Outputs.Entries, 1)
 	require.Equal(t, "bucketEndpoint", template.Components.Entries[0].Value.Outputs.Entries[0].Key.Value)
 
 	require.Equal(t, "anotherComponent", template.Components.Entries[1].Value.Name.Value)
-	require.Nil(t, template.Components.Entries[1].Value.Config.Entries)
+	require.Nil(t, template.Components.Entries[1].Value.Inputs.Entries)
 	require.Len(t, template.Components.Entries[1].Value.Resources.Entries, 1)
 	require.Equal(t, "differentBucket", template.Components.Entries[1].Value.Resources.Entries[0].Key.Value)
 	require.Len(t, template.Components.Entries[1].Value.Outputs.Entries, 1)
@@ -127,7 +127,7 @@ runtime: yaml
 components:
   aComponent:
     description: "A component"
-    config:
+    inputs:
       someStringArray:
         type: array
         items:


### PR DESCRIPTION
We decided that inputs is the better name for component inputs.  Make that rename happen.