### PR TITLE
Fix submodule url scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pulumi"]
 	path = pulumi
-	url = git@github.com:pulumi/pulumi.git
+	url = https://github.com/pulumi/pulumi
 	branch = master


### PR DESCRIPTION
The `git@` scheme will cause clients to try to use ssh, which is unnecessary for a public repo like pulumi/pulumi.

Notably, this will fix Renovate running on this repo.