### PR TITLE
Rename packages AST to sdks

### DIFF
--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -1,4 +1,4 @@
-// Copyright 2022, Pulumi Corporation.  All rights reserved.
+// Copyright 2022-2025, Pulumi Corporation.  All rights reserved.
 
 package ast
 
@@ -490,7 +490,7 @@ type Template interface {
 	GetVariables() VariablesMapDecl
 	GetResources() ResourcesMapDecl
 	GetOutputs() PropertyMapDecl
-	GetPackages() []packages.PackageDecl
+	GetSdks() []packages.PackageDecl
 
 	NewDiagnosticWriter(w io.Writer, width uint, color bool) hcl.DiagnosticWriter
 }
@@ -556,11 +556,11 @@ func (d *ComponentParamDecl) GetOutputs() PropertyMapDecl {
 	return d.Outputs
 }
 
-func (d *ComponentParamDecl) GetPackages() []packages.PackageDecl {
+func (d *ComponentParamDecl) GetSdks() []packages.PackageDecl {
 	if d == nil {
 		return nil
 	}
-	return d.Template.Packages
+	return d.Template.Sdks
 }
 
 func (d *ComponentParamDecl) NewDiagnosticWriter(w io.Writer, width uint, color bool) hcl.DiagnosticWriter {
@@ -625,7 +625,7 @@ type TemplateDecl struct {
 	Variables     VariablesMapDecl
 	Resources     ResourcesMapDecl
 	Outputs       PropertyMapDecl
-	Packages      []packages.PackageDecl
+	Sdks          []packages.PackageDecl
 	Components    ComponentListDecl
 }
 
@@ -672,11 +672,11 @@ func (d *TemplateDecl) GetOutputs() PropertyMapDecl {
 	return d.Outputs
 }
 
-func (d *TemplateDecl) GetPackages() []packages.PackageDecl {
+func (d *TemplateDecl) GetSdks() []packages.PackageDecl {
 	if d == nil {
 		return nil
 	}
-	return d.Packages
+	return d.Sdks
 }
 
 func (d *TemplateDecl) Syntax() syntax.Node {

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -1,4 +1,4 @@
-// Copyright 2022, Pulumi Corporation.  All rights reserved.
+// Copyright 2022-2025, Pulumi Corporation.  All rights reserved.
 
 package codegen
 
@@ -1152,7 +1152,7 @@ func (imp *importer) importTemplate(file *ast.TemplateDecl) (*model.Body, syntax
 
 // ImportTemplate converts a YAML template to a PCL definition.
 func ImportTemplate(file *ast.TemplateDecl, loader pulumiyaml.PackageLoader) (*model.Body, syntax.Diagnostics) {
-	pacakgeDescriptors, err := packages.ToPackageDescriptors(file.Packages)
+	pacakgeDescriptors, err := packages.ToPackageDescriptors(file.Sdks)
 	if err != nil {
 		return nil, syntax.Diagnostics{syntax.Error(nil, fmt.Sprintf("unable to parse package descriptors: %v", err), "")}
 	}

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -112,7 +112,7 @@ func GetReferencedPackages(tmpl *ast.TemplateDecl) ([]packages.PackageDecl, synt
 	packageMap := map[string]*packages.PackageDecl{}
 
 	// Iterate over the package declarations
-	for _, pkg := range tmpl.Packages {
+	for _, pkg := range tmpl.Sdks {
 		pkg := pkg
 		name := pkg.Name
 		version := pkg.Version

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1,4 +1,4 @@
-// Copyright 2022, Pulumi Corporation.  All rights reserved.
+// Copyright 2022-2025, Pulumi Corporation.  All rights reserved.
 
 package pulumiyaml
 
@@ -87,11 +87,11 @@ func LoadFromCompiler(compiler string, workingDirectory string, env []string) (*
 		template.Name = uncompiledTemplate.Name
 	}
 
-	packages, err := packages.SearchPackageDecls(workingDirectory)
+	sdks, err := packages.SearchPackageDecls(workingDirectory)
 	if err != nil {
 		diags.Extend(syntax.Error(nil, err.Error(), ""))
 	}
-	template.Packages = packages
+	template.Sdks = sdks
 
 	return template, tdiags, err
 }
@@ -137,11 +137,11 @@ func LoadDir(directory string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 		return nil, diags, diags
 	}
 
-	packages, err := packages.SearchPackageDecls(directory)
+	sdks, err := packages.SearchPackageDecls(directory)
 	if err != nil {
 		diags.Extend(syntax.Error(nil, err.Error(), ""))
 	}
-	template.Packages = packages
+	template.Sdks = sdks
 
 	return template, diags, nil
 }
@@ -207,11 +207,11 @@ func LoadPluginTemplate(directory string) (*ast.TemplateDecl, syntax.Diagnostics
 		}
 		componentNames[entry.Value.Name.Value] = true
 	}
-	packages, err := packages.SearchPackageDecls(directory)
+	sdks, err := packages.SearchPackageDecls(directory)
 	if err != nil {
 		return nil, nil, err
 	}
-	template.Packages = packages
+	template.Sdks = sdks
 
 	return template, nil, nil
 }
@@ -229,11 +229,11 @@ func LoadFile(path string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 		return nil, diags, err
 	}
 
-	packages, err := packages.SearchPackageDecls(filepath.Dir(path))
+	sdks, err := packages.SearchPackageDecls(filepath.Dir(path))
 	if err != nil {
 		diags.Extend(syntax.Error(nil, err.Error(), ""))
 	}
-	template.Packages = packages
+	template.Sdks = sdks
 
 	return template, diags, nil
 }
@@ -450,7 +450,7 @@ func (r *Runner) setDefaultProviders() {
 // Set the runner's package descriptors from the templates package decls.
 func (r *Runner) setPackageDesciptors() error {
 	// Register package refs for all packages we know upfront
-	packageDescriptors, err := packages.ToPackageDescriptors(r.t.GetPackages())
+	packageDescriptors, err := packages.ToPackageDescriptors(r.t.GetSdks())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Apparently, we use a fake `Packages` property in template's AST to hold metadata from generated SDKs (package descriptions). It's not a real AST node but we populate it manually to bring those SDKs into the same context.

Now, that we've introduced a proper `packages` section in Pulumi.yaml, this suddenly started to panic. This PR is a minimal non-functional change to avoid this problem by renaming the property and related methods to `Sdks`/`GetSdks`, which is closer to our common nomenclature.

The `packages` section support will come in a follow-up PR.

Fix https://github.com/pulumi/pulumi-yaml/issues/756