### PR TITLE
add namespace field to YAML

### DIFF
--- a/.changes/unreleased/Improvements-759.yaml
+++ b/.changes/unreleased/Improvements-759.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Allow setting the namespace for components
+time: 2025-03-19T11:35:10.768883069+01:00
+custom:
+  PR: "759"

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -619,6 +619,7 @@ type TemplateDecl struct {
 	syntax syntax.Node
 
 	Name          *StringExpr
+	Namespace     *StringExpr
 	Description   *StringExpr
 	Configuration ConfigMapDecl
 	Config        ConfigMapDecl
@@ -716,6 +717,11 @@ func (d *TemplateDecl) Merge(other *TemplateDecl) error {
 	} else if other.Description != nil {
 		return fmt.Errorf("cannot merge templates with different descriptions")
 	}
+	if d.Namespace == nil {
+		d.Namespace = other.Namespace
+	} else if other.Namespace != nil {
+		return fmt.Errorf("cannot merge templates with different namespaces")
+	}
 	d.Config.Entries = append(d.Config.Entries, other.Config.Entries...)
 	d.Components.Entries = append(d.Components.Entries, other.Components.Entries...)
 	return nil
@@ -754,9 +760,14 @@ func (d *TemplateDecl) GenerateSchema() (schema.PackageSpec, error) {
 	if d.Description != nil {
 		description = d.Description.Value
 	}
+	namespace := ""
+	if d.Namespace != nil {
+		namespace = d.Namespace.Value
+	}
 	schemaDef := schema.PackageSpec{
 		Name:        d.Name.Value,
 		Description: description,
+		Namespace:   namespace,
 		Language: map[string]schema.RawMessage{
 			"nodejs": schema.RawMessage(`{"respectSchemaVersion": true}`),
 			"python": schema.RawMessage(`{"respectSchemaVersion": true}`),

--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -122,6 +122,7 @@ func TestComponentParsing(t *testing.T) {
 
 const componentSchemaExample = `
 name: yaml-plugin
+namespace: my-company
 description: A YAML plugin
 runtime: yaml
 components:
@@ -173,6 +174,7 @@ func TestComponentSchemaGeneration(t *testing.T) {
 {
   "name": "yaml-plugin",
   "description": "A YAML plugin",
+  "namespace": "my-company",
   "language": {
     "cshap": {
       "respectSchemaVersion": true

--- a/pkg/pulumiyaml/sort_test.go
+++ b/pkg/pulumiyaml/sort_test.go
@@ -126,7 +126,7 @@ func TestSortMultipleDefaultProviders(t *testing.T) {
 	f, err := os.Open(path)
 	require.NoError(t, err)
 	defer f.Close()
-	tmpl, diags, err := LoadYAML(filepath.Base(path), f, false)
+	tmpl, diags, err := LoadYAML(filepath.Base(path), f)
 	requireNoErrors(t, tmpl, diags)
 	assert.NoError(t, err)
 

--- a/pkg/pulumiyaml/sort_test.go
+++ b/pkg/pulumiyaml/sort_test.go
@@ -5,6 +5,8 @@ package pulumiyaml
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,7 +122,11 @@ func TestSortUnordered(t *testing.T) {
 func TestSortMultipleDefaultProviders(t *testing.T) {
 	t.Parallel()
 
-	tmpl, diags, err := LoadFile("../tests/testdata/resource-ordering/Pulumi.yaml")
+	path := "../tests/testdata/resource-ordering/Pulumi.yaml"
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	tmpl, diags, err := LoadYAML(filepath.Base(path), f, false)
 	requireNoErrors(t, tmpl, diags)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Add a namespace field to YAML, which is then generated into the schema, so the user can set it.  This will be used in codegen to distinguish from pulumi packages.