### PR TITLE
upgrade toolchain versions

### DIFF
--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -12,17 +12,17 @@ on:
         type: boolean
       python-version:
         description: 'Version of the Python toolchain for the build'
-        default: '3.9.x'
+        default: '3.13.x'
         required: false
         type: string
       node-version:
         description: 'Version of the Node toolchain for the build'
-        default: '14.x'
+        default: '22.x'
         required: false
         type: string
       dotnet-version:
         description: 'Version of the .NET toolchain for the build'
-        default: '6.x'
+        default: '8.x'
         required: false
         type: string
       commit-ref:


### PR DESCRIPTION
We install some (very) outdated toolchains for the build.  The old nodeJS version for example makes `pulumi package add` in https://github.com/pulumi/pulumi-yaml/pull/761 not work properly. Update all of these to the latest supported releases.