### PR TITLE
allow config defaults to be integers

### DIFF
--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1211,6 +1211,11 @@ func (e *programEvaluator) registerConfig(intm configNode) (interface{}, bool) {
 					c.Type.Value, ctypes.ConfigTypes)
 			}
 
+			if t == ctypes.Int && expectedType == ctypes.Number {
+				expectedType = ctypes.Int
+				defaultValue = int(defaultValue.(float64))
+			}
+
 			// We have both a default value and a explicit type. Make sure they
 			// agree.
 			if ctypes.IsValidType(expectedType) && t != expectedType {

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -533,6 +533,32 @@ configuration:
 	require.True(t, diags.HasErrors())
 }
 
+func TestConfigTypeIntDefault(t *testing.T) {
+	t.Parallel()
+
+	const text = `name: test-yaml
+runtime: yaml
+configuration:
+  defaultInt:
+    type: integer
+    default: 42
+`
+	tmpl := yamlTemplate(t, text)
+	mocks := &testMonitor{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		runner := newRunner(tmpl, newMockPackageMap())
+		eCtx := runner.newContext(nil)
+		programEvaluator := &programEvaluator{evalContext: eCtx, pulumiCtx: ctx}
+		configNode := tmpl.GetConfig().Entries[0]
+		ok := programEvaluator.EvalConfig(runner, configNodeYaml(configNode))
+		require.True(t, ok)
+		require.Equal(t, 42, programEvaluator.config["defaultInt"])
+		return nil
+	}, pulumi.WithMocks(testProject, "dev", mocks))
+	require.NoError(t, err)
+}
+
 func TestConfigSecrets(t *testing.T) { //nolint:paralleltest
 	const text = `name: test-yaml
 runtime: yaml


### PR DESCRIPTION
In YAML it is possible to set a default value for a config entry. However YAML converts all number looking things into `float64`s/`number`s, which makes the config system reject an integer default value for an integer type.

Since there isn't a great way to distinguish floats and ints in YAML, let the config system continue to parse all numbers into floats. However when applying the default value, we check if it can fit an int, and convert it to an int in that case.

Fixes https://github.com/pulumi/pulumi-yaml/issues/764