### PR TITLE
pass through pluginDownloadURL when loading plugin

### DIFF
--- a/.changes/unreleased/Bug Fixes-776.yaml
+++ b/.changes/unreleased/Bug Fixes-776.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Use PluginDownloadURL resource option correctly when loading plugins
+time: 2025-04-10T12:05:41.083752708+02:00
+custom:
+    PR: "776"

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -587,7 +587,11 @@ func (tc *typeCache) typeResource(r *Runner, node resourceNode) bool {
 		ctx.error(v.Type, fmt.Sprintf("unable to parse resource %v provider version: %v", k, err))
 		return true
 	}
-	pkg, typ, err := ResolveResource(context.TODO(), ctx.pkgLoader, ctx.packageDescriptors, v.Type.Value, version)
+	pluginDownloadURL := ""
+	if v.Options.PluginDownloadURL != nil {
+		pluginDownloadURL = v.Options.PluginDownloadURL.Value
+	}
+	pkg, typ, err := ResolveResource(context.TODO(), ctx.pkgLoader, ctx.packageDescriptors, v.Type.Value, version, pluginDownloadURL)
 	if err != nil {
 		ctx.error(v.Type, fmt.Sprintf("error resolving type of resource %v: %v", k, err))
 		return true
@@ -764,7 +768,11 @@ func (tc *typeCache) typeInvoke(ctx *evalContext, t *ast.InvokeExpr) bool {
 		ctx.error(t.CallOpts.Version, fmt.Sprintf("unable to parse function provider version: %v", err))
 		return true
 	}
-	pkg, functionName, err := ResolveFunction(context.TODO(), ctx.pkgLoader, ctx.packageDescriptors, t.Token.Value, version)
+	pluginDownloadURL := ""
+	if t.CallOpts.PluginDownloadURL != nil {
+		pluginDownloadURL = t.CallOpts.PluginDownloadURL.Value
+	}
+	pkg, functionName, err := ResolveFunction(context.TODO(), ctx.pkgLoader, ctx.packageDescriptors, t.Token.Value, version, pluginDownloadURL)
 	if err != nil {
 		_, b := ctx.error(t, err.Error())
 		return b

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -312,7 +312,11 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 		if err != nil {
 			return nil, syntax.Diagnostics{ast.ExprError(node.CallOpts.Version, fmt.Sprintf("unable to parse function provider version: %v", err), "")}
 		}
-		pkg, functionName, err := pulumiyaml.ResolveFunction(context.TODO(), imp.loader, imp.packageDescriptors, node.Token.Value, version)
+		pluginDownloadURL := ""
+		if node.CallOpts.PluginDownloadURL != nil {
+			pluginDownloadURL = node.CallOpts.PluginDownloadURL.Value
+		}
+		pkg, functionName, err := pulumiyaml.ResolveFunction(context.TODO(), imp.loader, imp.packageDescriptors, node.Token.Value, version, pluginDownloadURL)
 		if err != nil {
 			return nil, syntax.Diagnostics{ast.ExprError(node.Token, fmt.Sprintf("unable to resolve function name: %v", err), "")}
 		}
@@ -774,7 +778,11 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry, latestPkgInfo map
 		diags.Extend(ast.ExprError(resource.Options.Version, fmt.Sprintf("unable to parse resource %v provider version: %v", name, err), ""))
 		return nil, diags
 	}
-	pkg, token, err := pulumiyaml.ResolveResource(context.TODO(), imp.loader, imp.packageDescriptors, resource.Type.Value, version)
+	pluginDownloadURL := ""
+	if resource.Options.PluginDownloadURL != nil {
+		pluginDownloadURL = resource.Options.PluginDownloadURL.Value
+	}
+	pkg, token, err := pulumiyaml.ResolveResource(context.TODO(), imp.loader, imp.packageDescriptors, resource.Type.Value, version, pluginDownloadURL)
 	if err != nil {
 		return nil, syntax.Diagnostics{ast.ExprError(resource.Type, fmt.Sprintf("unable to resolve resource type: %v", err), "")}
 	}

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -236,6 +236,7 @@ func ResolvePkgName(typeString string) string {
 func loadPackage(
 	ctx context.Context, loader PackageLoader,
 	descriptors map[tokens.Package]*schema.PackageDescriptor, typeString string, version *semver.Version,
+	pluginDownloadURL string,
 ) (Package, error) {
 	typeParts := strings.Split(typeString, ":")
 	if len(typeParts) < 2 || len(typeParts) > 3 {
@@ -247,8 +248,9 @@ func loadPackage(
 	if descriptor == nil {
 		// Fall back to just the package name and passed in version if we don't have a descriptor.
 		descriptor = &schema.PackageDescriptor{
-			Name:    packageName,
-			Version: version,
+			Name:        packageName,
+			Version:     version,
+			DownloadURL: pluginDownloadURL,
 		}
 	}
 	if version != nil {
@@ -290,6 +292,7 @@ var helmResourceNames = map[string]struct{}{
 func ResolveResource(ctx context.Context, loader PackageLoader,
 	descriptors map[tokens.Package]*schema.PackageDescriptor,
 	typeString string, version *semver.Version,
+	pluginDownloadURL string,
 ) (Package, ResourceTypeToken, error) {
 	if issue, found := kubernetesResourceNames[typeString]; found {
 		return nil, "", fmt.Errorf("The resource type [%v] is not supported in YAML at this time, see: %v", typeString, issue)
@@ -299,8 +302,9 @@ func ResolveResource(ctx context.Context, loader PackageLoader,
 		return nil, "", fmt.Errorf("Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/")
 	}
 
-	pkg, err := loadPackage(ctx, loader, descriptors, typeString, version)
+	pkg, err := loadPackage(ctx, loader, descriptors, typeString, version, pluginDownloadURL)
 	if err != nil {
+		fmt.Println("here")
 		return nil, "", err
 	}
 
@@ -327,8 +331,9 @@ func ResolveResource(ctx context.Context, loader PackageLoader,
 func ResolveFunction(ctx context.Context, loader PackageLoader,
 	descriptors map[tokens.Package]*schema.PackageDescriptor,
 	typeString string, version *semver.Version,
+	pluginDownloadURL string,
 ) (Package, FunctionTypeToken, error) {
-	pkg, err := loadPackage(ctx, loader, descriptors, typeString, version)
+	pkg, err := loadPackage(ctx, loader, descriptors, typeString, version, pluginDownloadURL)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1374,7 +1374,12 @@ func (e *programEvaluator) registerResourceWithParent(kvp resourceNode, parent p
 		opts = append(opts, pulumi.Version(version.String()))
 	}
 
-	pkg, typ, err := ResolveResource(context.TODO(), e.pkgLoader, e.packageDescriptors, v.Type.Value, version)
+	pluginDownloadURL := ""
+	if v.Options.PluginDownloadURL != nil {
+		pluginDownloadURL = v.Options.PluginDownloadURL.Value
+	}
+	pkg, typ, err := ResolveResource(context.TODO(), e.pkgLoader, e.packageDescriptors, v.Type.Value, version,
+		pluginDownloadURL)
 	if err != nil {
 		e.error(v.Type, fmt.Sprintf("error resolving type of resource %v: %v", kvp.Key.Value, err))
 		overallOk = false
@@ -2233,7 +2238,11 @@ func (e *programEvaluator) evaluateBuiltinInvoke(t *ast.InvokeExpr) (interface{}
 			e.error(t.CallOpts.Version, fmt.Sprintf("unable to parse function provider version: %v", err))
 			return nil, true
 		}
-		_, functionName, err := ResolveFunction(e.pulumiCtx.Context(), e.pkgLoader, e.packageDescriptors, t.Token.Value, version)
+		pluginDownloadURL := ""
+		if t.CallOpts.PluginDownloadURL != nil {
+			pluginDownloadURL = t.CallOpts.PluginDownloadURL.Value
+		}
+		_, functionName, err := ResolveFunction(e.pulumiCtx.Context(), e.pkgLoader, e.packageDescriptors, t.Token.Value, version, pluginDownloadURL)
 		if err != nil {
 			return e.error(t, err.Error())
 		}

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -283,10 +283,14 @@ func TestRemoteComponentTagged(t *testing.T) {
 
 	e.RunCommand("pulumi", "stack", "init", "organization/component-consumption-tagged/test")
 	e.Env = []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false"}
+	e.RunCommand("pulumi", "install")
+	stdout, _ := e.RunCommand("pulumi", "plugin", "ls")
+	// Make sure we have exactly the plugin we expect installed
+	assert.Equal(t, 1, strings.Count(stdout, "github.com_pulumi_pulumi-yaml.git"))
 
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
 
-	stdout, _ := e.RunCommand("pulumi", "plugin", "ls")
+	stdout, _ = e.RunCommand("pulumi", "plugin", "ls")
 	// Make sure random-plugin-component hasn't been installed under that name.
 	assert.Equal(t, 0, strings.Count(stdout, "random-plugin-component"))
 
@@ -311,14 +315,10 @@ func TestPluginDownloadURLUsed(t *testing.T) {
 
 	e.RunCommand("pulumi", "stack", "init", "organization/component-consumption-tagged/test")
 	e.Env = []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false"}
-	e.RunCommand("pulumi", "install")
-	stdout, _ := e.RunCommand("pulumi", "plugin", "ls")
-	// Make sure we have exactly the plugin we expect installed
-	assert.Equal(t, 1, strings.Count(stdout, "github.com_pulumi_pulumi-yaml.git"))
 
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
 
-	stdout, _ = e.RunCommand("pulumi", "plugin", "ls")
+	stdout, _ := e.RunCommand("pulumi", "plugin", "ls")
 	// Make sure random-plugin-component hasn't been installed under that name.
 	fmt.Println(stdout)
 	assert.Equal(t, 0, strings.Count(stdout, "random-plugin-component"))

--- a/pkg/tests/testdata/plugin-download-url/Pulumi.yaml
+++ b/pkg/tests/testdata/plugin-download-url/Pulumi.yaml
@@ -1,0 +1,20 @@
+name: component-consumption-tagged
+runtime: yaml
+resources:
+  randomPluginComponent:
+    type: pulumi:providers:random-plugin-component
+    defaultProvider: true
+    options:
+      pluginDownloadURL: git://github.com/pulumi/pulumi-yaml/pkg/tests/testdata/component/provider
+  randomPet:
+    type: random-plugin-component:index:randomPetGenerator
+    properties:
+      length: 3
+      prefix: "test"
+  randomString:
+    type: random-plugin-component:index:randomStringGenerator
+    properties:
+      length: 8
+outputs:
+  randomPet: ${randomPet.pet}
+  randomString: ${randomString.string}


### PR DESCRIPTION
pulumi-yaml supports a `pluginDownloadURL` resource option.  However when trying to load the package that URL is not passed through currently, and thus is not used when trying to get the package.

We should always be using it if it is available, and let the loading code handle what it wants to do with it.  Do that here.

This isn't meant to be the main way to load components anymore, but we should still deal with the option correctly.

Fixes https://github.com/pulumi/pulumi/issues/18638