### PR TITLE
avoid spaces in changie files

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -10,6 +10,7 @@ kinds:
   auto: minor
 - label: Bug Fixes
   auto: patch
+  key: bug-fixes
 # Custom fragment file format because we use / in the component name.
 fragmentFileFormat: '{{.Kind}}-{{.Custom.PR}}'
 components:


### PR DESCRIPTION
We made this change in dotnet a while ago, let's do it here as well. Spaces are annoying to deal with on the filesystem, and they don't bring any benefits here, so we might as well avoid them.