### PR TITLE
Allow resource properties to refer to an object variable 

### DIFF
--- a/.changes/unreleased/Improvements-779.yaml
+++ b/.changes/unreleased/Improvements-779.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Resource properties can be set together with an object variable
+time: 2025-04-14T19:28:12.052193299+01:00
+custom:
+  PR: "779"

--- a/.changes/unreleased/Improvements-779.yaml
+++ b/.changes/unreleased/Improvements-779.yaml
@@ -1,6 +1,6 @@
 component: runtime
 kind: Improvements
-body: Resource properties can be set together with an object variable
+body: Make setting resource properties using an object variables possible
 time: 2025-04-14T19:28:12.052193299+01:00
 custom:
   PR: "779"

--- a/examples/resource-config/Pulumi.yaml
+++ b/examples/resource-config/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: random
+runtime: yaml
+config:
+  inputs: {}
+resources:
+  randomPassword:
+    type: random:RandomPassword
+    properties: ${inputs}
+outputs:
+  password: ${randomPassword.result}

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -275,7 +275,7 @@ func (d *PropertyMapDecl) parse(name string, node syntax.Node) syntax.Diagnostic
 type PropertyMapOrExprDecl struct {
 	declNode
 
-	Symbol      *SymbolExpr
+	Expr        Expr
 	PropertyMap *PropertyMapDecl
 }
 
@@ -311,32 +311,9 @@ func (d *PropertyMapOrExprDecl) parse(name string, node syntax.Node) syntax.Diag
 		return diags
 	}
 
-	str, ok := node.(*syntax.StringNode)
-	if !ok {
-		return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
-	}
-
-	interpolate, diags := InterpolateSyntax(str)
-
-	if interpolate != nil {
-		switch len(interpolate.Parts) {
-		case 0:
-			return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
-		case 1:
-			switch {
-			case interpolate.Parts[0].Value == nil:
-				return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
-			case interpolate.Parts[0].Text == "":
-				d.Symbol = &SymbolExpr{
-					exprNode: expr(node),
-					Property: interpolate.Parts[0].Value,
-				}
-				return diags
-			}
-		}
-	}
-
-	return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
+	expr, diags := ParseExpr(node)
+	d.Expr = expr
+	return diags
 }
 
 type ConfigParamDecl struct {

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -243,6 +243,8 @@ func (d *PropertyMapDecl) defaultValue() interface{} {
 }
 
 func (d *PropertyMapDecl) parse(name string, node syntax.Node) syntax.Diagnostics {
+	d.syntax = node
+
 	obj, ok := node.(*syntax.ObjectNode)
 	if !ok {
 		return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be an object", name), "")}
@@ -268,6 +270,73 @@ func (d *PropertyMapDecl) parse(name string, node syntax.Node) syntax.Diagnostic
 	d.Entries = entries
 
 	return diags
+}
+
+type PropertyMapOrExprDecl struct {
+	declNode
+
+	Symbol      *SymbolExpr
+	PropertyMap *PropertyMapDecl
+}
+
+func (d *PropertyMapOrExprDecl) defaultValue() interface{} {
+	return &PropertyMapOrExprDecl{}
+}
+
+func (d *PropertyMapOrExprDecl) parse(name string, node syntax.Node) syntax.Diagnostics {
+	d.syntax = node
+
+	obj, ok := node.(*syntax.ObjectNode)
+	if ok {
+		var diags syntax.Diagnostics
+
+		entries := make([]PropertyMapEntry, obj.Len())
+		for i := range entries {
+			kvp := obj.Index(i)
+
+			var v Expr
+			vname := fmt.Sprintf("%s.%s", name, kvp.Key.Value())
+			vdiags := parseField(vname, reflect.ValueOf(&v).Elem(), kvp.Value)
+			diags.Extend(vdiags...)
+
+			entries[i] = PropertyMapEntry{
+				syntax: kvp,
+				Key:    StringSyntax(kvp.Key),
+				Value:  v,
+			}
+		}
+		d.PropertyMap = &PropertyMapDecl{}
+		d.PropertyMap.Entries = entries
+
+		return diags
+	}
+
+	str, ok := node.(*syntax.StringNode)
+	if !ok {
+		return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
+	}
+
+	interpolate, diags := InterpolateSyntax(str)
+
+	if interpolate != nil {
+		switch len(interpolate.Parts) {
+		case 0:
+			return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
+		case 1:
+			switch {
+			case interpolate.Parts[0].Value == nil:
+				return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
+			case interpolate.Parts[0].Text == "":
+				d.Symbol = &SymbolExpr{
+					exprNode: expr(node),
+					Property: interpolate.Parts[0].Value,
+				}
+				return diags
+			}
+		}
+	}
+
+	return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be a symbol or an object", name), "")}
 }
 
 type ConfigParamDecl struct {
@@ -419,7 +488,7 @@ type ResourceDecl struct {
 	Type            *StringExpr
 	Name            *StringExpr
 	DefaultProvider *BooleanExpr
-	Properties      PropertyMapDecl
+	Properties      PropertyMapOrExprDecl
 	Options         ResourceOptionsDecl
 	Get             GetResourceDecl
 }
@@ -434,7 +503,7 @@ func (*ResourceDecl) Fields() []string {
 }
 
 func ResourceSyntax(node *syntax.ObjectNode, typ *StringExpr, name *StringExpr, defaultProvider *BooleanExpr,
-	properties PropertyMapDecl, options ResourceOptionsDecl, get GetResourceDecl,
+	properties PropertyMapOrExprDecl, options ResourceOptionsDecl, get GetResourceDecl,
 ) *ResourceDecl {
 	return &ResourceDecl{
 		declNode:        decl(node),
@@ -451,7 +520,7 @@ func Resource(
 	typ *StringExpr,
 	name *StringExpr,
 	defaultProvider *BooleanExpr,
-	properties PropertyMapDecl,
+	properties PropertyMapOrExprDecl,
 	options ResourceOptionsDecl,
 	get GetResourceDecl,
 ) *ResourceDecl {

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -816,11 +816,11 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry, latestPkgInfo map
 				Value: v,
 			})
 		}
-	} else if resource.Properties.Symbol != nil {
+	} else if resource.Properties.Expr != nil {
 		// Else write out a literal object that refers to each known property in the resource indexed off the referred to symbol
 		for _, prop := range props.Resource.InputProperties {
 
-			receiver, rdiags := imp.importExpr(resource.Properties.Symbol, nil)
+			receiver, rdiags := imp.importExpr(resource.Properties.Expr, nil)
 			diags.Extend(rdiags...)
 
 			traversal := hcl.Traversal{hcl.TraverseAttr{Name: prop.Name}}

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -564,8 +564,6 @@ func (imp *importer) importConfig(kvp ast.ConfigMapEntry) (model.BodyItem, synta
 		if !ok {
 			return nil, syntax.Diagnostics{ast.ExprError(config.Type, fmt.Sprintf("unrecognized type '%v' for config variable '%s'", config.Type.Value, name), "")}
 		}
-	} else {
-		typeExpr = "string"
 	}
 
 	configName, ok := imp.configuration[name]
@@ -581,10 +579,14 @@ func (imp *importer) importConfig(kvp ast.ConfigMapEntry) (model.BodyItem, synta
 	}
 
 	// TODO(pdg): secret configuration -- requires changes in PCL
+	labels := []string{configName.Name}
+	if typeExpr != "" {
+		labels = append(labels, typeExpr)
+	}
 
 	configDef := &model.Block{
 		Type:   "config",
-		Labels: []string{configName.Name, typeExpr},
+		Labels: labels,
 		Body: &model.Body{
 			Items: []model.BodyItem{
 				&model.Attribute{

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -803,13 +803,38 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry, latestPkgInfo map
 			hints[input.Name] = input.Type
 		}
 	}
-	for _, kvp := range resource.Properties.Entries {
-		v, vdiags := imp.importExpr(kvp.Value, hints[kvp.Key.Value])
-		diags.Extend(vdiags...)
-		items = append(items, &model.Attribute{
-			Name:  kvp.Key.Value,
-			Value: v,
-		})
+
+	// If the properties are an object expression just copy that
+	if pm := resource.Properties.PropertyMap; pm != nil {
+		for _, kvp := range pm.Entries {
+			v, vdiags := imp.importExpr(kvp.Value, hints[kvp.Key.Value])
+			diags.Extend(vdiags...)
+			items = append(items, &model.Attribute{
+				Name:  kvp.Key.Value,
+				Value: v,
+			})
+		}
+	} else if resource.Properties.Symbol != nil {
+		// Else write out a literal object that refers to each known property in the resource indexed off the referred to symbol
+		for _, prop := range props.Resource.InputProperties {
+
+			receiver, rdiags := imp.importExpr(resource.Properties.Symbol, nil)
+			diags.Extend(rdiags...)
+
+			traversal := hcl.Traversal{hcl.TraverseAttr{Name: prop.Name}}
+			parts := []model.Traversable{model.DynamicType}
+
+			expr := &model.RelativeTraversalExpression{
+				Source:    receiver,
+				Traversal: traversal,
+				Parts:     parts,
+			}
+
+			items = append(items, &model.Attribute{
+				Name:  prop.Name,
+				Value: expr,
+			})
+		}
 	}
 
 	// TODO: resource options not supported by PCL: component, additional secret outputs, aliases, custom timeouts, delete before replace, import, version
@@ -1073,8 +1098,10 @@ func (imp *importer) importTemplate(file *ast.TemplateDecl) (*model.Body, syntax
 		imp.configuration[kvp.Key.Value] = nil
 	}
 	for _, kvp := range file.Resources.Entries {
-		for _, kvp := range kvp.Value.Properties.Entries {
-			imp.findStackReferences(kvp.Value)
+		if kvp.Value.Properties.PropertyMap != nil {
+			for _, kvp := range kvp.Value.Properties.PropertyMap.Entries {
+				imp.findStackReferences(kvp.Value)
+			}
 		}
 		imp.resources[kvp.Key.Value] = nil
 	}

--- a/pkg/pulumiyaml/expr.go
+++ b/pkg/pulumiyaml/expr.go
@@ -10,8 +10,13 @@ import (
 // GetResourceDependencies gets the full set of implicit and explicit dependencies for a Resource.
 func GetResourceDependencies(r *ast.ResourceDecl) []*ast.StringExpr {
 	var deps []*ast.StringExpr
-	for _, kvp := range r.Properties.Entries {
-		getExpressionDependencies(&deps, kvp.Value)
+
+	if r.Properties.PropertyMap != nil {
+		for _, kvp := range r.Properties.PropertyMap.Entries {
+			getExpressionDependencies(&deps, kvp.Value)
+		}
+	} else if r.Properties.Symbol != nil {
+		getExpressionDependencies(&deps, r.Properties.Symbol)
 	}
 	if r.Options.DependsOn != nil {
 		getExpressionDependencies(&deps, r.Options.DependsOn)

--- a/pkg/pulumiyaml/expr.go
+++ b/pkg/pulumiyaml/expr.go
@@ -15,8 +15,8 @@ func GetResourceDependencies(r *ast.ResourceDecl) []*ast.StringExpr {
 		for _, kvp := range r.Properties.PropertyMap.Entries {
 			getExpressionDependencies(&deps, kvp.Value)
 		}
-	} else if r.Properties.Symbol != nil {
-		getExpressionDependencies(&deps, r.Properties.Symbol)
+	} else if r.Properties.Expr != nil {
+		getExpressionDependencies(&deps, r.Properties.Expr)
 	}
 	if r.Options.DependsOn != nil {
 		getExpressionDependencies(&deps, r.Options.DependsOn)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1414,7 +1414,7 @@ func (e *programEvaluator) registerResourceWithParent(kvp resourceNode, parent p
 		if p, isPoison := readIntoProperties(*v.Properties.PropertyMap); isPoison {
 			return p, isPoison
 		}
-	} else {
+	} else if v.Properties.Symbol != nil {
 		// Evaluate the properties
 		pm, ok := e.evaluateExpr(v.Properties.Symbol)
 		if !ok {

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1414,9 +1414,9 @@ func (e *programEvaluator) registerResourceWithParent(kvp resourceNode, parent p
 		if p, isPoison := readIntoProperties(*v.Properties.PropertyMap); isPoison {
 			return p, isPoison
 		}
-	} else if v.Properties.Symbol != nil {
+	} else if v.Properties.Expr != nil {
 		// Evaluate the properties
-		pm, ok := e.evaluateExpr(v.Properties.Symbol)
+		pm, ok := e.evaluateExpr(v.Properties.Expr)
 		if !ok {
 			overallOk = false
 		}

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -2659,3 +2659,49 @@ outputs:
 	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
 	assert.NoError(t, err)
 }
+
+// TestResourceSecretObjectProperties tests we can use a secret object symbol for all the objects properties.
+func TestResourceSecretObjectProperties(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+config:
+  props: {}
+variables:
+  inputs:
+    fn::secret: ${props}
+resources:
+  my-resource:
+    type: test:resource:type
+    properties: ${inputs}
+outputs:
+  result:
+    fn::secret: ${my-resource}
+`
+	template := yamlTemplate(t, strings.TrimSpace(text))
+
+	mocks := &testMonitor{
+		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+			assert.Equal(t, "test:resource:type", args.TypeToken)
+			assert.Equal(t, resource.PropertyMap{
+				"foo": resource.MakeSecret(resource.NewStringProperty("bar")),
+				"bar": resource.MakeSecret(resource.NewNullProperty()),
+			}, args.Inputs)
+			return "", resource.PropertyMap{
+				"foo": resource.NewStringProperty("bar"),
+			}, nil
+		},
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		configMap := resource.PropertyMap{
+			"props": resource.NewObjectProperty(resource.PropertyMap{
+				"foo": resource.NewStringProperty("bar"),
+			}),
+		}
+
+		return RunTemplate(ctx, template, configMap, newMockPackageMap())
+	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
+	assert.NoError(t, err)
+}

--- a/pkg/pulumiyaml/run_test.go
+++ b/pkg/pulumiyaml/run_test.go
@@ -2631,9 +2631,6 @@ resources:
   my-resource:
     type: test:resource:type
     properties: ${props}
-outputs:
-  result:
-    fn::secret: ${my-resource}
 `
 	template := yamlTemplate(t, strings.TrimSpace(text))
 
@@ -2676,9 +2673,6 @@ resources:
   my-resource:
     type: test:resource:type
     properties: ${inputs}
-outputs:
-  result:
-    fn::secret: ${my-resource}
 `
 	template := yamlTemplate(t, strings.TrimSpace(text))
 

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -331,3 +331,10 @@ func TestPluginDownloadURLUsed(t *testing.T) {
 	stdout, _ = e.RunCommand("pulumi", "stack", "output", "randomString")
 	require.Len(t, strings.TrimSuffix(stdout, "\n"), 8, fmt.Sprintf("expected %s to have 8 characters", stdout))
 }
+
+//nolint:paralleltest // uses parallel programtest
+func TestResourcePropertiesConfig(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("testdata", "resource-properties-config"),
+	})
+}

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -335,6 +335,13 @@ func TestPluginDownloadURLUsed(t *testing.T) {
 //nolint:paralleltest // uses parallel programtest
 func TestResourcePropertiesConfig(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		OrderedConfig: []integration.ConfigValue{
+			{
+				Key:   "props.length",
+				Value: "8",
+				Path:  true,
+			},
+		},
 		Dir: filepath.Join("testdata", "resource-properties-config"),
 	})
 }

--- a/pkg/tests/testdata/parameterized/sdk/yaml/pkg-1.0.0.yaml
+++ b/pkg/tests/testdata/parameterized/sdk/yaml/pkg-1.0.0.yaml
@@ -2,6 +2,6 @@ packageDeclarationVersion: 1
 name: testprovider
 version: 0.0.1
 parameterization:
-  name: pkg
-  version: 1.0.0
-  value: cGtn
+    name: pkg
+    version: 1.0.0
+    value: cGtn

--- a/pkg/tests/testdata/parameterized/sdk/yaml/pkg-1.0.0.yaml
+++ b/pkg/tests/testdata/parameterized/sdk/yaml/pkg-1.0.0.yaml
@@ -2,6 +2,6 @@ packageDeclarationVersion: 1
 name: testprovider
 version: 0.0.1
 parameterization:
-    name: pkg
-    version: 1.0.0
-    value: cGtn
+  name: pkg
+  version: 1.0.0
+  value: cGtn

--- a/pkg/tests/testdata/resource-properties-config/Pulumi.yaml
+++ b/pkg/tests/testdata/resource-properties-config/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: resource-secret
+runtime:
+  name: yaml
+configuration:
+  props: {}
+resources:
+  randomPassword:
+    type: random:RandomPassword
+    properties: ${props}
+outputs:
+  superSecret:
+    fn::secret: ${randomPassword}

--- a/pkg/tests/testdata/resource-properties-config/Pulumi.yaml
+++ b/pkg/tests/testdata/resource-properties-config/Pulumi.yaml
@@ -1,7 +1,7 @@
 name: resource-secret
 runtime:
   name: yaml
-configuration:
+config:
   props: {}
 resources:
   randomPassword:

--- a/pkg/tests/transpiled_examples/resource-config-pp/resource-config.pp
+++ b/pkg/tests/transpiled_examples/resource-config-pp/resource-config.pp
@@ -1,0 +1,24 @@
+config inputs string {
+	__logicalName = "inputs"
+}
+
+resource randomPassword "random:index/randomPassword:RandomPassword" {
+	__logicalName = "randomPassword"
+	keepers = inputs.keepers
+	length = inputs.length
+	lower = inputs.lower
+	minLower = inputs.minLower
+	minNumeric = inputs.minNumeric
+	minSpecial = inputs.minSpecial
+	minUpper = inputs.minUpper
+	number = inputs.number
+	numeric = inputs.numeric
+	overrideSpecial = inputs.overrideSpecial
+	special = inputs.special
+	upper = inputs.upper
+}
+
+output password {
+	__logicalName = "password"
+	value = randomPassword.result
+}

--- a/pkg/tests/transpiled_examples/resource-config-pp/resource-config.pp
+++ b/pkg/tests/transpiled_examples/resource-config-pp/resource-config.pp
@@ -1,4 +1,4 @@
-config inputs string {
+config inputs {
 	__logicalName = "inputs"
 }
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-yaml/issues/770

This allows setting the properties of a resource with an object expression rather a fixed object:
```
resources:
  randomPassword:
    type: random:RandomPassword
    properties: ${inputs}
```
Where for example inputs is a config, object variable, or possible the output of another resource.

This is done by allowing either a `PropertyMapDecl` or an `Expr` for the "properties" key. For the `PropertyMap` case nothing changes. When we have an `Expr` we type check that the expression type matches the object shape of the resource. To actually set the properties depends on if the expression resolves as a plain map, in which case we simply copy each value off the map. Or if it resolves as an output, in which case we generate an Apply for each expected input property (given by the resource schema) to copy _that_ field from the map we expect the output to eventually resolve to.