### PR TITLE
fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install: install_pulumi-language-yaml install_pulumi-converter-yaml
 # Install a binary onto GOPATH
 .PHONY: install_%
 install_%: bin/%
-	cp $< $(or $(shell ${GO} env GOBIN),$(shell ${GO} env GOROOT)/bin)/$*
+	cp $< $(or $(shell ${GO} env GOBIN),$(shell ${GO} env GOPATH)/bin)/$*
 
 
 clean::


### PR DESCRIPTION
`make install` should fall back to `$GOPATH/bin`, not `$GOROOT/bin` if `$GOBIN` is not set.  I mentioned this in https://github.com/pulumi/pulumi-yaml/pull/791#discussion_r2084801184, but didn't realize automerge was enabled, so the PR was merged before the suggestion was applied.