### PR TITLE
Remove `codegen.ConvertTemplate`

### DIFF
--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -106,20 +106,3 @@ func EjectProgram(template *ast.TemplateDecl, loader schema.ReferenceLoader) (*p
 
 	return program, append(yamlDiags, diags...), nil
 }
-
-// ConvertTemplate converts a Pulumi YAML template to a target language using PCL as an intermediate representation.
-//
-// loader is the schema.Loader used when binding the the PCL program. If `nil`, a `schema.Loader` will be created from `newPluginHost()`.
-func ConvertTemplate(template *ast.TemplateDecl, generate GenerateFunc, loader schema.ReferenceLoader) (map[string][]byte, hcl.Diagnostics, error) {
-	program, diags, err := EjectProgram(template, loader)
-	if err != nil {
-		return nil, diags, err
-	}
-	if diags.HasErrors() {
-		return nil, diags, fmt.Errorf("internal error: %w", diags)
-	}
-
-	files, gdiags, err := generate(program)
-	diags = diags.Extend(gdiags)
-	return files, diags, err
-}


### PR DESCRIPTION
A [GH search](https://github.com/search?q=org%3Apulumi+ConvertTemplate&type=code) shows that this function is no longer used, we can remove it.