### PR TITLE
Downgrade to go 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ endef
 FALLBACK_DEV_VERSION := 1.0.0-dev.0
 DEV_VERSION := $(shell if command -v changie > /dev/null; then changie next patch -p dev.0; else echo "$(FALLBACK_DEV_VERSION)"; fi)
 
-_ := $(shell mkdir -p bin)
+HELPMAKEGO_VERSION := v0.2.0
+HELPMAKEGO := bin/${HELPMAKEGO_VERSION}/helpmakego
 
-HELPMAKEGO_VERSION := $(shell cat go.mod | grep 'github.com/iwahbe/helpmakego v' | awk '{ print $$2}')
-HELPMAKEGO := bin/$(HELPMAKEGO_VERSION)/helpmakego
-_ := $(shell if ! [ -x $(HELPMAKEGO) ]; then echo Building helpmakego@$(HELPMAKEGO_VERSION); go build -o $(dir $(HELPMAKEGO)) github.com/iwahbe/helpmakego; fi)
+_ := $(shell mkdir -p bin)
+_ := $(shell ./scripts/install_helpmakego.sh ${HELPMAKEGO_VERSION})
 
 .phony: .EXPORT_ALL_VARIABLES
 .EXPORT_ALL_VARIABLES:

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi-yaml
 
 go 1.23.0
 
-toolchain go1.23.7
-
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/ettle/strcase v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/pulumi/pulumi-yaml
 
-go 1.24
+go 1.23.0
+
+toolchain go1.23.7
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
@@ -107,7 +109,6 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.4.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/iwahbe/helpmakego v0.2.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
@@ -187,5 +188,3 @@ require (
 	lukechampine.com/frand v1.4.2 // indirect
 	mvdan.cc/gofumpt v0.5.0 // indirect
 )
-
-tool github.com/iwahbe/helpmakego

--- a/go.sum
+++ b/go.sum
@@ -350,8 +350,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/iwahbe/helpmakego v0.2.0 h1:ZpqfUhfw1Y5qn/08LT4OLYRWHWqHzag4Ang0glszFQk=
-github.com/iwahbe/helpmakego v0.2.0/go.mod h1:SNrBTLB/hEwr4EzMfcoMFVBGP9wQfJzSDF6PWZn4qac=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -437,8 +435,6 @@ github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/psanford/memfs v0.0.0-20241019191636-4ef911798f9b h1:xzjEJAHum+mV5Dd5KyohRlCyP03o4yq6vNpEUtAJQzI=
-github.com/psanford/memfs v0.0.0-20241019191636-4ef911798f9b/go.mod h1:tcaRap0jS3eifrEEllL6ZMd9dg8IlDpi2S1oARrQ+NI=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.13.0 h1:O2MPR2koScaQ2fXwyer8Q3Dd7z+DCnaDfsgNl5mVNMk=

--- a/scripts/install_helpmakego.sh
+++ b/scripts/install_helpmakego.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+HELPMAKEGO_VERSION="$1"
+HELPMAKEGO=bin/${HELPMAKEGO_VERSION}/helpmakego
+
+if ! [ -x ${HELPMAKEGO} ]; then
+    echo "Installing helpmakego@${HELPMAKEGO_VERSION}"
+    go install -mod readonly "github.com/iwahbe/helpmakego@${HELPMAKEGO_VERSION}"
+    mkdir -p "bin/${HELPMAKEGO_VERSION}"
+    cp $(go env GOPATH)/bin/helpmakego ${HELPMAKEGO}
+fi

--- a/scripts/install_helpmakego.sh
+++ b/scripts/install_helpmakego.sh
@@ -7,7 +7,5 @@ HELPMAKEGO=bin/${HELPMAKEGO_VERSION}/helpmakego
 
 if ! [ -x ${HELPMAKEGO} ]; then
     echo "Installing helpmakego@${HELPMAKEGO_VERSION}"
-    go install -mod readonly "github.com/iwahbe/helpmakego@${HELPMAKEGO_VERSION}"
-    mkdir -p "bin/${HELPMAKEGO_VERSION}"
-    cp $(go env GOPATH)/bin/helpmakego ${HELPMAKEGO}
+    GOBIN=${PWD}/bin/${HELPMAKEGO_VERSION} go install -mod readonly "github.com/iwahbe/helpmakego@${HELPMAKEGO_VERSION}"
 fi


### PR DESCRIPTION
Unfortunately pulumi-terraform-bridge library build-depends on pulumi-yaml as a library and therefore go 1.24 language requirement is a bit more infectious than anticipated and needs to affect all downstream bridged providers. Since pulumi/pulumi is itself on go 1.23 for the moment, this downgrades to 1.23 to match; the idea is to upgrade everything in Pulumi to 1.24 when the time comes to do that.

The HELPMAKEGO utility was automatically upgrading the project to go1.24 this is now fixed with `go install -mod readonly`.

https://github.com/pulumi/pulumi-terraform-bridge/issues/3077 reminder to chase down and remove the build-dependency.