### PR TITLE
fix panic when object key is not a string

### DIFF
--- a/.changes/unreleased/bug-fixes-816.yaml
+++ b/.changes/unreleased/bug-fixes-816.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Give a better error message when an object key is not a string, instead of panic'ing
+time: 2025-06-12T13:47:56.507610885+02:00
+custom:
+    PR: "816"

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -1052,7 +1052,16 @@ func (tc *typeCache) typeExpr(ctx *evalContext, t ast.Expr) bool {
 		properties := make([]*schema.Property, 0, len(t.Entries))
 		propNames := make([]string, 0, len(t.Entries))
 		for _, entry := range t.Entries {
-			k, v := entry.Key.(*ast.StringExpr), entry.Value
+			k, ok := entry.Key.(*ast.StringExpr)
+			if !ok {
+				tc.exprs[t] = &schema.InvalidType{
+					Diagnostics: []*hcl.Diagnostic{
+						{Summary: fmt.Sprintf("Object key must be a string, got %T", entry.Key)},
+					},
+				}
+				return true
+			}
+			v := entry.Value
 			properties = append(properties, &schema.Property{
 				Name: k.Value,
 				Type: tc.exprs[v],

--- a/pkg/pulumiyaml/analyser_test.go
+++ b/pkg/pulumiyaml/analyser_test.go
@@ -367,3 +367,20 @@ func TestConfigCompatibility(t *testing.T) {
 		})
 	}
 }
+
+func TestNonStringKeyInObjectReturnsError(t *testing.T) {
+	tc := typeCache{
+		exprs: make(map[ast.Expr]schema.Type),
+	}
+	expr := &ast.ObjectExpr{
+		Entries: []ast.ObjectProperty{
+			{
+				Key: &ast.BooleanExpr{},
+			},
+		},
+	}
+	_ = tc.typeExpr(nil, expr)
+	require.Equal(t, 1, len(tc.exprs))
+	require.Equal(t, "Object key must be a string, got *ast.BooleanExpr",
+		tc.exprs[expr].(*schema.InvalidType).Diagnostics[0].Summary)
+}

--- a/pkg/pulumiyaml/analyser_test.go
+++ b/pkg/pulumiyaml/analyser_test.go
@@ -369,6 +369,8 @@ func TestConfigCompatibility(t *testing.T) {
 }
 
 func TestNonStringKeyInObjectReturnsError(t *testing.T) {
+	t.Parallel()
+
 	tc := typeCache{
 		exprs: make(map[ast.Expr]schema.Type),
 	}


### PR DESCRIPTION
We currently don't support object keys that are not strings. However when a user uses something different than a string, e.g. a symbol, we just panic.  We can do better and give the user a diagnostic instead. Do that here.

Fixes https://github.com/pulumi/pulumi-yaml/issues/814