### PR TITLE
Hardcode yaml components to version 0.0.0

### DIFF
--- a/.changes/unreleased/bug-fixes-842.yaml
+++ b/.changes/unreleased/bug-fixes-842.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Always set a version for component schemas for `package add`
+time: 2025-07-23T10:52:03.349537+01:00
+custom:
+    PR: "842"

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -813,6 +813,7 @@ func (d *TemplateDecl) GenerateSchema() (schema.PackageSpec, error) {
 	schemaDef := schema.PackageSpec{
 		Name:        d.Name.Value,
 		Description: description,
+		Version:     "0.0.0",
 		Namespace:   namespace,
 		Language: map[string]schema.RawMessage{
 			"nodejs": schema.RawMessage(`{"respectSchemaVersion": true}`),

--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -175,6 +175,7 @@ func TestComponentSchemaGeneration(t *testing.T) {
   "name": "yaml-plugin",
   "description": "A YAML plugin",
   "namespace": "my-company",
+  "version": "0.0.0",
   "language": {
     "cshap": {
       "respectSchemaVersion": true

--- a/pkg/server/component_provider.go
+++ b/pkg/server/component_provider.go
@@ -39,7 +39,7 @@ type componentProvider struct {
 func (p *componentProvider) GetPluginInfo(context.Context, *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
 	// We fill in the version on the engine side for components.
 	return &pulumirpc.PluginInfo{
-		Version: "",
+		Version: "0.0.0",
 	}, nil
 }
 


### PR DESCRIPTION
`package add` requires that the schema sets a version, but its fine for us to just always use "0.0.0" for yaml.