### PR TITLE
[WIP] Fix incorrect config type

### DIFF
--- a/pkg/pulumiyaml/config/config.go
+++ b/pkg/pulumiyaml/config/config.go
@@ -63,7 +63,7 @@ var (
 	Number           = typ{schema.NumberType}
 	NumberList       = typ{&schema.ArrayType{ElementType: schema.NumberType}}
 	Boolean          = typ{schema.BoolType}
-	BooleanList      = typ{&schema.ArrayType{ElementType: schema.NumberType}}
+	BooleanList      = typ{&schema.ArrayType{ElementType: schema.BoolType}}
 	Int              = typ{schema.IntType}
 	IntList          = typ{&schema.ArrayType{ElementType: schema.IntType}}
 )


### PR DESCRIPTION
I think this is maybe enough of an edge case that it hasn't been discovered, but we incorrectly state that the type of `bool[]` is actually a list of numbers. This PR fixes that.