### PR TITLE
Report unknown types as PCL codegen errors

### DIFF
--- a/.changes/unreleased/Improvements-858.yaml
+++ b/.changes/unreleased/Improvements-858.yaml
@@ -1,6 +1,6 @@
 component: codegen
 kind: Improvements
-body: Unrecognised model types will now be reported as errors rather than failing silently
+body: Report unrecognised model types as errors rather than failing silently
 time: 2025-08-28T17:15:35.967773+02:00
 custom:
     PR: "858"

--- a/.changes/unreleased/Improvements-858.yaml
+++ b/.changes/unreleased/Improvements-858.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: Improvements
+body: Unrecognised model types will now be reported as errors rather than failing silently
+time: 2025-08-28T17:15:35.967773+02:00
+custom:
+    PR: "858"

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -550,7 +550,11 @@ func importParameterType(s string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return t.Pcl().String(), true
+	pcl, err := t.Pcl()
+	if err != nil {
+		return "", false
+	}
+	return pcl.String(), true
 }
 
 // importConfig imports a template config variable. The parameter is imported as a simple config variable definition.


### PR DESCRIPTION
I got bitten by this today: if we want to add a new type to PCL (or even handle a model/schema type we haven't previously), the codegen will fail silently, generating code like this:

```
config myValue "type(Invalid type :Map<any>)" {
    __logicalName = "myValue"
}
```

This PR reports this as an error, which will then be picked up in `load.go`:

```
...

typeExpr, ok = importParameterType(config.Type.Value)
if !ok {
  return nil, syntax.Diagnostics{ast.ExprError(config.Type, fmt.Sprintf("unrecognized type '%v' for config variable '%s'", config.Type.Value, name), "")}
}
...
```

... which should make this much easier to catch.