### PR TITLE
Upgrade the go pkg version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-yaml
 
-go 1.23.11
+go 1.24
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-yaml
 
-go 1.24
+go 1.24.7
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
1.23 is EOL and has CVE's against it. We previously didn't upgrade since it broke the bridge, but the bridge has since upgraded to 1.24. We can do the same.

Fixes #845 