### PR TITLE
Use the engine to load plugins

### DIFF
--- a/.changes/unreleased/Improvements-301.yaml
+++ b/.changes/unreleased/Improvements-301.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Use the engine for plugin loading, instead of loading another copy of a plugin for type checking
+time: 2025-12-03T12:49:52.832569+01:00
+custom:
+    PR: "301"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -165,7 +165,7 @@ func TestLanguage(t *testing.T) {
 	// Run the language plugin
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
-			pulumirpc.RegisterLanguageRuntimeServer(srv, server.NewLanguageHost(engineAddress, "", true /* useRPCLoader */))
+			pulumirpc.RegisterLanguageRuntimeServer(srv, server.NewLanguageHost(engineAddress, ""))
 			pulumirpc.RegisterConverterServer(srv, plugin.NewConverterServer(converter.New()))
 			return nil
 		},

--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -76,7 +76,7 @@ func main() {
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Cancel: cancelChannel,
 		Init: func(srv *grpc.Server) error {
-			host := server.NewLanguageHost(engineAddress, tracing, false /* useRPCLoader */)
+			host := server.NewLanguageHost(engineAddress, tracing)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -15,13 +14,9 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/packages"
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 type ResourceTypeToken string
@@ -90,14 +85,6 @@ func (l packageLoader) Close() {
 	if l.host != nil {
 		l.host.Close()
 	}
-}
-
-func NewPackageLoader(plugins *workspace.Plugins, packages map[string]workspace.PackageSpec) (PackageLoader, error) {
-	host, err := newResourcePackageHost(plugins, packages)
-	if err != nil {
-		return nil, err
-	}
-	return packageLoader{schema.NewCachedLoader(schema.NewPluginLoader(host)), host}, nil
 }
 
 // Unsafely create a PackageLoader from a schema.Loader, forfeiting the ability to close the host
@@ -576,22 +563,4 @@ func getResourceConstants(props []*schema.Property) map[string]any {
 	}
 
 	return constantProps
-}
-
-func newResourcePackageHost(plugins *workspace.Plugins, packages map[string]workspace.PackageSpec) (plugin.Host, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
-		Color: cmdutil.GetGlobalColorization(),
-	})
-	ctx := context.Background()
-	pluginCtx, err := plugin.NewContextWithRoot(ctx, sink, sink, nil, cwd, cwd, nil, true, nil, plugins, packages, nil, nil,
-		schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
-	if err != nil {
-		return nil, err
-	}
-
-	return pluginCtx.Host, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,16 +71,13 @@ type yamlLanguageHost struct {
 	engineAddress string
 	tracing       string
 
-	useRPCLoader  bool
 	templateCache map[string]templateCacheEntry
 }
 
-func NewLanguageHost(engineAddress, tracing string, useRPCLoader bool) pulumirpc.LanguageRuntimeServer {
+func NewLanguageHost(engineAddress, tracing string) pulumirpc.LanguageRuntimeServer {
 	return &yamlLanguageHost{
 		engineAddress: engineAddress,
 		tracing:       tracing,
-
-		useRPCLoader:  useRPCLoader,
 		templateCache: make(map[string]templateCacheEntry),
 	}
 }
@@ -215,15 +212,6 @@ func (host *yamlLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 		fmt.Sprintf(`PULUMI_ROOT_DIRECTORY=%s`, req.Info.RootDirectory),
 	}
 
-	projPath, err := workspace.DetectProjectPathFrom(req.Info.RootDirectory)
-	if err != nil {
-		return nil, err
-	}
-	proj, err := workspace.LoadProject(projPath)
-	if err != nil {
-		return nil, err
-	}
-
 	compiler, err := parseCompiler(req.Info.Options.AsMap())
 	if err != nil {
 		return nil, err
@@ -306,20 +294,12 @@ func (host *yamlLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 
 	// Because of async applies we may need the package loader to outlast the RunTemplate function. But by the
 	// time RunWithContext returns we should be done with all async work.
-	var loader pulumiyaml.PackageLoader
-	if host.useRPCLoader {
-		rpcLoader, err := schema.NewLoaderClient(req.LoaderTarget)
-		if err != nil {
-			return &pulumirpc.RunResponse{Error: err.Error()}, nil
-		}
-		loader = pulumiyaml.NewPackageLoaderFromSchemaLoader(
-			schema.NewCachedLoader(rpcLoader))
-	} else {
-		loader, err = pulumiyaml.NewPackageLoader(proj.Plugins, proj.GetPackageSpecs())
-		if err != nil {
-			return &pulumirpc.RunResponse{Error: err.Error()}, nil
-		}
+	rpcLoader, err := schema.NewLoaderClient(req.LoaderTarget)
+	if err != nil {
+		return &pulumirpc.RunResponse{Error: err.Error()}, nil
 	}
+	loader := pulumiyaml.NewPackageLoaderFromSchemaLoader(
+		schema.NewCachedLoader(rpcLoader))
 	defer loader.Close()
 
 	// Now instruct the Pulumi Go SDK to run the pulumi YAML interpreter.
@@ -381,22 +361,19 @@ func (host *yamlLanguageHost) RunPlugin(
 	}
 	defer pctx.Close()
 
+	loaderTarget := req.LoaderTarget
+	if loaderTarget == "" {
+		loaderTarget = host.engineAddress
+	}
+	rpcLoader, err := schema.NewLoaderClient(loaderTarget)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(rpcLoader)
+
 	// Because of async applies we may need the package loader to outlast the RunTemplate function. But by the
 	// time RunWithContext returns we should be done with all async work.
-	var loader pulumiyaml.PackageLoader
-	if req.LoaderTarget != "" {
-		schemaLoader, lerr := schema.NewLoaderClient(req.LoaderTarget)
-		if lerr != nil {
-			return lerr
-		}
-		defer contract.IgnoreClose(schemaLoader)
-		loader = pulumiyaml.NewPackageLoaderFromSchemaLoader(schema.NewCachedLoader(schemaLoader))
-	} else {
-		loader, err = pulumiyaml.NewPackageLoader(nil, nil)
-		if err != nil {
-			return err
-		}
-	}
+	loader := pulumiyaml.NewPackageLoaderFromSchemaLoader(schema.NewCachedLoader(rpcLoader))
 	defer loader.Close()
 
 	schema, err := template.GenerateSchema()


### PR DESCRIPTION
We already had this capability in the engine, and we use it for language tests (conformance tests). We should use the same capability during normal operation.

Fixes #301