### PR TITLE
Test resolveToken

### DIFF
--- a/pkg/pulumiyaml/packages_test.go
+++ b/pkg/pulumiyaml/packages_test.go
@@ -65,8 +65,7 @@ func TestResolveToken(t *testing.T) {
 			})
 
 			if tt.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.expectedError)
+				require.ErrorContains(t, err, tt.expectedError)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.found, found)


### PR DESCRIPTION
Pulumi-yaml allows you to abbreviate tokens, for example `pkg:type` gets resolved as `pkg:index:type`. It also allows abbreviating terraform bridge types like `aws:s3/bucket:Bucket` as `aws:s3:Bucket`.

The latter is a little finicky in regards to the lower casing, specifically `gcp:iam:IAMMember` needs to become `gcp:iam/iAMMember:IAMMember`. That is we lowercase the first character, not the whole acronym.

Currently we use `strcase.ToLowerCamel` from `github.com/iancoleman/strcase`. In v0.2.0 this behaves as required, only the first character is lower cased, but in v0.3.0 this was fixed to lowercase the whole acronym, and would generate `gcp:iam/iammember:IAMMember`.

This lead to a regression https://github.com/pulumi/pulumi/issues/21217

This PR adds tests to ensure we don’t break this again. In a follow up we can remove the usage of `strcase.ToLowerCamel` in this instance and match the code in the bridge.
