### PR TITLE
Implement `pulumirpc.Link` for `yamlLanguageHost`

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -754,3 +754,10 @@ func (host *yamlLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReque
 		ArtifactPath: dst,
 	}, nil
 }
+
+func (host *yamlLanguageHost) Link(context.Context, *pulumirpc.LinkRequest) (*pulumirpc.LinkResponse, error) {
+	// YAML doesn't need to do anything to link in a package.
+	//
+	// We still implement Link so the engine knows that we have done all we need to do.
+	return &pulumirpc.LinkResponse{}, nil
+}


### PR DESCRIPTION
The implementation is trivial, but this is required for https://github.com/pulumi/pulumi/issues/21323.