### PR TITLE
Add codegen support for "cwd"

### DIFF
--- a/.changes/unreleased/Improvements-935.yaml
+++ b/.changes/unreleased/Improvements-935.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: Improvements
+body: Add support for fn::cwd -> ${pulumi.cwd}
+time: 2026-02-02T18:56:59.125457+01:00
+custom:
+    PR: "935"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -174,8 +174,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l1-builtin-can":                               "#721 generation unimplemented",
-	"l1-builtin-cwd":                               "test failing",
-	"l1-builtin-project-root-main":                 "test failing",
 	"l1-builtin-require-pulumi-version":            "not yet implemented (https://github.com/pulumi/pulumi-yaml/issues/924)",
 	"l1-builtin-stash":                             "not yet implemented",
 	"l1-builtin-try":                               "#721 generation unimplemented",

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-cwd/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-cwd/Main.yaml
@@ -1,0 +1,2 @@
+outputs:
+  cwdOutput: ${pulumi.cwd}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-cwd/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-cwd/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-cwd
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-project-root-main/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-project-root-main/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: l1-builtin-project-root-main
+runtime: yaml
+main: subdir

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-project-root-main/subdir/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-project-root-main/subdir/Main.yaml
@@ -1,0 +1,3 @@
+outputs:
+  rootDirectoryOutput: ${pulumi.rootDirectory}
+  workingDirectoryOutput: ${pulumi.cwd}

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -760,6 +760,8 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return wrapFn("readFile", g.expr(f.Args[0]))
 	case "secret":
 		return wrapFn("secret", g.expr(f.Args[0]))
+	case "cwd":
+		return syn.String("${pulumi.cwd}")
 	case "getOutput":
 		// getOutput(var, key) => ${var.outputs[key]}
 


### PR DESCRIPTION
This unblocks 2 language conformance tests:

- l1-builtin-cwd
- l1-builtin-project-root-main