### PR TITLE
Correctly apply `parent` to invokes running within a component

### DIFF
--- a/.changes/unreleased/bug-fixes-955.yaml
+++ b/.changes/unreleased/bug-fixes-955.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Correctly apply parent to invokes running within a component
+time: 2026-02-21T15:07:25.119265+01:00
+custom:
+    PR: "955"


### PR DESCRIPTION
Invokes need to be passed parent the same as resources. This PR changes where parent is passed so it can reach invokes as well as resources. It adds a unit test for this behavior (and one for resources for good measure).

Fixes https://github.com/pulumi/pulumi-yaml/issues/955