### PR TITLE
Fix property access on `any` typed objects

### DIFF
--- a/.changes/unreleased/bug-fixes-974.yaml
+++ b/.changes/unreleased/bug-fixes-974.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Fix property access of `any` typed objects
+time: 2026-03-06T12:20:24.975982Z
+custom:
+    PR: "974"

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -949,6 +949,12 @@ func typePropertyAccess(ctx *evalContext, root schema.Type,
 	if len(accessors) == 0 {
 		return root
 	}
+	// If the type is any, allow any property/subscript access and return any. This handles cases like accessing a
+	// property of a variable that holds an element of an object-typed config value, where the element type is any.
+	if codegen.UnwrapType(root) == schema.AnyType {
+		return schema.AnyType
+	}
+
 	if root, ok := root.(*schema.UnionType); ok {
 		var possibilities OrderedTypeSet
 		errs := []*notAssignable{}

--- a/pkg/pulumiyaml/run_variable_test.go
+++ b/pkg/pulumiyaml/run_variable_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test that we can evaluate the Pulumi built-in variable.
@@ -362,4 +363,36 @@ func testVariableDiags(t *testing.T, template *ast.TemplateDecl, callback func(*
 	assert.NoError(t, err)
 	assert.Equal(t, 1, testInvokeCalls)
 	return nil
+}
+
+// Regression test for https://github.com/pulumi/pulumi-yaml/issues/959
+// Dot-notation property access on a variable that holds an element from an
+// object-typed config value should not produce a type error.
+func TestVariableDotAccessOnObjectConfigElement(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+config:
+  data:
+    type: object
+variables:
+  nametag: ${data.nametag}
+  team: ${nametag.Team}
+`
+
+	tmpl := yamlTemplate(t, strings.TrimSpace(text))
+	configMap := resource.PropertyMap{
+		resource.PropertyKey(testProject + ":data"): resource.NewObjectProperty(resource.PropertyMap{
+			"nametag": resource.NewObjectProperty(resource.PropertyMap{
+				"Team": resource.NewStringProperty("dev"),
+			}),
+		}),
+	}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		return RunTemplate(ctx, tmpl, configMap, newMockPackageMap())
+	}, pulumi.WithMocks(testProject, "dev", &testMonitor{}))
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-yaml/issues/959

When type checking property accessors if we ever encounter any `any` type allow the access and just return the resulting type as `any` as well.