### PR TITLE
rename env variable used for otel internal endpoint

### DIFF
--- a/cmd/pulumi-language-yaml/main.go
+++ b/cmd/pulumi-language-yaml/main.go
@@ -47,13 +47,19 @@ func main() {
 	var cancelChannel chan bool
 	args := flag.Args()
 	logging.InitLogging(false, 0, false)
-	cmdutil.InitTracing("pulumi-language-yaml", "pulumi-language-yaml", tracing)
 
-	otelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-	if err := cmdutil.InitOtelTracing("pulumi-language-yaml", otelEndpoint); err != nil {
-		logging.V(3).Infof("failed to initialize OTel tracing: %v", err)
+	// Use OTel when the CLI provides an OTLP endpoint; fall back to
+	// OpenTracing otherwise.  Only one system should be active to avoid
+	// duplicate spans.
+	otelEndpoint := os.Getenv("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT")
+	if otelEndpoint == "" {
+		cmdutil.InitTracing("pulumi-language-yaml", "pulumi-language-yaml", tracing)
+	} else {
+		if err := cmdutil.InitOtelTracing("pulumi-language-yaml", otelEndpoint); err != nil {
+			logging.V(3).Infof("failed to initialize OTel tracing: %v", err)
+		}
+		defer cmdutil.CloseOtelTracing()
 	}
-	defer cmdutil.CloseOtelTracing()
 
 	// Fetch the engine address if available so we can do logging, etc.
 	var engineAddress string


### PR DESCRIPTION
We're using this env variable to pass the addres of the internal otel receiver to plugins. However some users might already have set the env variable in their environment, which may lead to confusion, and wasn't intended.

Prefix the env variable with `PULUMI_`, so we don't accidentally enable this feature for users that didn't intend to do so.

Goes with https://github.com/pulumi/pulumi/pull/22187