### PR TITLE
Fix getting-started example S3 AccessDenied by adding missing dependsOn

### DIFF
--- a/examples/getting-started/Pulumi.yaml
+++ b/examples/getting-started/Pulumi.yaml
@@ -30,5 +30,6 @@ resources:
     options:
       dependsOn:
         - ${ownershipControls}
+        - ${publicAccessBlock}
 outputs:
   bucketEndpoint: http://${my-bucket.websiteEndpoint}

--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -58,7 +58,6 @@ func TestExampleAzureAppService(t *testing.T) {
 
 //nolint:paralleltest // uses parallel programtest
 func TestExampleGettingStarted(t *testing.T) {
-	t.Skip("https://github.com/pulumi/pulumi-yaml/issues/523")
 	testWrapper(t, exampleDir("getting-started"), RequireLiveRun, awsConfig)
 }
 


### PR DESCRIPTION
The index.html BucketObject uses acl: public-read but only depended on
ownershipControls, not publicAccessBlock. Without waiting for the
publicAccessBlock (which sets blockPublicAcls: false) to be applied,
the upload could fail with AccessDenied (HTTP 403).

Add publicAccessBlock to the dependsOn list and unskip the test.

Fixes #523

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
