### PR TITLE
Unskip l2-invoke-options-depends-on

### DIFF
--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -138,7 +138,6 @@ var expectedEjectFailures = map[string]string{
 	"l1-empty":                           "empty YAML program cannot be ejected (yamlgen.Eject returns 'no diagnostics')",
 	"l2-logical-name":                    "not implemented",
 	"l2-explicit-parameterized-provider": "parameterization is not preserved",
-	"l2-invoke-options-depends-on":       "does not generate out depends on",
 	"l2-large-string":                    "gRPC message exceeds max size during converter test",
 	"l2-parameterized-invoke":            "parameterization is not preserved",
 	"l2-parameterized-resource":          "parameterization is not preserved",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-invoke-options-depends-on/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-invoke-options-depends-on/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-options-depends-on
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-invoke-options-depends-on/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-invoke-options-depends-on/program.pp
@@ -1,0 +1,24 @@
+data = invoke("simple-invoke:index:myInvoke", {
+	value = "hello"
+}, {
+	dependsOn = [first]
+})
+
+resource explicitProvider "pulumi:providers:simple-invoke" {
+	__logicalName = "explicitProvider"
+}
+
+resource first "simple-invoke:index:StringResource" {
+	__logicalName = "first"
+	text = "first hello"
+}
+
+resource second "simple-invoke:index:StringResource" {
+	__logicalName = "second"
+	text = data.result
+}
+
+output hello {
+	__logicalName = "hello"
+	value = data.result
+}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-invoke-options-depends-on/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-invoke-options-depends-on/Main.yaml
@@ -1,0 +1,22 @@
+resources:
+  explicitProvider:
+    type: pulumi:providers:simple-invoke
+  first:
+    type: simple-invoke:StringResource
+    properties:
+      text: first hello
+  second:
+    type: simple-invoke:StringResource
+    properties:
+      text: ${data.result}
+variables:
+  data:
+    fn::invoke:
+      function: simple-invoke:myInvoke
+      arguments:
+        value: hello
+      options:
+        dependsOn:
+          - ${first}
+outputs:
+  hello: ${data.result}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-invoke-options-depends-on/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-invoke-options-depends-on/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-options-depends-on
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-invoke-options-depends-on/sdks/simple-invoke.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-invoke-options-depends-on/sdks/simple-invoke.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple-invoke
+version: 10.0.0

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -360,6 +360,18 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 		if node.CallOpts.PluginDownloadURL != nil {
 			appendOption("pluginDownloadUrl", node.CallOpts.PluginDownloadURL)
 		}
+		if node.CallOpts.DependsOn != nil {
+			refs, rdiags := imp.getResourceRefList(node.CallOpts.DependsOn, node.Token.Value, "dependsOn")
+			diags.Extend(rdiags...)
+			if len(refs) > 0 {
+				invokeOptions = append(invokeOptions, model.ObjectConsItem{
+					Key: plainLit("dependsOn"),
+					Value: &model.TupleConsExpression{
+						Expressions: refs,
+					},
+				})
+			}
+		}
 
 		if len(invokeOptions) > 0 {
 			invokeArgs = append(invokeArgs, &model.ObjectConsExpression{


### PR DESCRIPTION
Emit `dependsOn` when ejecting invoke options to PCL, fixing the eject round-trip test.