### PR TITLE
Fix `l2-logical-name`

### DIFF
--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -132,7 +132,6 @@ var expectedFailures = map[string]string{
 // Add test names here that are expected to fail the converter (eject) round-trip test.
 var expectedEjectFailures = map[string]string{
 	"l1-builtin-require-pulumi-version":  "ejecting require-pulumi-version not implemented",
-	"l2-logical-name":                    "not implemented",
 	"l2-explicit-parameterized-provider": "parameterization is not preserved",
 	"l2-large-string":                    "gRPC message exceeds max size during converter test",
 	"l2-parameterized-invoke":            "parameterization is not preserved",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-logical-name/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-logical-name/program.pp
@@ -1,18 +1,18 @@
 config configLexicalName bool {
-	__logicalName = "configLexicalName"
+	__logicalName = "cC-Charlie_charlie.\U0001f603⁉️"
 }
 
 resource resourceLexicalName "simple:index:Resource" {
-	__logicalName = "resourceLexicalName"
+	__logicalName = "aA-Alpha_alpha.\U0001f92f⁉️"
 	value = configLexicalName
 }
 
 output bBBetaBeta {
-	__logicalName = "bB-Beta_beta.💜⁉"
+	__logicalName = "bB-Beta_beta.\U0001f49c⁉"
 	value = resourceLexicalName.value
 }
 
 output dDDeltaDelta {
-	__logicalName = "dD-Delta_delta.🔥⁉"
+	__logicalName = "dD-Delta_delta.\U0001f525⁉"
 	value = resourceLexicalName.value
 }

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-logical-name/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-logical-name/Main.yaml
@@ -1,9 +1,11 @@
 configuration:
   configLexicalName:
     type: bool
+    name: "cC-Charlie_charlie.\U0001F603⁉️"
 resources:
   resourceLexicalName:
     type: simple:Resource
+    name: "aA-Alpha_alpha.\U0001F92F⁉️"
     properties:
       value: ${configLexicalName}
 outputs:

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -599,10 +599,14 @@ func (imp *importer) importConfig(kvp ast.ConfigMapEntry) (model.BodyItem, synta
 		labels = append(labels, typeExpr)
 	}
 
+	logicalName := kvp.Key.GetValue()
+	if config.Name != nil {
+		logicalName = config.Name.Value
+	}
 	bodyItems := []model.BodyItem{
 		&model.Attribute{
 			Name:  pcl.LogicalNamePropertyKey,
-			Value: quotedLit(kvp.Key.GetValue()),
+			Value: quotedLit(logicalName),
 		},
 	}
 	if config.Secret != nil && config.Secret.Value {
@@ -817,10 +821,14 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry, latestPkgInfo map
 	contract.Assertf(props != nil,
 		"token(%s) was obtained by the same ResolveResource call as pkg(%s),"+
 			" so must produce a non nil value", token.String(), pkg.Name())
+	logicalName := name
+	if resource.Name != nil {
+		logicalName = resource.Name.Value
+	}
 	items := []model.BodyItem{
 		&model.Attribute{
 			Name:  pcl.LogicalNamePropertyKey,
-			Value: quotedLit(name),
+			Value: quotedLit(logicalName),
 		},
 	}
 


### PR DESCRIPTION
When ejecting YAML to PCL, the importer was using the YAML map key as `__logicalName` for config variables and resources instead of the YAML `name:` property. The map key is the lexical identifier; the `name:` property is the actual logical name used in Pulumi state.