### PR TITLE
Unskip l1-builtin-stash

### DIFF
--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -103,7 +103,6 @@ var expectedFailures = map[string]string{
 	"l1-builtin-list":                              "Unknown Function; YAML does not support fn::length",
 	"l1-builtin-object":                            "Unknown Function; YAML does not support fn::entries",
 	"l1-builtin-secret":                            "Unknown Function; YAML does not support fn::unsecret",
-	"l1-builtin-stash":                             "not yet implemented",
 	"l1-builtin-try":                               "#721 generation unimplemented",
 	"l1-config-secret":                             "*model.BinaryOpExpression; Unimplemented! Needed for  aNumber + 1.25",
 	"l1-config-types-object":                       "not yet implemented",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/0/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/0/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-stash
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/0/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/0/program.pp
@@ -1,0 +1,20 @@
+resource myStash "pulumi:index:Stash" {
+	__logicalName = "myStash"
+	input = {
+		"key" = [
+			"value",
+			"s"
+		],
+		"" = false
+	}
+}
+
+output stashInput {
+	__logicalName = "stashInput"
+	value = myStash.input
+}
+
+output stashOutput {
+	__logicalName = "stashOutput"
+	value = myStash.output
+}

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-stash
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/1/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-stash/1/program.pp
@@ -1,0 +1,14 @@
+resource myStash "pulumi:index:Stash" {
+	__logicalName = "myStash"
+	input = "ignored"
+}
+
+output stashInput {
+	__logicalName = "stashInput"
+	value = myStash.input
+}
+
+output stashOutput {
+	__logicalName = "stashOutput"
+	value = myStash.output
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/0/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/0/Main.yaml
@@ -1,0 +1,12 @@
+resources:
+  myStash:
+    type: pulumi:Stash
+    properties:
+      input:
+        key:
+          - value
+          - s
+        "": false
+outputs:
+  stashInput: ${myStash.input}
+  stashOutput: ${myStash.output}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/0/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/0/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-stash
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/1/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/1/Main.yaml
@@ -1,0 +1,8 @@
+resources:
+  myStash:
+    type: pulumi:Stash
+    properties:
+      input: ignored
+outputs:
+  stashInput: ${myStash.input}
+  stashOutput: ${myStash.output}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-stash/1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-stash
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/0/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/0/Main.yaml
@@ -1,0 +1,12 @@
+resources:
+  myStash:
+    type: pulumi:Stash
+    properties:
+      input:
+        key:
+          - value
+          - s
+        "": false
+outputs:
+  stashInput: ${myStash.input}
+  stashOutput: ${myStash.output}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/0/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/0/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-stash
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/1/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/1/Main.yaml
@@ -1,0 +1,8 @@
+resources:
+  myStash:
+    type: pulumi:Stash
+    properties:
+      input: ignored
+outputs:
+  stashInput: ${myStash.input}
+  stashOutput: ${myStash.output}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-stash/1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-stash
+runtime: yaml


### PR DESCRIPTION
The l1-builtin-stash conformance test now passes without any code changes. This removes it from the expected failures list and checks in the generated snapshot files.