### PR TITLE
Unskip l2-proxy-index

### DIFF
--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -116,7 +116,6 @@ var expectedFailures = map[string]string{
 	"l2-module-format":                             "https://github.com/pulumi/pulumi-yaml/issues/951",
 	"l2-provider-call":                             "Traversal not allowed on function result",
 	"l2-provider-call-explicit":                    "Traversal not allowed on function result",
-	"l2-proxy-index":                               "test failing",
 	"l2-resource-elide-unknowns":                   `*model.BinaryOpExpression; Unimplemented! Needed for  unknown.output == "hello"`,
 	"l2-resource-name-type":                        "Unknown Function; YAML does not support fn::pulumiResourceName",
 	"l2-resource-option-additional-secret-outputs": "program.pp: undefined variable value",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-proxy-index/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-proxy-index/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-proxy-index
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-proxy-index/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-proxy-index/program.pp
@@ -1,0 +1,48 @@
+resource res "ref-ref:index:Resource" {
+	__logicalName = "res"
+	data = {
+		innerData = {
+			boolean = false,
+			float = 2.17,
+			integer = -12,
+			string = "Goodbye",
+			boolArray = [
+				false,
+				true
+			],
+			stringMap = {
+				"two" = "turtle doves",
+				"three" = "french hens"
+			}
+		},
+		boolean = true,
+		float = 4.5,
+		integer = 1024,
+		string = "Hello",
+		boolArray = [true],
+		stringMap = {
+			"x" = "100",
+			"y" = "200"
+		}
+	}
+}
+
+output bool {
+	__logicalName = "bool"
+	value = res.data.boolean
+}
+
+output array {
+	__logicalName = "array"
+	value = res.data.boolArray[0]
+}
+
+output map {
+	__logicalName = "map"
+	value = res.data.stringMap.x
+}
+
+output nested {
+	__logicalName = "nested"
+	value = res.data.innerData.stringMap.three
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-proxy-index/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-proxy-index/Main.yaml
@@ -1,0 +1,32 @@
+resources:
+  # Check we can index into properties of objects returned in outputs, this is similar to ref-ref but 
+  # we index into the outputs
+  res:
+    type: ref-ref:Resource
+    properties:
+      data:
+        innerData:
+          boolean: false
+          float: 2.17
+          integer: -12
+          string: Goodbye
+          boolArray:
+            - false
+            - true
+          stringMap:
+            two: turtle doves
+            three: french hens
+        boolean: true
+        float: 4.5
+        integer: 1024
+        string: Hello
+        boolArray:
+          - true
+        stringMap:
+          x: '100'
+          y: '200'
+outputs:
+  bool: ${res.data.boolean}
+  array: ${res.data.boolArray[0]}
+  map: ${res.data.stringMap.x}
+  nested: ${res.data.innerData.stringMap.three}

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-proxy-index/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-proxy-index/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-proxy-index
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-proxy-index/sdks/ref-ref.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-proxy-index/sdks/ref-ref.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: ref-ref
+version: 12.0.0

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-proxy-index/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-proxy-index/Main.yaml
@@ -1,0 +1,30 @@
+resources:
+  res:
+    type: ref-ref:Resource
+    properties:
+      data:
+        innerData:
+          boolean: false
+          float: 2.17
+          integer: -12
+          string: Goodbye
+          boolArray:
+            - false
+            - true
+          stringMap:
+            two: turtle doves
+            three: french hens
+        boolean: true
+        float: 4.5
+        integer: 1024
+        string: Hello
+        boolArray:
+          - true
+        stringMap:
+          x: '100'
+          y: '200'
+outputs:
+  bool: ${res.data.boolean}
+  array: ${res.data.boolArray[0]}
+  map: ${res.data.stringMap.x}
+  nested: ${res.data.innerData.stringMap.three}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-proxy-index/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-proxy-index/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-proxy-index
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-proxy-index/sdks/ref-ref.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-proxy-index/sdks/ref-ref.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: ref-ref
+version: 12.0.0


### PR DESCRIPTION
The l2-proxy-index conformance test now passes without any code changes. This removes it from the expected failures list and checks in the generated snapshot files.