### PR TITLE
Unskip l2-large-string

### DIFF
--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -125,9 +125,7 @@ var expectedFailures = map[string]string{
 }
 
 // Add test names here that are expected to fail the converter (eject) round-trip test.
-var expectedEjectFailures = map[string]string{
-	"l2-large-string": "gRPC message exceeds max size during converter test",
-}
+var expectedEjectFailures = map[string]string{}
 
 func log(t *testing.T, name, message string) {
 	if os.Getenv("PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT") != "true" {
@@ -199,7 +197,7 @@ func TestLanguage(t *testing.T) {
 				Token:            prepare.Token,
 				Test:             tt,
 				SkipConvertTests: has(expectedEjectFailures, tt),
-			})
+			}, grpc.MaxCallRecvMsgSize(1024*1024*1024))
 
 			require.NoError(t, err)
 			for _, msg := range result.Messages {

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-large-string/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-large-string/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-large-string
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-large-string/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-large-string/program.pp
@@ -1,0 +1,9 @@
+resource res "large:index:String" {
+	__logicalName = "res"
+	value = "hello world"
+}
+
+output output {
+	__logicalName = "output"
+	value = res.value
+}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-large-string/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-large-string/Main.yaml
@@ -1,0 +1,7 @@
+resources:
+  res:
+    type: large:String
+    properties:
+      value: hello world
+outputs:
+  output: ${res.value}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-large-string/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-large-string/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-large-string
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-large-string/sdks/large.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-large-string/sdks/large.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: large
+version: 4.3.2


### PR DESCRIPTION
Increase gRPC max receive message size on the `RunLanguageTest` call to 1 GB (matching `pulumi-language-pcl`), allowing the l2-large-string eject round-trip test to pass. The test's ~100 MB string exceeded the default 4 MB gRPC message limit.