### PR TITLE
Cache packages loaded by the in-process loader

### DIFF
--- a/.changes/unreleased/bug-fixes-1022.yaml
+++ b/.changes/unreleased/bug-fixes-1022.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Cache package loads so they aren't re-loaded over and over
+time: 2026-04-01T20:32:32.230505+01:00
+custom:
+    PR: "1022"

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -97,7 +97,7 @@ func NewPackageLoader(plugins *workspace.Plugins, packages map[string]workspace.
 	if err != nil {
 		return nil, err
 	}
-	return packageLoader{schema.NewPluginLoader(host), host}, nil
+	return packageLoader{schema.NewCachedLoader(schema.NewPluginLoader(host)), host}, nil
 }
 
 // Unsafely create a PackageLoader from a schema.Loader, forfeiting the ability to close the host


### PR DESCRIPTION
We cached in the YAML process when using the RPC loader, but not the in-process loader. That could result in many many calls to GetSchema that weren't needed.