### PR TITLE
Unskip l2-resource-option-replacement-trigger

### DIFF
--- a/.changes/unreleased/Improvements-1025.yaml
+++ b/.changes/unreleased/Improvements-1025.yaml
@@ -1,0 +1,5 @@
+kind: Improvements
+body: Support replacementTrigger resource option
+component: runtime
+custom:
+  PR: 1025

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -117,7 +117,6 @@ var expectedFailures = map[string]string{
 	"l2-resource-elide-unknowns":             `*model.BinaryOpExpression; Unimplemented! Needed for  unknown.output == "hello"`,
 	"l2-resource-name-type":                  "Unknown Function; YAML does not support fn::pulumiResourceName",
 	"l2-resource-option-plugin-download-url": "https://github.com/pulumi/pulumi-yaml/issues/944",
-	"l2-resource-option-replacement-trigger": "not yet implemented",
 	"l2-resource-option-version":             "https://github.com/pulumi/pulumi-yaml/issues/943",
 	"l2-resource-config-objects":             "unrecognized type 'map(bool)' for config variable; undefined variable plainBooleanMap",
 	"l2-resource-config-primitives":          "*model.BinaryOpExpression; Unimplemented! Needed for  plainNumber + 0.5",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/0/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/0/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-option-replacement-trigger
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/0/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/0/program.pp
@@ -1,0 +1,40 @@
+resource replacementTrigger "simple:index:Resource" {
+	__logicalName = "replacementTrigger"
+	value = true
+
+	options {
+		replacementTrigger = "test"
+	}
+}
+
+resource unknown "output:index:Resource" {
+	__logicalName = "unknown"
+	value = 1
+}
+
+resource unknownReplacementTrigger "simple:index:Resource" {
+	__logicalName = "unknownReplacementTrigger"
+	value = true
+
+	options {
+		replacementTrigger = "hellohello"
+	}
+}
+
+resource notReplacementTrigger "simple:index:Resource" {
+	__logicalName = "notReplacementTrigger"
+	value = true
+}
+
+resource secretReplacementTrigger "simple:index:Resource" {
+	__logicalName = "secretReplacementTrigger"
+	value = true
+
+	options {
+		replacementTrigger = secret([
+			1,
+			2,
+			3
+		])
+	}
+}

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-option-replacement-trigger
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/1/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-option-replacement-trigger/1/program.pp
@@ -1,0 +1,40 @@
+resource replacementTrigger "simple:index:Resource" {
+	__logicalName = "replacementTrigger"
+	value = true
+
+	options {
+		replacementTrigger = "test2"
+	}
+}
+
+resource unknown "output:index:Resource" {
+	__logicalName = "unknown"
+	value = 2
+}
+
+resource unknownReplacementTrigger "simple:index:Resource" {
+	__logicalName = "unknownReplacementTrigger"
+	value = true
+
+	options {
+		replacementTrigger = unknown.output
+	}
+}
+
+resource notReplacementTrigger "simple:index:Resource" {
+	__logicalName = "notReplacementTrigger"
+	value = true
+}
+
+resource secretReplacementTrigger "simple:index:Resource" {
+	__logicalName = "secretReplacementTrigger"
+	value = true
+
+	options {
+		replacementTrigger = secret([
+			3,
+			2,
+			1
+		])
+	}
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/Main.yaml
@@ -1,0 +1,31 @@
+resources:
+  replacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: test
+  unknown:
+    type: output:Resource
+    properties:
+      value: 1
+  unknownReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: hellohello
+  notReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+  secretReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger:
+        fn::secret:
+          - 1
+          - 2
+          - 3

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-option-replacement-trigger
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/sdks/output.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/sdks/output.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: output
+version: 23.0.0

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/0/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/Main.yaml
@@ -1,0 +1,31 @@
+resources:
+  replacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: test2
+  unknown:
+    type: output:Resource
+    properties:
+      value: 2
+  unknownReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: ${unknown.output}
+  notReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+  secretReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger:
+        fn::secret:
+          - 3
+          - 2
+          - 1

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-option-replacement-trigger
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/sdks/output.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/sdks/output.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: output
+version: 23.0.0

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-option-replacement-trigger/1/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/Main.yaml
@@ -1,0 +1,31 @@
+resources:
+  replacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: test
+  unknown:
+    type: output:Resource
+    properties:
+      value: 1
+  unknownReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: hellohello
+  notReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+  secretReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger:
+        fn::secret:
+          - 1
+          - 2
+          - 3

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-option-replacement-trigger
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/sdks/output.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/sdks/output.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: output
+version: 23.0.0

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/0/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/Main.yaml
@@ -1,0 +1,31 @@
+resources:
+  replacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: test2
+  unknown:
+    type: output:Resource
+    properties:
+      value: 2
+  unknownReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger: ${unknown.output}
+  notReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+  secretReplacementTrigger:
+    type: simple:Resource
+    properties:
+      value: true
+    options:
+      replacementTrigger:
+        fn::secret:
+          - 3
+          - 2
+          - 1

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-option-replacement-trigger
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/sdks/output.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/sdks/output.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: output
+version: 23.0.0

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-option-replacement-trigger/1/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/sdks/output-23.0.0/output-23.0.0.yaml
+++ b/cmd/pulumi-language-yaml/testdata/sdks/output-23.0.0/output-23.0.0.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: output
+version: 23.0.0

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -1540,6 +1540,9 @@ func (e walker) walkResourceOptions(ctx *evalContext, opts ast.ResourceOptionsDe
 	if !e.walk(ctx, opts.ReplaceWith) {
 		return false
 	}
+	if !e.walk(ctx, opts.ReplacementTrigger) {
+		return false
+	}
 	if !e.walk(ctx, opts.DeletedWith) {
 		return false
 	}

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -386,6 +386,7 @@ type ResourceOptionsDecl struct {
 	ReplaceWith             Expr
 	DeletedWith             Expr
 	HideDiffs               *StringListDecl
+	ReplacementTrigger      Expr
 	EnvVarMappings          Expr
 }
 
@@ -403,6 +404,7 @@ func ResourceOptionsSyntax(node *syntax.ObjectNode,
 	parent Expr, protect Expr, provider, providers Expr, version *StringExpr,
 	pluginDownloadURL *StringExpr, replaceOnChanges *StringListDecl,
 	retainOnDelete *BooleanExpr, replaceWith, deletedWith Expr, hideDiffs *StringListDecl,
+	replacementTrigger Expr,
 	envVarMappings Expr,
 ) ResourceOptionsDecl {
 	return ResourceOptionsDecl{
@@ -424,6 +426,7 @@ func ResourceOptionsSyntax(node *syntax.ObjectNode,
 		ReplaceWith:             replaceWith,
 		DeletedWith:             deletedWith,
 		HideDiffs:               hideDiffs,
+		ReplacementTrigger:      replacementTrigger,
 		EnvVarMappings:          envVarMappings,
 	}
 }
@@ -433,11 +436,13 @@ func ResourceOptions(additionalSecretOutputs *StringListDecl, aliases Expr,
 	dependsOn Expr, ignoreChanges *StringListDecl, importID *StringExpr, parent Expr,
 	protect Expr, provider, providers Expr, version *StringExpr, pluginDownloadURL *StringExpr,
 	replaceOnChanges *StringListDecl, retainOnDelete *BooleanExpr, replaceWith, deletedWith Expr, hideDiffs *StringListDecl,
+	replacementTrigger Expr,
 	envVarMappings Expr,
 ) ResourceOptionsDecl {
 	return ResourceOptionsSyntax(nil, additionalSecretOutputs, aliases, customTimeouts,
 		deleteBeforeReplace, dependsOn, ignoreChanges, importID, parent, protect, provider, providers,
 		version, pluginDownloadURL, replaceOnChanges, retainOnDelete, replaceWith, deletedWith, hideDiffs,
+		replacementTrigger,
 		envVarMappings)
 }
 

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -308,6 +308,10 @@ func (g *generator) genResourceOpts(opts *pcl.ResourceOptions) *syn.ObjectNode {
 		list := syn.ListSyntax(elems.Syntax(), items...)
 		rOpts = append(rOpts, syn.ObjectProperty(syn.String("replaceOnChanges"), list))
 	}
+	if opts.ReplacementTrigger != nil {
+		rOpts = append(rOpts, syn.ObjectProperty(syn.String("replacementTrigger"),
+			g.expr(opts.ReplacementTrigger)))
+	}
 	if opts.EnvVarMappings != nil {
 		rOpts = append(rOpts, syn.ObjectProperty(syn.String("envVarMappings"),
 			g.expr(opts.EnvVarMappings)))

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -1068,6 +1068,15 @@ func (imp *importer) importResource(kvp ast.ResourcesMapEntry, latestPkgInfo map
 		}
 	}
 
+	if resource.Options.ReplacementTrigger != nil {
+		expr, rdiags := imp.importExpr(resource.Options.ReplacementTrigger, nil)
+		diags.Extend(rdiags...)
+		resourceOptions.Body.Items = append(resourceOptions.Body.Items, &model.Attribute{
+			Name:  "replacementTrigger",
+			Value: expr,
+		})
+	}
+
 	if resource.Options.EnvVarMappings != nil {
 		expr, ediags := imp.importExpr(resource.Options.EnvVarMappings, nil)
 		diags.Extend(ediags...)

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1828,6 +1828,14 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 	if v.Options.HideDiffs != nil {
 		opts = append(opts, pulumi.HideDiffs(listStrings(v.Options.HideDiffs)))
 	}
+	if v.Options.ReplacementTrigger != nil {
+		value, ok := e.evaluateExpr(v.Options.ReplacementTrigger)
+		if ok {
+			opts = append(opts, pulumi.ReplacementTrigger(pulumi.Any(value)))
+		} else {
+			overallOk = false
+		}
+	}
 	if v.Options.EnvVarMappings != nil {
 		value, ok := e.evaluateExpr(v.Options.EnvVarMappings)
 		if !ok {

--- a/pkg/pulumiyaml/template.go
+++ b/pkg/pulumiyaml/template.go
@@ -106,6 +106,8 @@ type ResourceOptions struct {
 	// If set, the provider's Delete method will not be called for this resource if the specified resource is being
 	// deleted as well.
 	DeletedWith string `json:",omitempty" yaml:",omitempty"`
+	// ReplacementTrigger specifies a list of paths that will trigger a replacement if changed.
+	ReplacementTrigger interface{} `json:",omitempty" yaml:",omitempty"`
 	// EnvVarMappings specifies environment variable remappings for provider resources.
 	EnvVarMappings map[string]string `json:",omitempty" yaml:",omitempty"`
 }


### PR DESCRIPTION
## Summary
- Add `replacementTrigger` resource option support to the YAML runtime, AST, codegen, and converter
- Remove `l2-resource-option-replacement-trigger` from the expected failures list

## Test plan
- [x] `TestLanguage/l2-resource-option-replacement-trigger` passes
- [x] `golangci-lint run` passes