### PR TITLE
`GetRequiredPackages` works for Plugins, not just Programs

### DIFF
--- a/.changes/unreleased/bug-fixes-937.yaml
+++ b/.changes/unreleased/bug-fixes-937.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Allow GetRequiredPackages to run against a YAML based plugin
+time: 2026-04-07T17:57:02.991439+02:00
+custom:
+    PR: "937"

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -161,7 +161,7 @@ func GetReferencedPackages(tmpl *ast.TemplateDecl) ([]packages.PackageDecl, synt
 		}
 	}
 
-	diags := newRunner(tmpl, nil).Run(walker{
+	w := walker{
 		VisitResource: func(r *Runner, node resourceNode) bool {
 			res := node.Value
 
@@ -183,7 +183,20 @@ func GetReferencedPackages(tmpl *ast.TemplateDecl) ([]packages.PackageDecl, synt
 			}
 			return true
 		},
-	})
+	}
+
+	// Walk top-level resources, then walk each component's resources.
+	// Components have their own nested templates that also implement ast.Template.
+	diags := newRunner(tmpl, nil).Run(w)
+	if !diags.HasErrors() {
+		for _, comp := range tmpl.Components.Entries {
+			compDiags := newRunner(comp.Value, nil).Run(w)
+			diags.Extend(compDiags...)
+			if compDiags.HasErrors() {
+				break
+			}
+		}
+	}
 
 	if diags.HasErrors() {
 		return nil, diags

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"os/exec"
@@ -113,21 +114,35 @@ func conflictingEnvVars(env []string) []string {
 	return duplicates
 }
 
+var ErrMissingTemplateFile = errors.New("missing template file")
+
+func probeForFile(dir string, filenames ...string) ([]byte, string, error) {
+	contract.Assertf(len(filenames) > 0, "must have at least one option")
+	for _, filename := range filenames {
+		f, err := os.ReadFile(filepath.Join(dir, filename))
+		if err == nil {
+			return f, filename, nil
+		}
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		return nil, "", err
+	}
+	return nil, filenames[0], ErrMissingTemplateFile
+}
+
 // Load a template from the given directory.
 func LoadDir(directory string) (*ast.TemplateDecl, syntax.Diagnostics, error) {
 	// Read in the template file - search first for Main.json, then Main.yaml, then Pulumi.yaml.
 	// The last of these will actually read the proram from the same Pulumi.yaml project file used by
 	// Pulumi CLI, which now plays double duty, and allows a Pulumi deployment that uses a single file.
-	var filename string
-	var bs []byte
-	if b, err := os.ReadFile(filepath.Join(directory, MainTemplate+".json")); err == nil {
-		filename, bs = MainTemplate+".json", b
-	} else if b, err := os.ReadFile(filepath.Join(directory, MainTemplate+".yaml")); err == nil {
-		filename, bs = MainTemplate+".yaml", b
-	} else if b, err := os.ReadFile(filepath.Join(directory, "Pulumi.yaml")); err == nil {
-		filename, bs = "Pulumi.yaml", b
-	} else {
-		return nil, nil, fmt.Errorf("reading template %s: %w", MainTemplate, err)
+	bs, filename, err := probeForFile(directory,
+		MainTemplate+".json",
+		MainTemplate+".yaml",
+		"Pulumi.yaml",
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading template %s: %w", filename, err)
 	}
 
 	template, diags, err := LoadYAMLBytes(filename, bs)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -149,6 +149,9 @@ func (host *yamlLanguageHost) GetRequiredPackages(ctx context.Context,
 	}
 
 	template, diags, err := host.loadTemplate(compiler, req.Info.ProgramDirectory, nil)
+	if errors.Is(err, pulumiyaml.ErrMissingTemplateFile) {
+		template, diags, err = host.loadPluginTemplate(req.Info.ProgramDirectory)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // countingLoaderServer wraps a codegenrpc.LoaderServer and counts GetSchema
@@ -194,4 +197,74 @@ func TestGeneratePackageCachesSchemaLoadsRegression(t *testing.T) {
 	// how many resources reference it. Without caching this would be numResources.
 	assert.Equal(t, 1, counter.callCount("dep"),
 		"expected 1 GetSchema call for dep, got %d (caching not working)", counter.callCount("dep"))
+}
+
+func TestGetRequiredPackages(t *testing.T) {
+	t.Parallel()
+
+	newRequest := func(dir string) *pulumirpc.GetRequiredPackagesRequest {
+		return &pulumirpc.GetRequiredPackagesRequest{
+			Info: &pulumirpc.ProgramInfo{
+				ProgramDirectory: dir,
+				EntryPoint:       ".",
+				Options:          &structpb.Struct{},
+			},
+		}
+	}
+
+	t.Run("Pulumi.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte(`
+name: test-project
+runtime: yaml
+resources:
+  bucket:
+    type: aws:s3:Bucket
+  pet:
+    type: random:RandomPet
+    properties:
+      length: 2
+`), 0o600))
+
+		host := &yamlLanguageHost{templateCache: make(map[string]templateCacheEntry)}
+		resp, err := host.GetRequiredPackages(t.Context(), newRequest(dir))
+		require.NoError(t, err)
+
+		assert.Equal(t, []*pulumirpc.PackageDependency{
+			{Kind: "resource", Name: "aws"},
+			{Kind: "resource", Name: "random"},
+		}, resp.Packages)
+	})
+
+	t.Run("PulumiPlugin.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "PulumiPlugin.yaml"), []byte(`
+name: my-component
+runtime: yaml
+components:
+  myComponent:
+    inputs:
+      length:
+        type: integer
+    resources:
+      pet:
+        type: random:RandomPet
+        properties:
+          length: ${length}
+    outputs:
+      name: ${pet.id}
+`), 0o600))
+
+		host := &yamlLanguageHost{templateCache: make(map[string]templateCacheEntry)}
+		resp, err := host.GetRequiredPackages(t.Context(), newRequest(dir))
+		require.NoError(t, err)
+
+		assert.Equal(t, []*pulumirpc.PackageDependency{
+			{Kind: "resource", Name: "random"},
+		}, resp.Packages)
+	})
 }


### PR DESCRIPTION
This is necessary to enable `pulumi install` to figure out what packages need to be installed when installing source based components.

Enables https://github.com/pulumi/pulumi/issues/20963 Fixes https://github.com/pulumi/pulumi-yaml/issues/937