### PR TITLE
Apply some `usetesting` lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,12 @@ linters:
     - paralleltest
     - revive
     - unconvert
+    - usetesting
   settings:
+    usetesting:
+      os-temp-dir: true
+      context-background: true
+      context-todo: true
     govet:
       enable:
         - nilness

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,13 @@ clean::
 	rm -f ./bin/*
 	rm -f pkg/pulumiyaml/testing/test/testdata/{aws,azure-native,azure,kubernetes,random,eks,aws-native,docker}.json
 
-.phony: lint
+.PHONY: lint lint-golang lint-copyright
+
 lint:: lint-copyright lint-golang
+
 lint-golang:
 	golangci-lint run
+
 lint-copyright:
     # Generated examples don't have the copyright notice.
 	pulumictl copyright -x 'pkg/tests/transpiled_examples/**'

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -43,7 +42,8 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 	// We can't just go run the pulumi-test-language package because of
 	// https://github.com/golang/go/issues/39172, so we build it to a temp file then run that.
 	binary := t.TempDir() + "/pulumi-test-language"
-	cmd := exec.Command("go", "build", "-o", binary, "github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language") //nolint:gosec
+	cmd := exec.CommandContext(t.Context(), "go", "build", "-o", binary,
+		"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language") //nolint:gosec
 	output, err := cmd.CombinedOutput()
 	t.Logf("build output: %s", output)
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestLanguage(t *testing.T) {
 
 	engineAddress, engine := runTestingHost(t)
 
-	tests, err := engine.GetLanguageTests(context.Background(), &testingrpc.GetLanguageTestsRequest{})
+	tests, err := engine.GetLanguageTests(t.Context(), &testingrpc.GetLanguageTestsRequest{})
 	require.NoError(t, err)
 
 	cancel := make(chan bool)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -183,7 +183,7 @@ func TestGeneratePackageCachesSchemaLoadsRegression(t *testing.T) {
 	// schema.BindSpec. Before the fix, BindSpec received an uncached loader and
 	// would issue a GetSchema RPC for every cross-package type reference.
 	host := &yamlLanguageHost{}
-	resp, err := host.GeneratePackage(context.Background(), &pulumirpc.GeneratePackageRequest{
+	resp, err := host.GeneratePackage(t.Context(), &pulumirpc.GeneratePackageRequest{
 		Directory:    t.TempDir(),
 		Schema:       string(mainJSON),
 		LoaderTarget: lis.Addr().String(),


### PR DESCRIPTION
We use these in `pulumi/pulumi`, and it helps constrain LLMs from generating out of date test code.