### PR TITLE
Fix l2-resource-type-name

### DIFF
--- a/.changes/unreleased/Improvements-1060.yaml
+++ b/.changes/unreleased/Improvements-1060.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Support the pulumiresourcename and pulumiresourcetype functions
+time: 2026-04-25T11:37:31.333419+01:00
+custom:
+    PR: "1060"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -116,7 +116,6 @@ var expectedFailures = map[string]string{
 	"l2-provider-call":               "Traversal not allowed on function result",
 	"l2-provider-call-explicit":      "Traversal not allowed on function result",
 	"l2-resource-elide-unknowns":     `*model.BinaryOpExpression; Unimplemented! Needed for  unknown.output == "hello"`,
-	"l2-resource-name-type":          "Unknown Function; YAML does not support fn::pulumiResourceName",
 	"l2-resource-optional":           "*model.ConditionalExpression; Unimplemented! YAML does not support conditional expressions",
 	"l2-resource-primitive-defaults": "missing required property boolean: YAML runtime does not apply primitive defaults",
 	"l2-resource-config-objects":     "unrecognized type 'map(bool)' for config variable; undefined variable plainBooleanMap",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-name-type/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-name-type/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-name-type
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-name-type/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l2-resource-name-type/program.pp
@@ -1,0 +1,14 @@
+resource res1 "simple:index:Resource" {
+	__logicalName = "res1"
+	value = true
+}
+
+output name {
+	__logicalName = "name"
+	value = pulumiResourceName(res1)
+}
+
+output type {
+	__logicalName = "type"
+	value = pulumiResourceType(res1)
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-name-type/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-name-type/Main.yaml
@@ -1,0 +1,10 @@
+resources:
+  res1:
+    type: simple:Resource
+    properties:
+      value: true
+outputs:
+  name:
+    fn::pulumiResourceName: ${res1}
+  type:
+    fn::pulumiResourceType: ${res1}

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-name-type/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-name-type/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-name-type
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-name-type/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-name-type/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-name-type/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-name-type/Main.yaml
@@ -1,0 +1,10 @@
+resources:
+  res1:
+    type: simple:Resource
+    properties:
+      value: true
+outputs:
+  name:
+    fn::pulumiResourceName: ${res1}
+  type:
+    fn::pulumiResourceType: ${res1}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-name-type/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-name-type/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-name-type
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-name-type/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-name-type/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -739,6 +739,38 @@ func parseReadFile(node *syntax.ObjectNode, name *StringExpr, path Expr) (Expr, 
 	return ReadFileSyntax(node, name, path), nil
 }
 
+type PulumiResourceNameExpr struct {
+	builtinNode
+	Resource Expr
+}
+
+func PulumiResourceNameSyntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *PulumiResourceNameExpr {
+	return &PulumiResourceNameExpr{
+		builtinNode: builtin(node, name, args),
+		Resource:    args,
+	}
+}
+
+func parsePulumiResourceName(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
+	return PulumiResourceNameSyntax(node, name, args), nil
+}
+
+type PulumiResourceTypeExpr struct {
+	builtinNode
+	Resource Expr
+}
+
+func PulumiResourceTypeSyntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *PulumiResourceTypeExpr {
+	return &PulumiResourceTypeExpr{
+		builtinNode: builtin(node, name, args),
+		Resource:    args,
+	}
+}
+
+func parsePulumiResourceType(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
+	return PulumiResourceTypeSyntax(node, name, args), nil
+}
+
 func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) {
 	if node.Len() != 1 {
 		return nil, nil, false
@@ -783,6 +815,10 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		set("fn::secret", parseSecret)
 	case "fn::readfile":
 		set("fn::readFile", parseReadFile)
+	case "fn::pulumiresourcename":
+		set("fn::pulumiResourceName", parsePulumiResourceName)
+	case "fn::pulumiresourcetype":
+		set("fn::pulumiResourceType", parsePulumiResourceType)
 	default:
 		k := kvp.Key.Value()
 		// fn::invoke can be called as fn::${pkg}:${module}(:${name})?

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -938,6 +938,10 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return wrapFn("readFile", g.expr(f.Args[0]))
 	case "secret":
 		return wrapFn("secret", g.expr(f.Args[0]))
+	case "pulumiResourceName":
+		return wrapFn("pulumiResourceName", g.expr(f.Args[0]))
+	case "pulumiResourceType":
+		return wrapFn("pulumiResourceType", g.expr(f.Args[0]))
 	case "cwd":
 		return syn.String("${pulumi.cwd}")
 	case "getOutput":

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -468,6 +468,18 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 			Name: "fromBase64",
 			Args: []model.Expression{path},
 		}, pdiags
+	case *ast.PulumiResourceNameExpr:
+		res, rdiags := imp.importExpr(node.Resource, nil)
+		return &model.FunctionCallExpression{
+			Name: "pulumiResourceName",
+			Args: []model.Expression{res},
+		}, rdiags
+	case *ast.PulumiResourceTypeExpr:
+		res, rdiags := imp.importExpr(node.Resource, nil)
+		return &model.FunctionCallExpression{
+			Name: "pulumiResourceType",
+			Args: []model.Expression{res},
+		}, rdiags
 	default:
 		contract.Failf("unexpected builtin type %T", node)
 		return nil, nil

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -747,6 +747,7 @@ type lateboundResource interface {
 type lateboundCustomResourceState struct {
 	pulumi.CustomResourceState
 	name           string
+	resourceType   string
 	Outputs        pulumi.MapOutput `pulumi:""`
 	resourceSchema *schema.Resource
 }
@@ -790,6 +791,7 @@ func (st *lateboundCustomResourceState) GetResourceSchema() *schema.Resource {
 type lateboundProviderResourceState struct {
 	pulumi.ProviderResourceState
 	name           string
+	resourceType   string
 	Outputs        pulumi.MapOutput `pulumi:""`
 	resourceSchema *schema.Resource
 }
@@ -1891,12 +1893,12 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 	}
 	isProvider := false
 	if strings.HasPrefix(v.Type.Value, "pulumi:providers:") {
-		r := lateboundProviderResourceState{name: resourceName, resourceSchema: resourceSchema}
+		r := lateboundProviderResourceState{name: resourceName, resourceType: string(typ), resourceSchema: resourceSchema}
 		state = &r
 		res = &r
 		isProvider = true
 	} else {
-		r := lateboundCustomResourceState{name: resourceName, resourceSchema: resourceSchema}
+		r := lateboundCustomResourceState{name: resourceName, resourceType: string(typ), resourceSchema: resourceSchema}
 		state = &r
 		res = &r
 	}
@@ -2181,6 +2183,10 @@ func (e *programEvaluator) evaluateExpr(x ast.Expr) (interface{}, bool) {
 		return e.evaluateBuiltinSecret(x)
 	case *ast.ReadFileExpr:
 		return e.evaluateBuiltinReadFile(x)
+	case *ast.PulumiResourceNameExpr:
+		return e.evaluateBuiltinPulumiResourceName(x)
+	case *ast.PulumiResourceTypeExpr:
+		return e.evaluateBuiltinPulumiResourceType(x)
 	default:
 		panic(fmt.Sprintf("fatal: invalid expr type %v", reflect.TypeOf(x)))
 	}
@@ -2937,6 +2943,36 @@ func (e *programEvaluator) evaluateBuiltinReadFile(s *ast.ReadFileExpr) (interfa
 	})
 
 	return readFileF(expr)
+}
+
+func (e *programEvaluator) evaluateBuiltinPulumiResourceName(s *ast.PulumiResourceNameExpr) (interface{}, bool) {
+	res, ok := e.evaluateExpr(s.Resource)
+	if !ok {
+		return nil, false
+	}
+	switch r := res.(type) {
+	case *lateboundCustomResourceState:
+		return r.name, true
+	case *lateboundProviderResourceState:
+		return r.name, true
+	default:
+		return e.error(s.Resource, fmt.Sprintf("fn::pulumiResourceName requires a resource, got %v", typeString(res)))
+	}
+}
+
+func (e *programEvaluator) evaluateBuiltinPulumiResourceType(s *ast.PulumiResourceTypeExpr) (interface{}, bool) {
+	res, ok := e.evaluateExpr(s.Resource)
+	if !ok {
+		return nil, false
+	}
+	switch r := res.(type) {
+	case *lateboundCustomResourceState:
+		return r.resourceType, true
+	case *lateboundProviderResourceState:
+		return r.resourceType, true
+	default:
+		return e.error(s.Resource, fmt.Sprintf("fn::pulumiResourceType requires a resource, got %v", typeString(res)))
+	}
 }
 
 func hasOutputs(v interface{}) bool {


### PR DESCRIPTION
What it says on the tin. Adds the pulumiresourcename and pulumiresourcetype functions so the l2-resource-type-name test can pass.

Pulls the type and name off the late bound state objects.