### PR TITLE
Support sha1 builtin

### DIFF
--- a/.changes/unreleased/Improvements-1062.yaml
+++ b/.changes/unreleased/Improvements-1062.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Support the `fn:sha1` built-in function
+time: 2026-04-27T14:31:59.495798+01:00
+custom:
+    PR: "1062"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -101,7 +101,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 var expectedFailures = map[string]string{
 	"l1-builtin-can":                 "#721 generation unimplemented",
 	"l1-builtin-file":                "Unknown Function; YAML does not support fn::filebase64",
-	"l1-builtin-sha1":                "Unknown Function; YAML does not support fn::sha1",
 	"l1-builtin-list":                "Unknown Function; YAML does not support fn::length",
 	"l1-builtin-object":              "Unknown Function; YAML does not support fn::entries",
 	"l1-builtin-secret":              "Unknown Function; YAML does not support fn::unsecret",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-sha1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-sha1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-sha1
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-sha1/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-sha1/program.pp
@@ -1,0 +1,10 @@
+config input string {
+	__logicalName = "input"
+}
+
+hashVar = sha1(input)
+
+output hash {
+	__logicalName = "hash"
+	value = hashVar
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-sha1/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-sha1/Main.yaml
@@ -1,0 +1,8 @@
+configuration:
+  input:
+    type: string
+variables:
+  hash:
+    fn::sha1: ${input}
+outputs:
+  hash: ${hash}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-sha1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-sha1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-sha1
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-sha1/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-sha1/Main.yaml
@@ -1,0 +1,8 @@
+configuration:
+  input:
+    type: string
+variables:
+  hashVar:
+    fn::sha1: ${input}
+outputs:
+  hash: ${hashVar}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-sha1/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-sha1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-sha1
+runtime: yaml

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -739,6 +739,22 @@ func parseReadFile(node *syntax.ObjectNode, name *StringExpr, path Expr) (Expr, 
 	return ReadFileSyntax(node, name, path), nil
 }
 
+type Sha1Expr struct {
+	builtinNode
+	Value Expr
+}
+
+func Sha1Syntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *Sha1Expr {
+	return &Sha1Expr{
+		builtinNode: builtin(node, name, args),
+		Value:       args,
+	}
+}
+
+func parseSha1(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
+	return Sha1Syntax(node, name, args), nil
+}
+
 type PulumiResourceNameExpr struct {
 	builtinNode
 	Resource Expr
@@ -815,6 +831,8 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		set("fn::secret", parseSecret)
 	case "fn::readfile":
 		set("fn::readFile", parseReadFile)
+	case "fn::sha1":
+		set("fn::sha1", parseSha1)
 	case "fn::pulumiresourcename":
 		set("fn::pulumiResourceName", parsePulumiResourceName)
 	case "fn::pulumiresourcetype":

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -938,6 +938,8 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return wrapFn("readFile", g.expr(f.Args[0]))
 	case "secret":
 		return wrapFn("secret", g.expr(f.Args[0]))
+	case "sha1":
+		return wrapFn("sha1", g.expr(f.Args[0]))
 	case "pulumiResourceName":
 		return wrapFn("pulumiResourceName", g.expr(f.Args[0]))
 	case "pulumiResourceType":

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -468,6 +468,12 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 			Name: "fromBase64",
 			Args: []model.Expression{path},
 		}, pdiags
+	case *ast.Sha1Expr:
+		val, vdiags := imp.importExpr(node.Args(), nil)
+		return &model.FunctionCallExpression{
+			Name: "sha1",
+			Args: []model.Expression{val},
+		}, vdiags
 	case *ast.PulumiResourceNameExpr:
 		res, rdiags := imp.importExpr(node.Resource, nil)
 		return &model.FunctionCallExpression{

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -5,7 +5,9 @@ package pulumiyaml
 import (
 	"bytes"
 	"context"
+	"crypto/sha1" //nolint:gosec
 	b64 "encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2183,6 +2185,8 @@ func (e *programEvaluator) evaluateExpr(x ast.Expr) (interface{}, bool) {
 		return e.evaluateBuiltinSecret(x)
 	case *ast.ReadFileExpr:
 		return e.evaluateBuiltinReadFile(x)
+	case *ast.Sha1Expr:
+		return e.evaluateBuiltinSha1(x)
 	case *ast.PulumiResourceNameExpr:
 		return e.evaluateBuiltinPulumiResourceName(x)
 	case *ast.PulumiResourceTypeExpr:
@@ -2943,6 +2947,21 @@ func (e *programEvaluator) evaluateBuiltinReadFile(s *ast.ReadFileExpr) (interfa
 	})
 
 	return readFileF(expr)
+}
+
+func (e *programEvaluator) evaluateBuiltinSha1(s *ast.Sha1Expr) (interface{}, bool) {
+	expr, ok := e.evaluateExpr(s.Value)
+	if !ok {
+		return nil, false
+	}
+	return e.lift(func(args ...interface{}) (interface{}, bool) {
+		str, ok := args[0].(string)
+		if !ok {
+			return e.error(s.Value, fmt.Sprintf("fn::sha1 requires a string, got %v", typeString(args[0])))
+		}
+		h := sha1.Sum([]byte(str)) //nolint:gosec
+		return hex.EncodeToString(h[:]), true
+	})(expr)
 }
 
 func (e *programEvaluator) evaluateBuiltinPulumiResourceName(s *ast.PulumiResourceNameExpr) (interface{}, bool) {


### PR DESCRIPTION
Another simple conformance test fix, get l1-builtin-sha1 working by adding the sha1 function.