### PR TITLE
Prefix component children with the name of their parent

### DIFF
--- a/.changes/unreleased/Bug Fixes-957.yaml
+++ b/.changes/unreleased/Bug Fixes-957.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: YAML components can now be instantiated multiple times in a single stack. Child resource names are prefixed with the component instance name (e.g. `cp1-res`); aliases to the un-prefixed name are emitted so existing single-instance stacks migrate without replacement.
+time: 2026-04-28T12:40:00.000000-07:00
+custom:
+    PR: "957"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -127,6 +127,10 @@ var expectedFailures = map[string]string{
 	"l2-resource-option-custom-timeouts": "Failing after updating to 3.232",
 	"l2-name-conflicts":                  "Failing after updating to 3.232",
 	"l2-index-mod":                       "Failing after updating to 3.232",
+
+	"provider-alias-component":               "needs YAML testdata for the Simple component provider plus alias-migration support",
+	"provider-ignore-changes-component":      "needs YAML testdata for the Simple component provider plus ignoreChanges support",
+	"provider-replacement-trigger-component": "needs YAML testdata for the Simple component provider plus replaceOnChanges support",
 }
 
 // Add test names here that are expected to fail the converter (eject) round-trip test.
@@ -178,6 +182,7 @@ func TestLanguage(t *testing.T) {
 		TemporaryDirectory:    rootDir,
 		SnapshotDirectory:     snapshotDir,
 		ConverterPluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
+		ProvidersDirectory:    "testdata/providers",
 	})
 	require.NoError(t, err)
 
@@ -190,10 +195,6 @@ func TestLanguage(t *testing.T) {
 			if strings.HasPrefix(tt, "policy-") {
 				t.Skip("YAML does not support policy tests")
 			}
-			if strings.HasPrefix(tt, "provider-") {
-				t.Skip("YAML does not support provider tests")
-			}
-
 			if expected, ok := expectedFailures[tt]; ok {
 				t.Skipf("Skipping known failure: %s", expected)
 			}

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/provider-resource-component/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/provider-resource-component/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: provider-resource-component
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/provider-resource-component/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/provider-resource-component/program.pp
@@ -1,0 +1,9 @@
+resource res "conformance-component:index:Simple" {
+	__logicalName = "res"
+	value = true
+}
+
+resource simpleResource "simple:index:Resource" {
+	__logicalName = "simpleResource"
+	value = false
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/Main.yaml
@@ -1,0 +1,10 @@
+resources:
+  res:
+    type: conformance-component:Simple
+    properties:
+      value: true
+  # Make a simple resource so that plugin detection works.
+  simpleResource:
+    type: simple:Resource
+    properties:
+      value: false

--- a/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: provider-resource-component
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/sdks/conformance-component.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/sdks/conformance-component.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: conformance-component
+version: 22.0.0

--- a/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/provider-resource-component/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/providers/conformance-component/PulumiPlugin.yaml
+++ b/cmd/pulumi-language-yaml/testdata/providers/conformance-component/PulumiPlugin.yaml
@@ -1,0 +1,17 @@
+name: conformance-component
+version: 22.0.0
+runtime: yaml
+components:
+  Simple:
+    inputs:
+      value:
+        type: boolean
+    resources:
+      child:
+        type: simple:index:Resource
+        properties:
+          value: false
+        options:
+          version: 2.0.0
+    outputs:
+      value: ${value}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/Main.yaml
@@ -1,0 +1,9 @@
+resources:
+  res:
+    type: conformance-component:Simple
+    properties:
+      value: true
+  simpleResource:
+    type: simple:Resource
+    properties:
+      value: false

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: provider-resource-component
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/sdks/conformance-component.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/sdks/conformance-component.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: conformance-component
+version: 22.0.0

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/sdks/simple.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/provider-resource-component/sdks/simple.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: simple
+version: 2.0.0

--- a/cmd/pulumi-language-yaml/testdata/sdks/conformance-component-22.0.0/conformance-component-22.0.0.yaml
+++ b/cmd/pulumi-language-yaml/testdata/sdks/conformance-component-22.0.0/conformance-component-22.0.0.yaml
@@ -1,0 +1,3 @@
+packageDeclarationVersion: 1
+name: conformance-component
+version: 22.0.0

--- a/pkg/pulumiyaml/ast/template.go
+++ b/pkg/pulumiyaml/ast/template.go
@@ -708,6 +708,7 @@ type TemplateDecl struct {
 	Name          *StringExpr
 	Namespace     *StringExpr
 	Description   *StringExpr
+	Version       *StringExpr
 	Pulumi        PulumiDecl
 	Configuration ConfigMapDecl
 	Config        ConfigMapDecl
@@ -874,10 +875,14 @@ func (d *TemplateDecl) GenerateSchema() (schema.PackageSpec, error) {
 	if d.Namespace != nil {
 		namespace = d.Namespace.Value
 	}
+	version := "0.0.0"
+	if d.Version != nil && d.Version.Value != "" {
+		version = d.Version.Value
+	}
 	schemaDef := schema.PackageSpec{
 		Name:        d.Name.Value,
 		Description: description,
-		Version:     "0.0.0",
+		Version:     version,
 		Namespace:   namespace,
 		Language: map[string]schema.RawMessage{
 			"nodejs": schema.RawMessage(`{"respectSchemaVersion": true}`),

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1893,17 +1893,43 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 	// collide on URN.
 	//
 	// For backwards compatibility (pre 1.33.0), emit an alias to the un-prefixed URN
-	// so existing single-instance stacks migrate without replacement.
+	// so existing single-instance stacks migrate without replacement. Suppress the
+	// alias when its target URN's name would also be the post-fix URN name of
+	// another sibling in the same component — emitting it would create an
+	// ambiguous alias claim that the engine would reject.
 	if e.parent != nil {
 		originalName := resourceName
 		resourceName = e.parent.PulumiResourceName() + "-" + resourceName
 
-		resourceType := tokens.Type(typ)
-		aliasURN := e.parent.URN().ApplyT(func(parentURN pulumi.URN) pulumi.URN {
-			p := urn.URN(parentURN)
-			return pulumi.URN(urn.New(p.Stack(), p.Project(), p.QualifiedType(), resourceType, originalName))
-		}).(pulumi.URNOutput)
-		opts = append(opts, pulumi.Aliases([]pulumi.Alias{{URN: aliasURN}}))
+		// Walk siblings in this component template once to detect alias collisions.
+		// If this resource's post-fix name (resourceName) is also the literal pre-fix
+		// name of another sibling in the component, the sibling's auto-alias would
+		// target the same URN as this resource's *current* URN — and the engine
+		// would reject the conflicting alias claim. Suppress this resource's alias
+		// in that case so the sibling's alias remains unambiguous.
+		aliasCollidesWithSibling := false
+		for _, sibling := range e.Runner.t.GetResources().Entries {
+			if sibling.Key.Value == k {
+				continue
+			}
+			siblingName := sibling.Key.Value
+			if sibling.Value.Name != nil && sibling.Value.Name.Value != "" {
+				siblingName = sibling.Value.Name.Value
+			}
+			if siblingName == resourceName {
+				aliasCollidesWithSibling = true
+				break
+			}
+		}
+
+		if !aliasCollidesWithSibling {
+			resourceType := tokens.Type(typ)
+			aliasURN := e.parent.URN().ApplyT(func(parentURN pulumi.URN) pulumi.URN {
+				p := urn.URN(parentURN)
+				return pulumi.URN(urn.New(p.Stack(), p.Project(), p.QualifiedType(), resourceType, originalName))
+			}).(pulumi.URNOutput)
+			opts = append(opts, pulumi.Aliases([]pulumi.Alias{{URN: aliasURN}}))
+		}
 	}
 
 	var state lateboundResource

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1888,6 +1888,16 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 		resourceName = v.Name.Value
 	}
 
+	// When evaluating inside a component, prefix child resource names with the component
+	// instance name so multiple instances of the same component don't collide on URN.
+	// Emit an alias to the un-prefixed name so existing single-instance stacks migrate
+	// without replacement.
+	if e.parent != nil {
+		originalName := resourceName
+		resourceName = e.parent.PulumiResourceName() + "-" + resourceName
+		opts = append(opts, pulumi.Aliases([]pulumi.Alias{{Name: pulumi.String(originalName)}}))
+	}
+
 	var state lateboundResource
 	var res pulumi.Resource
 	var resourceSchema *schema.Resource

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -564,7 +564,7 @@ func RunComponentTemplate(ctx *pulumi.Context,
 		},
 	}
 
-	if err := ctx.RegisterComponentResource(typ, name, component, options); err != nil {
+	if err := ctx.RegisterComponentResourceV2(typ, name, inputs, component, options); err != nil {
 		return pulumi.URNOutput{}, nil, err
 	}
 	component.evaluator.parent = component

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1888,14 +1888,22 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 		resourceName = v.Name.Value
 	}
 
-	// When evaluating inside a component, prefix child resource names with the component
-	// instance name so multiple instances of the same component don't collide on URN.
-	// Emit an alias to the un-prefixed name so existing single-instance stacks migrate
-	// without replacement.
+	// When evaluating inside a component, prefix child resource names with the
+	// component instance name so multiple instances of the same component don't
+	// collide on URN.
+	//
+	// For backwards compatibility (pre 1.33.0), emit an alias to the un-prefixed URN
+	// so existing single-instance stacks migrate without replacement.
 	if e.parent != nil {
 		originalName := resourceName
 		resourceName = e.parent.PulumiResourceName() + "-" + resourceName
-		opts = append(opts, pulumi.Aliases([]pulumi.Alias{{Name: pulumi.String(originalName)}}))
+
+		resourceType := tokens.Type(typ)
+		aliasURN := e.parent.URN().ApplyT(func(parentURN pulumi.URN) pulumi.URN {
+			p := urn.URN(parentURN)
+			return pulumi.URN(urn.New(p.Stack(), p.Project(), p.QualifiedType(), resourceType, originalName))
+		}).(pulumi.URNOutput)
+		opts = append(opts, pulumi.Aliases([]pulumi.Alias{{URN: aliasURN}}))
 	}
 
 	var state lateboundResource

--- a/pkg/pulumiyaml/run_options_test.go
+++ b/pkg/pulumiyaml/run_options_test.go
@@ -335,7 +335,7 @@ components:
 	template := yamlTemplate(t, strings.TrimSpace(text))
 
 	var innerNames []string
-	var innerAliasNames [][]string
+	var innerAliasURNs [][]string
 	mocks := &testMonitor{
 		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 			switch args.TypeToken {
@@ -343,15 +343,15 @@ components:
 				return "", resource.PropertyMap{}, nil
 			case testResourceToken:
 				innerNames = append(innerNames, args.Name)
-				var aliasNames []string
+				var aliasURNs []string
 				if args.RegisterRPC != nil {
 					for _, a := range args.RegisterRPC.Aliases {
-						if spec := a.GetSpec(); spec != nil {
-							aliasNames = append(aliasNames, spec.GetName())
+						if u := a.GetUrn(); u != "" {
+							aliasURNs = append(aliasURNs, u)
 						}
 					}
 				}
-				innerAliasNames = append(innerAliasNames, aliasNames)
+				innerAliasURNs = append(innerAliasURNs, aliasURNs)
 				return "innerID", resource.PropertyMap{
 					"foo": resource.NewStringProperty("bar"),
 					"bar": resource.NewStringProperty("baz"),
@@ -379,9 +379,13 @@ components:
 	}
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"cp1-inner", "cp2-inner"}, innerNames)
-	require.Len(t, innerAliasNames, 2)
-	for _, names := range innerAliasNames {
-		assert.Equal(t, []string{"inner"}, names)
+	require.Len(t, innerAliasURNs, 2)
+	// Both instances alias to the same un-prefixed URN — that was the singleton URN
+	// before the fix. Each registration gets exactly one alias entry, scoped via
+	// component-derived URN to its own component instance.
+	expected := "urn:pulumi:stackDev::projectFoo::test:index:myComponent$" + testResourceToken + "::inner"
+	for _, urns := range innerAliasURNs {
+		assert.Equal(t, []string{expected}, urns)
 	}
 }
 
@@ -407,7 +411,7 @@ components:
 	template := yamlTemplate(t, strings.TrimSpace(text))
 
 	var leafName string
-	var leafAliases []string
+	var leafAliasURNs []string
 	mocks := &testMonitor{
 		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 			switch args.TypeToken {
@@ -417,8 +421,8 @@ components:
 				leafName = args.Name
 				if args.RegisterRPC != nil {
 					for _, a := range args.RegisterRPC.Aliases {
-						if spec := a.GetSpec(); spec != nil {
-							leafAliases = append(leafAliases, spec.GetName())
+						if u := a.GetUrn(); u != "" {
+							leafAliasURNs = append(leafAliasURNs, u)
 						}
 					}
 				}
@@ -444,7 +448,12 @@ components:
 	}
 	require.NoError(t, err)
 	assert.Equal(t, "outer-inner-leaf", leafName)
-	assert.Equal(t, []string{"leaf"}, leafAliases)
+	// The alias URN is derived from the parent component's URN (whose name is
+	// "outer-inner"), confirming the alias is scoped under the nested component.
+	assert.Equal(t,
+		[]string{"urn:pulumi:stackDev::projectFoo::test:index:myComponent$" + testResourceToken + "::leaf"},
+		leafAliasURNs,
+	)
 }
 
 // TestComponentResourceExplicitName verifies that an explicit `name:` field on a
@@ -467,7 +476,7 @@ components:
 	template := yamlTemplate(t, strings.TrimSpace(text))
 
 	var registeredName string
-	var aliases []string
+	var aliasURNs []string
 	mocks := &testMonitor{
 		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 			switch args.TypeToken {
@@ -477,8 +486,8 @@ components:
 				registeredName = args.Name
 				if args.RegisterRPC != nil {
 					for _, a := range args.RegisterRPC.Aliases {
-						if spec := a.GetSpec(); spec != nil {
-							aliases = append(aliases, spec.GetName())
+						if u := a.GetUrn(); u != "" {
+							aliasURNs = append(aliasURNs, u)
 						}
 					}
 				}
@@ -502,7 +511,10 @@ components:
 	}
 	require.NoError(t, err)
 	assert.Equal(t, "cp1-customName", registeredName)
-	assert.Equal(t, []string{"customName"}, aliases)
+	assert.Equal(t,
+		[]string{"urn:pulumi:stackDev::projectFoo::test:index:myComponent$" + testResourceToken + "::customName"},
+		aliasURNs,
+	)
 }
 
 // TestComponentResourceUserAliasesCombined verifies that a user-supplied alias on a
@@ -527,7 +539,8 @@ components:
 `
 	template := yamlTemplate(t, strings.TrimSpace(text))
 
-	var aliases []string
+	var aliasNames []string
+	var aliasURNs []string
 	mocks := &testMonitor{
 		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 			switch args.TypeToken {
@@ -536,8 +549,11 @@ components:
 			case testResourceToken:
 				if args.RegisterRPC != nil {
 					for _, a := range args.RegisterRPC.Aliases {
-						if spec := a.GetSpec(); spec != nil {
-							aliases = append(aliases, spec.GetName())
+						if u := a.GetUrn(); u != "" {
+							aliasURNs = append(aliasURNs, u)
+						}
+						if spec := a.GetSpec(); spec != nil && spec.GetName() != "" {
+							aliasNames = append(aliasNames, spec.GetName())
 						}
 					}
 				}
@@ -560,9 +576,13 @@ components:
 		requireNoErrors(t, template, diags)
 	}
 	require.NoError(t, err)
-	// Both aliases must be present: the user-supplied one and the auto-generated one
-	// for backwards compatibility with un-prefixed stacks.
-	assert.ElementsMatch(t, []string{"legacyName", "inner"}, aliases)
+	// Both aliases must be present: the user-supplied Name-only one and the
+	// auto-generated URN-scoped one for backwards compatibility with un-prefixed stacks.
+	assert.Equal(t, []string{"legacyName"}, aliasNames)
+	assert.Equal(t,
+		[]string{"urn:pulumi:stackDev::projectFoo::test:index:myComponent$" + testResourceToken + "::inner"},
+		aliasURNs,
+	)
 }
 
 // TestComponentResourceProviderAndRead verifies that the prefix logic also applies on
@@ -587,9 +607,9 @@ components:
 	template := yamlTemplate(t, strings.TrimSpace(text))
 
 	type observation struct {
-		name    string
-		read    bool
-		aliases []string
+		name      string
+		read      bool
+		aliasURNs []string
 	}
 	var observed []observation
 	mocks := &testMonitor{
@@ -604,8 +624,8 @@ components:
 				}
 				if args.RegisterRPC != nil {
 					for _, a := range args.RegisterRPC.Aliases {
-						if spec := a.GetSpec(); spec != nil {
-							obs.aliases = append(obs.aliases, spec.GetName())
+						if u := a.GetUrn(); u != "" {
+							obs.aliasURNs = append(obs.aliasURNs, u)
 						}
 					}
 				}
@@ -642,6 +662,9 @@ components:
 	require.NotNil(t, providerObs, "expected provider resource registered as cp1-myProvider; got %+v", observed)
 	require.NotNil(t, readObs, "expected read resource registered as cp1-readMe; got %+v", observed)
 	assert.False(t, providerObs.read, "provider resource should not be a read")
-	assert.Equal(t, []string{"myProvider"}, providerObs.aliases)
+	assert.Equal(t,
+		[]string{"urn:pulumi:stackDev::projectFoo::test:index:myComponent$pulumi:providers:test::myProvider"},
+		providerObs.aliasURNs,
+	)
 	assert.True(t, readObs.read, "readMe should go through the read path (Get.Id was set)")
 }

--- a/pkg/pulumiyaml/run_options_test.go
+++ b/pkg/pulumiyaml/run_options_test.go
@@ -313,3 +313,74 @@ components:
 	require.NoError(t, err)
 	assert.True(t, invokeCalled, "expected invoke to be called")
 }
+
+// TestComponentResourceMultipleInstances exercises the fix for #957: instantiating the
+// same YAML component twice in a single stack must not produce duplicate URNs. Each
+// child resource's name is prefixed with the component instance name, and an alias to
+// the un-prefixed name is emitted so existing single-instance stacks migrate cleanly.
+func TestComponentResourceMultipleInstances(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+components:
+  myComponent:
+    resources:
+      inner:
+        type: ` + testResourceToken + `
+        properties:
+          foo: bar
+`
+	template := yamlTemplate(t, strings.TrimSpace(text))
+
+	var innerNames []string
+	var innerAliasNames [][]string
+	mocks := &testMonitor{
+		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+			switch args.TypeToken {
+			case "test:index:myComponent":
+				return "", resource.PropertyMap{}, nil
+			case testResourceToken:
+				innerNames = append(innerNames, args.Name)
+				var aliasNames []string
+				if args.RegisterRPC != nil {
+					for _, a := range args.RegisterRPC.Aliases {
+						if spec := a.GetSpec(); spec != nil {
+							aliasNames = append(aliasNames, spec.GetName())
+						}
+					}
+				}
+				innerAliasNames = append(innerAliasNames, aliasNames)
+				return "innerID", resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+					"bar": resource.NewStringProperty("baz"),
+				}, nil
+			}
+			return "", resource.PropertyMap{}, fmt.Errorf("unexpected resource type %s", args.TypeToken)
+		},
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, _, err := RunComponentTemplate(ctx,
+			"test:index:myComponent", "cp1", nil,
+			template, pulumi.Map{}, newMockPackageMap(),
+		)
+		if err != nil {
+			return err
+		}
+		_, _, err = RunComponentTemplate(ctx,
+			"test:index:myComponent", "cp2", nil,
+			template, pulumi.Map{}, newMockPackageMap(),
+		)
+		return err
+	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
+	if diags, ok := HasDiagnostics(err); ok {
+		requireNoErrors(t, template, diags)
+	}
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"cp1-inner", "cp2-inner"}, innerNames)
+	require.Len(t, innerAliasNames, 2)
+	for _, names := range innerAliasNames {
+		assert.Equal(t, []string{"inner"}, names)
+	}
+}

--- a/pkg/pulumiyaml/run_options_test.go
+++ b/pkg/pulumiyaml/run_options_test.go
@@ -668,3 +668,99 @@ components:
 	)
 	assert.True(t, readObs.read, "readMe should go through the read path (Get.Id was set)")
 }
+
+// TestComponentResourceAliasSuppressedOnSiblingCollision verifies that when a child's
+// post-fix name would equal another sibling's literal pre-fix name, the auto-alias is
+// suppressed for that child to avoid emitting an alias whose target URN duplicates the
+// sibling's current URN — which the engine would reject as an ambiguous claim. The
+// sibling's own alias still gets emitted.
+//
+// Component "Outer" with siblings "child" and "res-child", instantiated as "res":
+//   - "child"     → post-fix "res-child"     ; alias would target "::child"
+//   - "res-child" → post-fix "res-res-child" ; alias targets "::res-child"
+//
+// "child" post-fix URN matches "res-child"'s pre-fix URN, so "child"'s alias must
+// be suppressed.
+func TestComponentResourceAliasSuppressedOnSiblingCollision(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+components:
+  myComponent:
+    resources:
+      child:
+        type: ` + testResourceToken + `
+        properties:
+          foo: bar
+      res-child:
+        type: ` + testResourceToken + `
+        properties:
+          foo: bar
+`
+	template := yamlTemplate(t, strings.TrimSpace(text))
+
+	type observation struct {
+		name      string
+		aliasURNs []string
+	}
+	var observed []observation
+	mocks := &testMonitor{
+		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+			switch args.TypeToken {
+			case "test:index:myComponent":
+				return "", resource.PropertyMap{}, nil
+			case testResourceToken:
+				obs := observation{name: args.Name}
+				if args.RegisterRPC != nil {
+					for _, a := range args.RegisterRPC.Aliases {
+						if u := a.GetUrn(); u != "" {
+							obs.aliasURNs = append(obs.aliasURNs, u)
+						}
+					}
+				}
+				observed = append(observed, obs)
+				return "id", resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+					"bar": resource.NewStringProperty("baz"),
+				}, nil
+			}
+			return "", resource.PropertyMap{}, fmt.Errorf("unexpected resource type %s", args.TypeToken)
+		},
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, _, err := RunComponentTemplate(ctx,
+			"test:index:myComponent", "res", nil,
+			template, pulumi.Map{}, newMockPackageMap(),
+		)
+		return err
+	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
+	if diags, ok := HasDiagnostics(err); ok {
+		requireNoErrors(t, template, diags)
+	}
+	require.NoError(t, err)
+
+	var childObs, resChildObs *observation
+	for i := range observed {
+		switch observed[i].name {
+		case "res-child":
+			childObs = &observed[i]
+		case "res-res-child":
+			resChildObs = &observed[i]
+		}
+	}
+	require.NotNil(t, childObs, "expected post-fix `res-child` (from `child`); got %+v", observed)
+	require.NotNil(t, resChildObs, "expected post-fix `res-res-child` (from `res-child`); got %+v", observed)
+
+	// `child` (post-fix `res-child`) must NOT carry an alias — its target URN
+	// would collide with `res-child` sibling's pre-fix URN.
+	assert.Empty(t, childObs.aliasURNs,
+		"child's alias must be suppressed to avoid colliding with sibling's pre-fix URN")
+
+	// `res-child` (post-fix `res-res-child`) keeps its alias to the un-prefixed URN.
+	assert.Equal(t,
+		[]string{"urn:pulumi:stackDev::projectFoo::test:index:myComponent$" + testResourceToken + "::res-child"},
+		resChildObs.aliasURNs,
+	)
+}

--- a/pkg/pulumiyaml/run_options_test.go
+++ b/pkg/pulumiyaml/run_options_test.go
@@ -384,3 +384,264 @@ components:
 		assert.Equal(t, []string{"inner"}, names)
 	}
 }
+
+// TestComponentResourceNestedComposition verifies that prefixing composes correctly when
+// a component is itself nested inside another component. The engine constructs a nested
+// component by passing the already-prefixed name (e.g. "outer-inner") as `name` to
+// RunComponentTemplate; children inside it should pick up the cumulative prefix
+// "outer-inner-leaf".
+func TestComponentResourceNestedComposition(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+components:
+  myComponent:
+    resources:
+      leaf:
+        type: ` + testResourceToken + `
+        properties:
+          foo: bar
+`
+	template := yamlTemplate(t, strings.TrimSpace(text))
+
+	var leafName string
+	var leafAliases []string
+	mocks := &testMonitor{
+		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+			switch args.TypeToken {
+			case "test:index:myComponent":
+				return "", resource.PropertyMap{}, nil
+			case testResourceToken:
+				leafName = args.Name
+				if args.RegisterRPC != nil {
+					for _, a := range args.RegisterRPC.Aliases {
+						if spec := a.GetSpec(); spec != nil {
+							leafAliases = append(leafAliases, spec.GetName())
+						}
+					}
+				}
+				return "leafID", resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+					"bar": resource.NewStringProperty("baz"),
+				}, nil
+			}
+			return "", resource.PropertyMap{}, fmt.Errorf("unexpected resource type %s", args.TypeToken)
+		},
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		// Simulate the engine's construct of a nested component: it passes the
+		// already-prefixed instance name "outer-inner" as the component's name.
+		_, _, err := RunComponentTemplate(ctx,
+			"test:index:myComponent", "outer-inner", nil,
+			template, pulumi.Map{}, newMockPackageMap(),
+		)
+		return err
+	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
+	if diags, ok := HasDiagnostics(err); ok {
+		requireNoErrors(t, template, diags)
+	}
+	require.NoError(t, err)
+	assert.Equal(t, "outer-inner-leaf", leafName)
+	assert.Equal(t, []string{"leaf"}, leafAliases)
+}
+
+// TestComponentResourceExplicitName verifies that an explicit `name:` field on a
+// resource inside a component is also prefixed (and aliased to its un-prefixed form).
+func TestComponentResourceExplicitName(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+components:
+  myComponent:
+    resources:
+      yamlKey:
+        type: ` + testResourceToken + `
+        name: customName
+        properties:
+          foo: bar
+`
+	template := yamlTemplate(t, strings.TrimSpace(text))
+
+	var registeredName string
+	var aliases []string
+	mocks := &testMonitor{
+		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+			switch args.TypeToken {
+			case "test:index:myComponent":
+				return "", resource.PropertyMap{}, nil
+			case testResourceToken:
+				registeredName = args.Name
+				if args.RegisterRPC != nil {
+					for _, a := range args.RegisterRPC.Aliases {
+						if spec := a.GetSpec(); spec != nil {
+							aliases = append(aliases, spec.GetName())
+						}
+					}
+				}
+				return "id", resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+					"bar": resource.NewStringProperty("baz"),
+				}, nil
+			}
+			return "", resource.PropertyMap{}, fmt.Errorf("unexpected resource type %s", args.TypeToken)
+		},
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, _, err := RunComponentTemplate(ctx,
+			"test:index:myComponent", "cp1", nil,
+			template, pulumi.Map{}, newMockPackageMap(),
+		)
+		return err
+	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
+	if diags, ok := HasDiagnostics(err); ok {
+		requireNoErrors(t, template, diags)
+	}
+	require.NoError(t, err)
+	assert.Equal(t, "cp1-customName", registeredName)
+	assert.Equal(t, []string{"customName"}, aliases)
+}
+
+// TestComponentResourceUserAliasesCombined verifies that a user-supplied alias on a
+// resource inside a component is preserved alongside the auto-generated alias to the
+// un-prefixed name.
+func TestComponentResourceUserAliasesCombined(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+components:
+  myComponent:
+    resources:
+      inner:
+        type: ` + testResourceToken + `
+        properties:
+          foo: bar
+        options:
+          aliases:
+            - name: legacyName
+`
+	template := yamlTemplate(t, strings.TrimSpace(text))
+
+	var aliases []string
+	mocks := &testMonitor{
+		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+			switch args.TypeToken {
+			case "test:index:myComponent":
+				return "", resource.PropertyMap{}, nil
+			case testResourceToken:
+				if args.RegisterRPC != nil {
+					for _, a := range args.RegisterRPC.Aliases {
+						if spec := a.GetSpec(); spec != nil {
+							aliases = append(aliases, spec.GetName())
+						}
+					}
+				}
+				return "id", resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+					"bar": resource.NewStringProperty("baz"),
+				}, nil
+			}
+			return "", resource.PropertyMap{}, fmt.Errorf("unexpected resource type %s", args.TypeToken)
+		},
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, _, err := RunComponentTemplate(ctx,
+			"test:index:myComponent", "cp1", nil,
+			template, pulumi.Map{}, newMockPackageMap(),
+		)
+		return err
+	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
+	if diags, ok := HasDiagnostics(err); ok {
+		requireNoErrors(t, template, diags)
+	}
+	require.NoError(t, err)
+	// Both aliases must be present: the user-supplied one and the auto-generated one
+	// for backwards compatibility with un-prefixed stacks.
+	assert.ElementsMatch(t, []string{"legacyName", "inner"}, aliases)
+}
+
+// TestComponentResourceProviderAndRead verifies that the prefix logic also applies on
+// the provider-resource path (pulumi:providers:*) and the read path (resources with
+// `get.id`), since both share the same `resourceName` variable in registerResource.
+func TestComponentResourceProviderAndRead(t *testing.T) {
+	t.Parallel()
+
+	const text = `
+name: test-yaml
+runtime: yaml
+components:
+  myComponent:
+    resources:
+      myProvider:
+        type: pulumi:providers:test
+      readMe:
+        type: ` + testResourceToken + `
+        get:
+          id: external-id
+`
+	template := yamlTemplate(t, strings.TrimSpace(text))
+
+	type observation struct {
+		name    string
+		read    bool
+		aliases []string
+	}
+	var observed []observation
+	mocks := &testMonitor{
+		NewResourceF: func(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+			switch args.TypeToken {
+			case "test:index:myComponent":
+				return "", resource.PropertyMap{}, nil
+			case "pulumi:providers:test", testResourceToken:
+				obs := observation{
+					name: args.Name,
+					read: args.ReadRPC != nil,
+				}
+				if args.RegisterRPC != nil {
+					for _, a := range args.RegisterRPC.Aliases {
+						if spec := a.GetSpec(); spec != nil {
+							obs.aliases = append(obs.aliases, spec.GetName())
+						}
+					}
+				}
+				observed = append(observed, obs)
+				return "id", resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+					"bar": resource.NewStringProperty("baz"),
+				}, nil
+			}
+			return "", resource.PropertyMap{}, fmt.Errorf("unexpected resource type %s", args.TypeToken)
+		},
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, _, err := RunComponentTemplate(ctx,
+			"test:index:myComponent", "cp1", nil,
+			template, pulumi.Map{}, newMockPackageMap(),
+		)
+		return err
+	}, pulumi.WithMocks("projectFoo", "stackDev", mocks))
+	if diags, ok := HasDiagnostics(err); ok {
+		requireNoErrors(t, template, diags)
+	}
+	require.NoError(t, err)
+
+	var providerObs, readObs *observation
+	for i := range observed {
+		switch observed[i].name {
+		case "cp1-myProvider":
+			providerObs = &observed[i]
+		case "cp1-readMe":
+			readObs = &observed[i]
+		}
+	}
+	require.NotNil(t, providerObs, "expected provider resource registered as cp1-myProvider; got %+v", observed)
+	require.NotNil(t, readObs, "expected read resource registered as cp1-readMe; got %+v", observed)
+	assert.False(t, providerObs.read, "provider resource should not be a read")
+	assert.Equal(t, []string{"myProvider"}, providerObs.aliases)
+	assert.True(t, readObs.read, "readMe should go through the read path (Get.Id was set)")
+}

--- a/pkg/server/component_provider.go
+++ b/pkg/server/component_provider.go
@@ -31,16 +31,14 @@ type componentProvider struct {
 
 	host      *grpc.ClientConn
 	name      string
+	version   string
 	schema    []byte
 	construct provider.ConstructFunc
 }
 
 // GetPluginInfo returns generic information about this plugin, like its version.
 func (p *componentProvider) GetPluginInfo(context.Context, *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
-	// We fill in the version on the engine side for components.
-	return &pulumirpc.PluginInfo{
-		Version: "0.0.0",
-	}, nil
+	return &pulumirpc.PluginInfo{Version: p.version}, nil
 }
 
 // GetSchema returns the JSON-encoded schema for this provider's package.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -382,9 +383,19 @@ func (host *yamlLanguageHost) RunPlugin(
 
 	// Because of async applies we may need the package loader to outlast the RunTemplate function. But by the
 	// time RunWithContext returns we should be done with all async work.
-	loader, err := pulumiyaml.NewPackageLoader(nil, nil)
-	if err != nil {
-		return err
+	var loader pulumiyaml.PackageLoader
+	if req.LoaderTarget != "" {
+		schemaLoader, lerr := schema.NewLoaderClient(req.LoaderTarget)
+		if lerr != nil {
+			return lerr
+		}
+		defer contract.IgnoreClose(schemaLoader)
+		loader = pulumiyaml.NewPackageLoaderFromSchemaLoader(schema.NewCachedLoader(schemaLoader))
+	} else {
+		loader, err = pulumiyaml.NewPackageLoader(nil, nil)
+		if err != nil {
+			return err
+		}
 	}
 	defer loader.Close()
 
@@ -404,23 +415,30 @@ func (host *yamlLanguageHost) RunPlugin(
 		return fmt.Errorf("fatal: could not connect to host RPC: %w", err)
 	}
 
-	// If we have a host cancel our cancellation context if it fails the healthcheck
-	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel our gRPC server when either the engine fails its healthcheck or the RunPlugin RPC
+	// itself is cancelled by the engine (e.g. when the engine is done with this plugin instance).
+	// Without the latter, this in-process plugin would stay alive for the entire engine lifetime.
+	healthCtx, cancel := context.WithCancel(server.Context())
 	// map the context Done channel to the rpcutil boolean cancel channel
 	cancelChannel = make(chan bool)
 	go func() {
-		<-ctx.Done()
+		<-healthCtx.Done()
 		close(cancelChannel)
 	}()
-	err = rpcutil.Healthcheck(ctx, host.engineAddress, 5*time.Minute, cancel)
+	err = rpcutil.Healthcheck(healthCtx, host.engineAddress, 5*time.Minute, cancel)
 	if err != nil {
 		return fmt.Errorf("could not start health check host RPC server: %w", err)
 	}
 
+	var templateVersion string
+	if template.Version != nil {
+		templateVersion = template.Version.Value
+	}
 	prov := &componentProvider{
-		host:   providerHost.EngineConn(),
-		name:   template.Name.Value,
-		schema: jsonSchema,
+		host:    providerHost.EngineConn(),
+		name:    template.Name.Value,
+		version: templateVersion,
+		schema:  jsonSchema,
 		construct: func(ctx *pulumi.Context, typ, name string, inputs providersdk.ConstructInputs,
 			options pulumi.ResourceOption,
 		) (*providersdk.ConstructResult, error) {

--- a/pkg/tests/integration_test.go
+++ b/pkg/tests/integration_test.go
@@ -221,6 +221,79 @@ func TestAuthoredComponent(t *testing.T) {
 	require.Len(t, strings.TrimSuffix(stdout, "\n"), 8, fmt.Sprintf("expected %s to have 8 characters", stdout))
 }
 
+// TestComponentChildAliasMigration verifies end-to-end that when a stack already exists
+// containing a child resource at the *un-prefixed* URN (the shape produced by code from
+// before the #957 fix), running `pulumi up` with the current YAML runtime rebinds the
+// existing resource via the auto-generated alias instead of creating a fresh one.
+//
+// The program also declares a top-level resource named `child` of the same type
+// (`random:RandomString`) as the un-prefixed inner URN. This pins the alias scope: an
+// alias that was not properly scoped to the component's parent-type chain would either
+// match this top-level sibling (rebinding the wrong resource and leaving the inner one
+// orphaned) or be rejected as ambiguous. A correct URN-based alias only matches the
+// inner child because the parent-type chains differ.
+func TestComponentChildAliasMigration(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.ImportDirectory(filepath.Join("testdata", "component-alias-migration"))
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+
+	e.CWD = filepath.Join(e.RootPath, "program")
+	e.RunCommand("pulumi", "stack", "init", "organization/component-alias-test/test")
+	e.RunCommand("pulumi", "package", "add", "../provider")
+
+	// Step 1: initial up. Under the current code this produces:
+	//   - a top-level `child` at  ...pulumi:Stack$random:RandomString::child
+	//   - an inner child at      ...withChild$random:RandomString::myComp-child
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+
+	originalComponentChild, _ := e.RunCommand("pulumi", "stack", "output", "componentChild")
+	originalComponentChild = strings.TrimSuffix(originalComponentChild, "\n")
+	require.Len(t, originalComponentChild, 8, "component child output should be 8 characters")
+
+	originalTopLevelChild, _ := e.RunCommand("pulumi", "stack", "output", "topLevelChild")
+	originalTopLevelChild = strings.TrimSuffix(originalTopLevelChild, "\n")
+	require.Len(t, originalTopLevelChild, 8, "top-level child output should be 8 characters")
+
+	// Step 2: rewrite the stack state so the inner child sits at the un-prefixed URN
+	// (".../withChild$random:RandomString::child"), simulating a stack created before the
+	// #957 fix. We deliberately don't touch the top-level `child`, whose URN already ends
+	// in `::child` but is parented by the Stack type rather than the component type.
+	stateJSON, _ := e.RunCommand("pulumi", "stack", "export")
+	const prefixedSuffix = "$random:index/randomString:RandomString::myComp-child"
+	const unprefixedSuffix = "$random:index/randomString:RandomString::child"
+	require.Contains(t, stateJSON, prefixedSuffix,
+		"expected initial state to contain the prefixed child URN")
+	rewritten := strings.ReplaceAll(stateJSON, prefixedSuffix, unprefixedSuffix)
+	require.NotEqual(t, stateJSON, rewritten, "expected state rewrite to change the URN")
+
+	rewrittenPath := filepath.Join(e.CWD, "rewritten-state.json")
+	require.NoError(t, os.WriteFile(rewrittenPath, []byte(rewritten), 0o600))
+	e.RunCommand("pulumi", "stack", "import", "--file", rewrittenPath)
+
+	// Step 3: run `pulumi up` again. With a correctly-scoped alias URN the engine should
+	// recognize only the *inner* un-prefixed `child` (parent type withChild) and rebind
+	// it under the new prefixed name. The top-level `child` (parent type Stack) must
+	// remain untouched.
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+
+	// Both outputs must equal their pre-migration values: the alias correctly migrated
+	// the inner child, and the alias did NOT spuriously match the top-level sibling.
+	migratedComponentChild, _ := e.RunCommand("pulumi", "stack", "output", "componentChild")
+	migratedComponentChild = strings.TrimSuffix(migratedComponentChild, "\n")
+	assert.Equal(t, originalComponentChild, migratedComponentChild,
+		"expected alias to rebind the inner child; got a fresh random value")
+
+	migratedTopLevelChild, _ := e.RunCommand("pulumi", "stack", "output", "topLevelChild")
+	migratedTopLevelChild = strings.TrimSuffix(migratedTopLevelChild, "\n")
+	assert.Equal(t, originalTopLevelChild, migratedTopLevelChild,
+		"top-level child must be untouched; alias scope leaked outside the component")
+}
+
 func TestRemoteComponent(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tests/testdata/component-alias-migration/program/Pulumi.yaml
+++ b/pkg/tests/testdata/component-alias-migration/program/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: component-alias-test
+runtime: yaml
+resources:
+  myComp:
+    type: aliasplugin:index:withChild
+  # A top-level sibling with the same name AND type as the un-prefixed URN our
+  # auto-alias targets. If the alias were not properly scoped to the component's
+  # parent-type chain, it would also match this resource (or be ambiguous about
+  # which to rebind), which would replace `child`'s random value.
+  child:
+    type: random:RandomString
+    properties:
+      length: 8
+outputs:
+  componentChild: ${myComp.childResult}
+  topLevelChild: ${child.result}

--- a/pkg/tests/testdata/component-alias-migration/provider/PulumiPlugin.yaml
+++ b/pkg/tests/testdata/component-alias-migration/provider/PulumiPlugin.yaml
@@ -1,0 +1,11 @@
+name: aliasplugin
+runtime: yaml
+components:
+  withChild:
+    resources:
+      child:
+        type: random:RandomString
+        properties:
+          length: 8
+    outputs:
+      childResult: ${child.result}


### PR DESCRIPTION
This PR prefixes each resource created within a component with the name of the component. This allows instantiating multiple instances of a component resource within a single stack. 

To minimize the breaking change, a back-port alias is emitted to avoid needing to re-import. 

Fixes https://github.com/pulumi/pulumi-yaml/issues/957