### PR TITLE
Fix the capitalization for 6 functions

### DIFF
--- a/cmd/pulumi-language-yaml/testdata/projects/l2-resource-asset-archive/subdir/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l2-resource-asset-archive/subdir/Main.yaml
@@ -3,37 +3,37 @@ resources:
     type: asset-archive:AssetResource
     properties:
       value:
-        fn::FileAsset: ../test.txt
+        fn::fileAsset: ../test.txt
   arc:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::FileArchive: ../archive.tar
+        fn::fileArchive: ../archive.tar
   dir:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::FileArchive: ../folder
+        fn::fileArchive: ../folder
   assarc:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::AssetArchive:
+        fn::assetArchive:
           string:
-            fn::StringAsset: file contents
+            fn::stringAsset: file contents
           file:
-            fn::FileAsset: ../test.txt
+            fn::fileAsset: ../test.txt
           folder:
-            fn::FileArchive: ../folder
+            fn::fileArchive: ../folder
           archive:
-            fn::FileArchive: ../archive.tar
+            fn::fileArchive: ../archive.tar
   remoteass:
     type: asset-archive:AssetResource
     properties:
       value:
-        fn::RemoteAsset: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt
+        fn::remoteAsset: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt
   remotearc:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::RemoteArchive: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar
+        fn::remoteArchive: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-asset-archive/subdir/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l2-resource-asset-archive/subdir/Main.yaml
@@ -3,37 +3,37 @@ resources:
     type: asset-archive:AssetResource
     properties:
       value:
-        fn::FileAsset: ../test.txt
+        fn::fileAsset: ../test.txt
   arc:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::FileArchive: ../archive.tar
+        fn::fileArchive: ../archive.tar
   dir:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::FileArchive: ../folder
+        fn::fileArchive: ../folder
   assarc:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::AssetArchive:
+        fn::assetArchive:
           string:
-            fn::StringAsset: file contents
+            fn::stringAsset: file contents
           file:
-            fn::FileAsset: ../test.txt
+            fn::fileAsset: ../test.txt
           folder:
-            fn::FileArchive: ../folder
+            fn::fileArchive: ../folder
           archive:
-            fn::FileArchive: ../archive.tar
+            fn::fileArchive: ../archive.tar
   remoteass:
     type: asset-archive:AssetResource
     properties:
       value:
-        fn::RemoteAsset: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt
+        fn::remoteAsset: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt
   remotearc:
     type: asset-archive:ArchiveResource
     properties:
       value:
-        fn::RemoteArchive: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar
+        fn::remoteArchive: https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.9
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/ettle/strcase v0.1.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,6 @@ github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/ettle/strcase v0.1.1 h1:htFueZyVeE1XNnMEfbqp5r67qAN/4r6ya1ysq8Q+Zcw=
-github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/pkg/pulumiyaml/ast/template_test.go
+++ b/pkg/pulumiyaml/ast/template_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -283,4 +284,53 @@ func TestComponentSchemaGeneration(t *testing.T) {
 }
 `
 	require.JSONEq(t, expectedSchema, string(marshalled))
+}
+
+const oldCasingAssetExample = `
+name: simple-yaml
+runtime: yaml
+resources:
+  index.html:
+    type: aws:s3/bucketObject:BucketObject
+    properties:
+      bucket: my-bucket
+      source:
+        fn::FileAsset: ./index.html
+`
+
+// TestOldCasingAssetWarns verifies that legacy PascalCase asset/archive function
+// names (e.g. fn::FileAsset) are still accepted but emit a miscapitalization
+// warning steering users toward the canonical camelCase form (fn::fileAsset).
+func TestOldCasingAssetWarns(t *testing.T) {
+	t.Parallel()
+
+	syntax, sdiags := encoding.DecodeYAML("<stdin>", yaml.NewDecoder(strings.NewReader(oldCasingAssetExample)), nil)
+	require.Len(t, sdiags, 0)
+
+	template, diags := ParseTemplate([]byte(oldCasingAssetExample), syntax)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	var warnings []string
+	for _, d := range diags {
+		if d.Severity == hcl.DiagWarning {
+			warnings = append(warnings, d.Summary)
+		}
+	}
+	assert.Equal(t, []string{
+		"'fn::FileAsset' looks like a miscapitalization of 'fn::fileAsset'",
+	}, warnings)
+
+	resources := template.Resources.Entries
+	require.Len(t, resources, 1)
+	props := resources[0].Value.Properties.PropertyMap
+	require.NotNil(t, props)
+	var source Expr
+	for _, e := range props.Entries {
+		if e.Key.Value == "source" {
+			source = e.Value
+		}
+	}
+	require.NotNil(t, source)
+	_, ok := source.(*FileAssetExpr)
+	assert.True(t, ok, "expected *FileAssetExpr, got %T", source)
 }

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ettle/strcase"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
@@ -913,7 +912,7 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return g.MustInvoke(f, "")
 	case "fileArchive", "remoteArchive", "assetArchive",
 		"fileAsset", "stringAsset", "remoteAsset":
-		return wrapFn(strcase.ToPascal(f.Name), g.expr(f.Args[0]))
+		return wrapFn(f.Name, g.expr(f.Args[0]))
 	case "join":
 		args := make([]syn.Node, len(f.Args))
 		for i, arg := range f.Args {

--- a/pkg/pulumiyaml/testing/test/testdata/assets-archives-pp/yaml/assets-archives.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/assets-archives-pp/yaml/assets-archives.yaml
@@ -7,61 +7,61 @@ resources:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        fn::FileAsset: file.txt
+        fn::fileAsset: file.txt
   testStringAsset:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        fn::StringAsset: <h1>File contents</h1>
+        fn::stringAsset: <h1>File contents</h1>
   testRemoteAsset:
     type: aws:s3:BucketObject
     properties:
       bucket: ${siteBucket.id}
       # Reference the s3.Bucket object
       source:
-        fn::RemoteAsset: https://pulumi.test
+        fn::remoteAsset: https://pulumi.test
   testFileArchive:
     type: aws:lambda:Function
     properties:
       role: ${siteBucket.arn}
       # Reference the s3.Bucket object
       code:
-        fn::FileArchive: file.tar.gz
+        fn::fileArchive: file.tar.gz
   testRemoteArchive:
     type: aws:lambda:Function
     properties:
       role: ${siteBucket.arn}
       # Reference the s3.Bucket object
       code:
-        fn::RemoteArchive: https://pulumi.test/foo.tar.gz
+        fn::remoteArchive: https://pulumi.test/foo.tar.gz
   testAssetArchive:
     type: aws:lambda:Function
     properties:
       role: ${siteBucket.arn}
       # Reference the s3.Bucket object
       code:
-        fn::AssetArchive:
+        fn::assetArchive:
           file.txt:
-            fn::FileAsset: file.txt
+            fn::fileAsset: file.txt
           string.txt:
-            fn::StringAsset: <h1>File contents</h1>
+            fn::stringAsset: <h1>File contents</h1>
           remote.txt:
-            fn::RemoteAsset: https://pulumi.test
+            fn::remoteAsset: https://pulumi.test
           file.tar:
-            fn::FileArchive: file.tar.gz
+            fn::fileArchive: file.tar.gz
           remote.tar:
-            fn::RemoteArchive: https://pulumi.test/foo.tar.gz
+            fn::remoteArchive: https://pulumi.test/foo.tar.gz
           .nestedDir:
-            fn::AssetArchive:
+            fn::assetArchive:
               file.txt:
-                fn::FileAsset: file.txt
+                fn::fileAsset: file.txt
               string.txt:
-                fn::StringAsset: <h1>File contents</h1>
+                fn::stringAsset: <h1>File contents</h1>
               remote.txt:
-                fn::RemoteAsset: https://pulumi.test
+                fn::remoteAsset: https://pulumi.test
               file.tar:
-                fn::FileArchive: file.tar.gz
+                fn::fileArchive: file.tar.gz
               remote.tar:
-                fn::RemoteArchive: https://pulumi.test/foo.tar.gz
+                fn::remoteArchive: https://pulumi.test/foo.tar.gz

--- a/pkg/pulumiyaml/testing/test/testdata/aws-lambda-pp/yaml/aws-lambda.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/aws-lambda-pp/yaml/aws-lambda.yaml
@@ -7,7 +7,7 @@ resources:
     type: aws:lambda:Function
     properties:
       code:
-        fn::FileArchive: lambda_function_payload.zip
+        fn::fileArchive: lambda_function_payload.zip
       role: ${iamForLambda.arn}
       handler: index.test
       runtime: nodejs12.x

--- a/pkg/pulumiyaml/testing/test/testdata/depends-on-array-pp/yaml/depends-on-array.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/depends-on-array-pp/yaml/depends-on-array.yaml
@@ -21,7 +21,7 @@ resources:
     properties:
       bucket: ${myBucket.id}
       source:
-        fn::FileAsset: ./index.html
+        fn::fileAsset: ./index.html
       contentType: text/html
       acl: public-read
     options:


### PR DESCRIPTION
This PR fixes the capitalization for 6 functions when the are generated: "fileArchive", "remoteArchive", "assetArchive", "fileAsset", "stringAsset", "remoteAsset".

This also reduces a bunch of warnings in CI.