### PR TITLE
Fix l1-builtin-list

### DIFF
--- a/.changes/unreleased/Improvements-1069.yaml
+++ b/.changes/unreleased/Improvements-1069.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Support the `singleOrNone` and `length` intrinsic functions
+time: 2026-04-29T22:34:54.737218+01:00
+custom:
+    PR: "1069"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -100,7 +100,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l1-builtin-can":                 "#721 generation unimplemented",
-	"l1-builtin-list":                "Unknown Function; YAML does not support fn::length",
 	"l1-builtin-object":              "Unknown Function; YAML does not support fn::entries",
 	"l1-builtin-secret":              "Unknown Function; YAML does not support fn::unsecret",
 	"l1-builtin-try":                 "#721 generation unimplemented",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-list/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-list/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-list
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-list/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-list/program.pp
@@ -1,0 +1,41 @@
+config aList "list(string)" {
+	__logicalName = "aList"
+}
+
+config singleOrNoneList "list(string)" {
+	__logicalName = "singleOrNoneList"
+}
+
+config aString string {
+	__logicalName = "aString"
+}
+
+output elementOutput1 {
+	__logicalName = "elementOutput1"
+	value = aList[1]
+}
+
+output elementOutput2 {
+	__logicalName = "elementOutput2"
+	value = aList[2]
+}
+
+output joinOutput {
+	__logicalName = "joinOutput"
+	value = join("|", aList)
+}
+
+output lengthOutput {
+	__logicalName = "lengthOutput"
+	value = length(aList)
+}
+
+output splitOutput {
+	__logicalName = "splitOutput"
+	value = split("-", aString)
+}
+
+output singleOrNoneOutput {
+	__logicalName = "singleOrNoneOutput"
+	value = [singleOrNone(singleOrNoneList)]
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-list/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-list/Main.yaml
@@ -1,0 +1,29 @@
+configuration:
+  aList:
+    type: list<string>
+  singleOrNoneList:
+    type: list<string>
+  aString:
+    type: string
+outputs:
+  elementOutput1:
+    fn::select:
+      - 1
+      - ${aList}
+  elementOutput2:
+    fn::select:
+      - 2
+      - ${aList}
+  joinOutput:
+    fn::join:
+      - '|'
+      - ${aList}
+  lengthOutput:
+    fn::length: ${aList}
+  splitOutput:
+    fn::split:
+      - '-'
+      - ${aString}
+  # Wrap in list to avoid unsafe-null-output (see l1-builtin-try/main.pp).
+  singleOrNoneOutput:
+    - fn::singleOrNone: ${singleOrNoneList}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-list/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-list/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-list
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-list/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-list/Main.yaml
@@ -1,0 +1,22 @@
+configuration:
+  aList:
+    type: list<string>
+  singleOrNoneList:
+    type: list<string>
+  aString:
+    type: string
+outputs:
+  elementOutput1: ${aList[1]}
+  elementOutput2: ${aList[2]}
+  joinOutput:
+    fn::join:
+      - '|'
+      - ${aList}
+  lengthOutput:
+    fn::length: ${aList}
+  splitOutput:
+    fn::split:
+      - '-'
+      - ${aString}
+  singleOrNoneOutput:
+    - fn::singleOrNone: ${singleOrNoneList}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-list/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-list/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-list
+runtime: yaml

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -787,6 +787,38 @@ func parseSha1(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, synt
 	return Sha1Syntax(node, name, args), nil
 }
 
+type LengthExpr struct {
+	builtinNode
+	Value Expr
+}
+
+func LengthSyntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *LengthExpr {
+	return &LengthExpr{
+		builtinNode: builtin(node, name, args),
+		Value:       args,
+	}
+}
+
+func parseLength(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
+	return LengthSyntax(node, name, args), nil
+}
+
+type SingleOrNoneExpr struct {
+	builtinNode
+	Value Expr
+}
+
+func SingleOrNoneSyntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *SingleOrNoneExpr {
+	return &SingleOrNoneExpr{
+		builtinNode: builtin(node, name, args),
+		Value:       args,
+	}
+}
+
+func parseSingleOrNone(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
+	return SingleOrNoneSyntax(node, name, args), nil
+}
+
 type PulumiResourceNameExpr struct {
 	builtinNode
 	Resource Expr
@@ -869,6 +901,10 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		set("fn::filebase64sha256", parseFileBase64Sha256)
 	case "fn::sha1":
 		set("fn::sha1", parseSha1)
+	case "fn::length":
+		set("fn::length", parseLength)
+	case "fn::singleornone":
+		set("fn::singleOrNone", parseSingleOrNone)
 	case "fn::pulumiresourcename":
 		set("fn::pulumiResourceName", parsePulumiResourceName)
 	case "fn::pulumiresourcetype":

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -920,7 +920,7 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		}
 		return wrapFn("join", syn.List(args...))
 	case "split":
-		return wrapFn("split", syn.List(g.expr(f.Args[1]), g.expr(f.Args[0])))
+		return wrapFn("split", syn.List(g.expr(f.Args[0]), g.expr(f.Args[1])))
 	case "toBase64":
 		return wrapFn("toBase64", g.expr(f.Args[0]))
 	case "fromBase64":
@@ -943,6 +943,10 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return wrapFn("secret", g.expr(f.Args[0]))
 	case "sha1":
 		return wrapFn("sha1", g.expr(f.Args[0]))
+	case "length":
+		return wrapFn("length", g.expr(f.Args[0]))
+	case "singleOrNone":
+		return wrapFn("singleOrNone", g.expr(f.Args[0]))
 	case "pulumiResourceName":
 		return wrapFn("pulumiResourceName", g.expr(f.Args[0]))
 	case "pulumiResourceType":

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -486,6 +486,18 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 			Name: "sha1",
 			Args: []model.Expression{val},
 		}, vdiags
+	case *ast.LengthExpr:
+		val, vdiags := imp.importExpr(node.Args(), nil)
+		return &model.FunctionCallExpression{
+			Name: "length",
+			Args: []model.Expression{val},
+		}, vdiags
+	case *ast.SingleOrNoneExpr:
+		val, vdiags := imp.importExpr(node.Args(), nil)
+		return &model.FunctionCallExpression{
+			Name: "singleOrNone",
+			Args: []model.Expression{val},
+		}, vdiags
 	case *ast.PulumiResourceNameExpr:
 		res, rdiags := imp.importExpr(node.Resource, nil)
 		return &model.FunctionCallExpression{

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -2192,6 +2192,10 @@ func (e *programEvaluator) evaluateExpr(x ast.Expr) (interface{}, bool) {
 		return e.evaluateBuiltinFileBase64Sha256(x)
 	case *ast.Sha1Expr:
 		return e.evaluateBuiltinSha1(x)
+	case *ast.LengthExpr:
+		return e.evaluateBuiltinLength(x)
+	case *ast.SingleOrNoneExpr:
+		return e.evaluateBuiltinSingleOrNone(x)
 	case *ast.PulumiResourceNameExpr:
 		return e.evaluateBuiltinPulumiResourceName(x)
 	case *ast.PulumiResourceTypeExpr:
@@ -2952,6 +2956,44 @@ func (e *programEvaluator) evaluateBuiltinReadFile(s *ast.ReadFileExpr) (interfa
 	})
 
 	return readFileF(expr)
+}
+
+func (e *programEvaluator) evaluateBuiltinLength(s *ast.LengthExpr) (interface{}, bool) {
+	expr, ok := e.evaluateExpr(s.Value)
+	if !ok {
+		return nil, false
+	}
+	return e.lift(func(args ...interface{}) (interface{}, bool) {
+		switch v := args[0].(type) {
+		case []interface{}:
+			return float64(len(v)), true
+		case map[string]interface{}:
+			return float64(len(v)), true
+		default:
+			return e.error(s.Value, fmt.Sprintf("fn::length requires a list or map, got %v", typeString(args[0])))
+		}
+	})(expr)
+}
+
+func (e *programEvaluator) evaluateBuiltinSingleOrNone(s *ast.SingleOrNoneExpr) (interface{}, bool) {
+	expr, ok := e.evaluateExpr(s.Value)
+	if !ok {
+		return nil, false
+	}
+	return e.lift(func(args ...interface{}) (interface{}, bool) {
+		list, ok := args[0].([]interface{})
+		if !ok {
+			return e.error(s.Value, fmt.Sprintf("fn::singleOrNone requires a list, got %v", typeString(args[0])))
+		}
+		switch len(list) {
+		case 0:
+			return nil, true
+		case 1:
+			return list[0], true
+		default:
+			return e.error(s.Value, fmt.Sprintf("fn::singleOrNone expected a list of 0 or 1 elements, got %d", len(list)))
+		}
+	})(expr)
 }
 
 func (e *programEvaluator) evaluateBuiltinFileBase64(s *ast.FileBase64Expr) (interface{}, bool) {

--- a/pkg/pulumiyaml/testing/test/testdata/join-template-pp/yaml/join-template.yaml
+++ b/pkg/pulumiyaml/testing/test/testdata/join-template-pp/yaml/join-template.yaml
@@ -15,5 +15,5 @@ resources:
         fn::select:
           - 0
           - fn::split:
-              - '-'
               - '{}-foo'
+              - '-'


### PR DESCRIPTION
This required adding `singleOrNone` and `length`. Also found that `split` was wrong, we'll want to get a focused conformance test in place for the string functions I think.