### PR TITLE
Fix l1-builtin-string

### DIFF
--- a/.changes/unreleased/Improvements-1085.yaml
+++ b/.changes/unreleased/Improvements-1085.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Support `fn::length` on strings, returning the grapheme cluster count to match PCL's `length()` builtin
+time: 2026-05-08T17:25:00+02:00
+custom:
+    PR: "1085"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -134,8 +134,6 @@ var expectedFailures = map[string]string{
 	"l1-stack-reference":      "Unknown Function; YAML does not support fn::unsecret",
 	"l2-resource-read":        "*pcl.ReadResource generation unimplemented",
 	"l2-component-call-plain": "Unknown Function; YAML does not support fn::call",
-
-	"l1-builtin-string": "fn::length does not support strings (would need grapheme cluster count)",
 }
 
 // Add test names here that are expected to fail the converter (eject) round-trip test.

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-string/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-string/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-string
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-string/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-string/program.pp
@@ -1,0 +1,23 @@
+config aString string {
+	__logicalName = "aString"
+}
+
+output lengthResult {
+	__logicalName = "lengthResult"
+	value = length(aString)
+}
+
+output splitResult {
+	__logicalName = "splitResult"
+	value = split("-", aString)
+}
+
+output joinResult {
+	__logicalName = "joinResult"
+	value = join("|", split("-", aString))
+}
+
+output interpolateResult {
+	__logicalName = "interpolateResult"
+	value = "prefix-${aString}"
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-string/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-string/Main.yaml
@@ -1,0 +1,17 @@
+configuration:
+  aString:
+    type: string
+outputs:
+  lengthResult:
+    fn::length: ${aString}
+  splitResult:
+    fn::split:
+      - '-'
+      - ${aString}
+  joinResult:
+    fn::join:
+      - '|'
+      - fn::split:
+          - '-'
+          - ${aString}
+  interpolateResult: prefix-${aString}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-string/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-string/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-string
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-string/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-string/Main.yaml
@@ -1,0 +1,17 @@
+configuration:
+  aString:
+    type: string
+outputs:
+  lengthResult:
+    fn::length: ${aString}
+  splitResult:
+    fn::split:
+      - '-'
+      - ${aString}
+  joinResult:
+    fn::join:
+      - '|'
+      - fn::split:
+          - '-'
+          - ${aString}
+  interpolateResult: prefix-${aString}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-string/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-string/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-string
+runtime: yaml

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi/pkg/v3 v3.236.0
 	github.com/pulumi/pulumi/sdk/v3 v3.236.0
+	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.13.2
@@ -173,7 +174,6 @@ require (
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.23.0 // indirect
 	github.com/pulumi/inflector v0.2.1 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -28,6 +28,8 @@ import (
 	"github.com/google/shlex"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/rivo/uniseg"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
@@ -3020,8 +3022,10 @@ func (e *programEvaluator) evaluateBuiltinLength(s *ast.LengthExpr) (interface{}
 			return float64(len(v)), true
 		case map[string]interface{}:
 			return float64(len(v)), true
+		case string:
+			return float64(uniseg.GraphemeClusterCount(v)), true
 		default:
-			return e.error(s.Value, fmt.Sprintf("fn::length requires a list or map, got %v", typeString(args[0])))
+			return e.error(s.Value, fmt.Sprintf("fn::length requires a list, map, or string, got %v", typeString(args[0])))
 		}
 	})(expr)
 }


### PR DESCRIPTION
## Summary
- Extend `fn::length` to accept strings, returning the Unicode grapheme cluster count via `github.com/rivo/uniseg`. This matches PCL's `length()` builtin, which the `l1-builtin-string` conformance test exercises with multi-byte Latin, emoji-with-variation-selector, and ZWJ family sequences.
- Remove `l1-builtin-string` from the expected-failures map in `cmd/pulumi-language-yaml/language_test.go`.
- Add the generated YAML project, eject-pcl, and round-tripped-project snapshots produced by `PULUMI_ACCEPT=true`.

## Test plan
- [x] `go test ./cmd/pulumi-language-yaml/ -run TestLanguage/l1-builtin-string`
- [x] `go test ./cmd/pulumi-language-yaml/ -run TestLanguage/l1-builtin`
- [x] `go test ./pkg/pulumiyaml/...`
- [x] `make lint-golang`