### PR TITLE
Fix l1-builtin-secret

### DIFF
--- a/.changes/unreleased/Improvements-1086.yaml
+++ b/.changes/unreleased/Improvements-1086.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Support `fn::unsecret` to unwrap a secret value, matching PCL's `unsecret()` builtin
+time: 2026-05-08T15:59:05+00:00
+custom:
+    PR: "1086"

--- a/cmd/pulumi-language-yaml/language_test.go
+++ b/cmd/pulumi-language-yaml/language_test.go
@@ -101,7 +101,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 var expectedFailures = map[string]string{
 	"l1-builtin-can":                 "#721 generation unimplemented",
 	"l1-builtin-object":              "Unknown Function; YAML does not support fn::entries",
-	"l1-builtin-secret":              "Unknown Function; YAML does not support fn::unsecret",
 	"l1-builtin-try":                 "#721 generation unimplemented",
 	"l1-config-secret":               "*model.BinaryOpExpression; Unimplemented! Needed for  aNumber + 1.25",
 	"l1-config-types-object":         "not yet implemented",

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-secret/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-secret/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-secret
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-secret/program.pp
+++ b/cmd/pulumi-language-yaml/testdata/eject-pcl/l1-builtin-secret/program.pp
@@ -1,0 +1,33 @@
+config aSecret string {
+	__logicalName = "aSecret"
+	secret = true
+}
+
+config notSecret string {
+	__logicalName = "notSecret"
+}
+
+output roundtripSecret {
+	__logicalName = "roundtripSecret"
+	value = aSecret
+}
+
+output roundtripNotSecret {
+	__logicalName = "roundtripNotSecret"
+	value = notSecret
+}
+
+output double {
+	__logicalName = "double"
+	value = secret(aSecret)
+}
+
+output open {
+	__logicalName = "open"
+	value = unsecret(aSecret)
+}
+
+output close {
+	__logicalName = "close"
+	value = secret(notSecret)
+}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-secret/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-secret/Main.yaml
@@ -1,0 +1,15 @@
+configuration:
+  aSecret:
+    type: string
+    secret: true
+  notSecret:
+    type: string
+outputs:
+  roundtripSecret: ${aSecret}
+  roundtripNotSecret: ${notSecret}
+  double:
+    fn::secret: ${aSecret}
+  open:
+    fn::unsecret: ${aSecret}
+  close:
+    fn::secret: ${notSecret}

--- a/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-secret/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/projects/l1-builtin-secret/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-secret
+runtime: yaml

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-secret/Main.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-secret/Main.yaml
@@ -1,0 +1,15 @@
+configuration:
+  aSecret:
+    type: string
+    secret: true
+  notSecret:
+    type: string
+outputs:
+  roundtripSecret: ${aSecret}
+  roundtripNotSecret: ${notSecret}
+  double:
+    fn::secret: ${aSecret}
+  open:
+    fn::unsecret: ${aSecret}
+  close:
+    fn::secret: ${notSecret}

--- a/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-secret/Pulumi.yaml
+++ b/cmd/pulumi-language-yaml/testdata/round-tripped-project/l1-builtin-secret/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-secret
+runtime: yaml

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -1143,6 +1143,9 @@ func (tc *typeCache) typeExpr(ctx *evalContext, t ast.Expr) bool {
 	case *ast.SecretExpr:
 		// The type of a secret is the type of its argument
 		tc.exprs[t] = tc.exprs[t.Value]
+	case *ast.UnsecretExpr:
+		// The type of an unsecret is the type of its argument
+		tc.exprs[t] = tc.exprs[t.Value]
 	case *ast.SplitExpr:
 		tc.assertTypeAssignable(ctx, t.Delimiter, schema.StringType)
 		tc.assertTypeAssignable(ctx, t.Source, schema.StringType)

--- a/pkg/pulumiyaml/ast/expr.go
+++ b/pkg/pulumiyaml/ast/expr.go
@@ -723,6 +723,19 @@ func SecretSyntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *SecretE
 	}
 }
 
+type UnsecretExpr struct {
+	builtinNode
+
+	Value Expr
+}
+
+func UnsecretSyntax(node *syntax.ObjectNode, name *StringExpr, args Expr) *UnsecretExpr {
+	return &UnsecretExpr{
+		builtinNode: builtin(node, name, args),
+		Value:       args,
+	}
+}
+
 type ReadFileExpr struct {
 	builtinNode
 	Path Expr
@@ -893,6 +906,8 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		set("fn::assetArchive", parseAssetArchive)
 	case "fn::secret":
 		set("fn::secret", parseSecret)
+	case "fn::unsecret":
+		set("fn::unsecret", parseUnsecret)
 	case "fn::readfile":
 		set("fn::readFile", parseReadFile)
 	case "fn::filebase64":
@@ -1081,6 +1096,10 @@ func parseStackReference(node *syntax.ObjectNode, name *StringExpr, args Expr) (
 
 func parseSecret(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
 	return SecretSyntax(node, name, args), nil
+}
+
+func parseUnsecret(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics) {
+	return UnsecretSyntax(node, name, args), nil
 }
 
 // We expect the following format

--- a/pkg/pulumiyaml/codegen/gen_program.go
+++ b/pkg/pulumiyaml/codegen/gen_program.go
@@ -941,6 +941,8 @@ func (g *generator) function(f *model.FunctionCallExpression) syn.Node {
 		return wrapFn("filebase64sha256", g.expr(f.Args[0]))
 	case "secret":
 		return wrapFn("secret", g.expr(f.Args[0]))
+	case "unsecret":
+		return wrapFn("unsecret", g.expr(f.Args[0]))
 	case "sha1":
 		return wrapFn("sha1", g.expr(f.Args[0]))
 	case "length":

--- a/pkg/pulumiyaml/codegen/load.go
+++ b/pkg/pulumiyaml/codegen/load.go
@@ -307,6 +307,12 @@ func (imp *importer) importBuiltin(node ast.BuiltinExpr) (model.Expression, synt
 			Name: "secret",
 			Args: []model.Expression{path},
 		}, pdiags
+	case *ast.UnsecretExpr:
+		path, pdiags := imp.importExpr(node.Args(), nil)
+		return &model.FunctionCallExpression{
+			Name: "unsecret",
+			Args: []model.Expression{path},
+		}, pdiags
 	case *ast.InvokeExpr:
 		var diags syntax.Diagnostics
 
@@ -1241,6 +1247,7 @@ func (imp *importer) assignNames() {
 		"stack",
 		"toBase64",
 		"toJSON",
+		"unsecret",
 	)
 
 	assign := func(name, suffix string) *model.Variable {

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -2232,6 +2232,8 @@ func (e *programEvaluator) evaluateExpr(x ast.Expr) (interface{}, bool) {
 		return e.evaluateBuiltinStackReference(x)
 	case *ast.SecretExpr:
 		return e.evaluateBuiltinSecret(x)
+	case *ast.UnsecretExpr:
+		return e.evaluateBuiltinUnsecret(x)
 	case *ast.ReadFileExpr:
 		return e.evaluateBuiltinReadFile(x)
 	case *ast.FileBase64Expr:
@@ -2957,6 +2959,14 @@ func (e *programEvaluator) evaluateBuiltinSecret(s *ast.SecretExpr) (interface{}
 		return nil, false
 	}
 	return pulumi.ToSecret(expr), true
+}
+
+func (e *programEvaluator) evaluateBuiltinUnsecret(s *ast.UnsecretExpr) (interface{}, bool) {
+	expr, ok := e.evaluateExpr(s.Value)
+	if !ok {
+		return nil, false
+	}
+	return pulumi.Unsecret(pulumi.ToOutput(expr)), true
 }
 
 func (e *programEvaluator) evaluateInterpolatedBuiltinAssetArchive(x, s ast.Expr) (interface{}, bool) {


### PR DESCRIPTION
## Summary
- Add `fn::unsecret` builtin to unwrap a secret value, matching PCL's `unsecret()`. The new builtin is wired through the AST, parser, analyser, runtime evaluator, and YAML <-> PCL codegen.
- Remove `l1-builtin-secret` from the expected-failures map in `cmd/pulumi-language-yaml/language_test.go`.
- Add the generated YAML project, eject-pcl, and round-tripped-project snapshots produced by `PULUMI_ACCEPT=true`.

## Test plan
- [x] `go test ./cmd/pulumi-language-yaml/ -run TestLanguage/l1-builtin-secret`
- [x] `go test ./cmd/pulumi-language-yaml/ -run TestLanguage/l1-builtin`
- [x] `go test ./pkg/pulumiyaml/...`
- [x] `make lint-golang`