### PR TITLE
Add producer workflow to export secrets to ESC

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [ workflow_dispatch ]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@9d6485759b6adff2538ae91f1b77cc96265c9dad # v1
+        with:
+          organization: pulumi
+          org-environment: github-secrets/pulumi-pulumi-yaml
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}


### PR DESCRIPTION
These changes add the standard `export-repo-secrets.yml` producer workflow. Adapted directly from [pulumi/pulumi-service's `export-repo-secrets.yml`](https://github.com/pulumi/pulumi-service/blob/master/.github/workflows/export-repo-secrets.yml); only the target env name differs.

Writes to the per-repo env `pulumi/github-secrets/pulumi-pulumi-yaml`, which imports the org-wide `imports/github-secrets` env. The workflow runs on `workflow_dispatch` only.

Required follow-up after merge:
1. Provision `EXPORT_SECRETS_PRIVATE_KEY` as a repo secret (private key for the Export Secrets GitHub App, id `1256780`)--match the pattern used by `pulumi-service`, `pulumi-java`, etc.
2. Dispatch the workflow once to populate `pulumi/github-secrets/pulumi-pulumi-yaml`.
3. Repoint #847 to target `github-secrets/pulumi-pulumi-yaml` instead of `imports/github-secrets`.

Context: needed because `pulumi/pulumi-yaml`'s CI authenticates to `api.pulumi-staging.io` using a `PULUMI_ACCESS_TOKEN` that is currently only available as a GitHub Actions secret. Without the producer workflow + per-repo env, [#847](https://github.com/pulumi/pulumi-yaml/pull/847) (Use ESC secrets) can't migrate that token through ESC.