### PR TITLE
Point export-repo-secrets at imports/github-secrets

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@9d6485759b6adff2538ae91f1b77cc96265c9dad # v1
         with:
           organization: pulumi
-          org-environment: github-secrets/pulumi-pulumi-yaml
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true


### PR DESCRIPTION
Follow-up to #1090. The producer ran successfully but wrote nothing because the target env `pulumi/github-secrets/pulumi-pulumi-yaml` does not exist.

pulumi-yaml's GHA Secrets are org-shared (`PULUMI_ACCESS_TOKEN`, `AWS_*`, `ARM_*`, `CODECOV_TOKEN`, etc.), so the right target is `imports/github-secrets`. This matches [pulumi/pulumi-java's `export-repo-secrets.yml`](https://github.com/pulumi/pulumi-java/blob/main/.github/workflows/export-repo-secrets.yml).

Once merged, dispatch the workflow to sync secrets into the org env.