### PR TITLE
Fix weekly release workflow follow-ups

### DIFF
--- a/.github/workflows/attempt-release.yml
+++ b/.github/workflows/attempt-release.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install changie
         uses: jaxxstorm/action-install-gh-release@v1.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: miniscruff/changie
 
@@ -99,7 +101,7 @@ jobs:
             --body-file /tmp/pr-body.md)
           echo "url=${pr_url}" >> "$GITHUB_OUTPUT"
 
-      - name: Notify Slack
+      - name: Notify Slack (release ready)
         if: steps.pr.outputs.url != ''
         uses: slackapi/slack-github-action@v2
         with:
@@ -108,3 +110,13 @@ jobs:
           payload: |
             channel: "#team-iac-core"
             text: "`pulumi-yaml` ${{ steps.latest.outputs.output }} release is ready to go! ${{ steps.pr.outputs.url }}"
+
+      - name: Notify Slack (no changes)
+        if: steps.check.outputs.has-changes == 'false'
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+          payload: |
+            channel: "#team-iac-core"
+            text: "No `pulumi-yaml` release this week — no unreleased changes."


### PR DESCRIPTION
## Summary

Two follow-ups to #1094 after seeing the first run ([run 25923925369](https://github.com/pulumi/pulumi-yaml/actions/runs/25923925369)):

- **Fix `Install changie` step.** It was failing with `No GitHub token found` — `jaxxstorm/action-install-gh-release` makes an authenticated request to the GitHub releases API and falls over without a token. Pass `GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}` to the step. No new secret needed; this is the automatic token GitHub injects into every workflow.
- **Notify Slack when there's nothing to release.** Currently the workflow runs silently on weeks with no fragments. Added a second Slack step gated on `steps.check.outputs.has-changes == 'false'` posting `No \`pulumi-yaml\` release this week — no unreleased changes.` to `#team-iac-core`. The two notify steps are mutually exclusive on `has-changes`.

## Test plan

- [ ] `workflow_dispatch` with empty `.changes/unreleased/` → expect the `Install changie` step to succeed, the `Check for unreleased changes` step to set `has-changes=false`, and the `Notify Slack (no changes)` message to appear in `#team-iac-core`
- [ ] `workflow_dispatch` with a throwaway fragment → expect a release PR opened and the `Notify Slack (release ready)` message to appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)