### PR TITLE
Remove TestExampleGettingStarted

### DIFF
--- a/pkg/tests/example_test.go
+++ b/pkg/tests/example_test.go
@@ -57,11 +57,6 @@ func TestExampleAzureAppService(t *testing.T) {
 }
 
 //nolint:paralleltest // uses parallel programtest
-func TestExampleGettingStarted(t *testing.T) {
-	testWrapper(t, exampleDir("getting-started"), RequireLiveRun, awsConfig)
-}
-
-//nolint:paralleltest // uses parallel programtest
 func TestImportComputedID(t *testing.T) {
 	testWrapper(t, "./testdata/import-computed-id", RequireLiveRun, awsConfig)
 }


### PR DESCRIPTION
## Summary

Removes the flaky `TestExampleGettingStarted` live test. Fixes #481.

## Why the test is inherently flaky

The getting-started example creates an `aws:s3:BucketPublicAccessBlock` with `blockPublicAcls: false`. Three facts combine into a race that no test-side retry can avoid:

1. Since April 2023, AWS auto-provisions every new bucket with an all-true public access block.
2. `PutPublicAccessBlock` is eventually consistent, so a `GetPublicAccessBlock` immediately after the write can return the pre-existing values.
3. The upstream terraform-provider-aws create only waits for the configuration to *exist* (`tfresource.RetryWhenNotFound`), not for the read-back to *equal* what was written. The auto-provisioned block already exists, so the wait succeeds instantly and can persist the stale all-true values into state as the resource's outputs.

The subsequent `pulumi preview --expect-no-changes` in `ProgramTest` makes no AWS calls — it diffs the program's inputs against the stale state outputs and proposes an update:

```
~ blockPublicAcls      : true => false
- blockPublicPolicy    : true
- ignorePublicAcls     : true
- restrictPublicBuckets: true
error: no changes were expected for preview but changes were proposed
```

The flake is decided at `pulumi up` time, so retrying the preview (`RetryFailedSteps`) cannot help. The real fix is in the AWS provider: retry the create read-back until it matches the written configuration.

Latest occurrence: https://github.com/pulumi/pulumi-yaml/actions/runs/27281821732/job/80578126790

## What is kept

- `examples/getting-started/` itself, as documentation.
- The `getting-started` transpile coverage in `example_transpile_test.go`, which does not touch AWS.