### PR TITLE
get pulumi schema from submodule

### DIFF
--- a/scripts/get_schemas.sh
+++ b/scripts/get_schemas.sh
@@ -4,7 +4,7 @@ LIST_ONLY=${LIST_ONLY:-false}
 
 default_url_template='https://raw.githubusercontent.com/pulumi/pulumi-_NAME_/v_VERSION_/provider/cmd/pulumi-resource-_NAME_/schema.json'
 awsx_url='https://raw.githubusercontent.com/pulumi/pulumi-awsx/v_VERSION_/awsx/schema.json'
-function pulumi_schema { echo "$1@$2@https://raw.githubusercontent.com/pulumi/pulumi/master/tests/testdata/codegen/$1-$2.json"; }
+function pulumi_schema { echo "$1@$2@pulumi/tests/testdata/codegen/$1-$2.json"; }
 schemas=(
   "awsx@1.0.0-beta.5@${awsx_url}"
   "random@4.11.2"
@@ -43,8 +43,17 @@ for s in "${schemas[@]}"; do
       fi
   fi
   if [ ! -f "${FILEPATH}" ]; then
-    echo "Downloading ${FILEPATH} FROM ${URL}"
-    curl "${URL}" \
-      | jq ".version = \"${VERSION}\"" > "${FILEPATH}"
+    if [[ "${URL}" == http* ]]; then
+      echo "Downloading ${FILEPATH} from ${URL}"
+      curl "${URL}" \
+        | jq ".version = \"${VERSION}\"" > "${FILEPATH}"
+    else
+      if [ ! -f "${URL}" ]; then
+        echo "Missing ${URL}; run 'git submodule update --init' to fetch it" >&2
+        exit 1
+      fi
+      echo "Copying ${FILEPATH} from ${URL}"
+      jq ".version = \"${VERSION}\"" "${URL}" > "${FILEPATH}"
+    fi
   fi
 done


### PR DESCRIPTION
Rather than getting the schema from `pulumi/pulumi`s master branch (where it can and does change, for example in 0e567075aa4e366366a2fa98a062ea91f4cf8d85), get the schema from the submodule.  This way it always stays pinned, and we can fix the tests when we update the submodule, rather than them randomly breaking, when `pulumi/pulumi` makes changes.

This fixes https://github.com/pulumi/pulumi-yaml/issues/1131, as upstream removed `std:index:AbsMultiArgs` from the schema. Of course we still need to fix that test when we upgrade the submodule, but pinning this dependency seems like the right first step either way.

Fixes https://github.com/pulumi/pulumi-yaml/issues/1131