### PR TITLE
Remove unused `newPluginContext`

### DIFF
--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -5,21 +5,14 @@ package codegen
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
-	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"gopkg.in/yaml.v3"
 
@@ -33,46 +26,9 @@ import (
 // higher-level languages using PCL as an intermediate representation.
 type GenerateFunc func(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error)
 
-// newPluginContext constructs a plugin context backed by a freshly booted host. The host is owned
-// by the context as far as the caller is concerned, so the returned closer tears down both: the
-// context first, then the host it was bound to.
-func newPluginContext() (*plugin.Context, func(), error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, nil, err
-	}
-	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
-		Color: cmdutil.GetGlobalColorization(),
-	})
-	ctx := context.Background()
-	host, err := pkghost.New(ctx, sink, sink, nil, pkgWorkspace.EnsureLanguageInstalled)
-	if err != nil {
-		return nil, nil, err
-	}
-	pluginCtx, err := plugin.NewContext(ctx, sink, sink, host, nil, cwd, nil, true, nil,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
-	if err != nil {
-		contract.IgnoreClose(host)
-		return nil, nil, err
-	}
-	closer := func() {
-		contract.IgnoreClose(pluginCtx)
-		contract.IgnoreClose(host)
-	}
-	return pluginCtx, closer, nil
-}
-
 func ConvertTemplateIL(template *ast.TemplateDecl, loader schema.ReferenceLoader) (string, hcl.Diagnostics, error) {
+	contract.Assertf(loader != nil, "loader must be non-nil")
 	var diags hcl.Diagnostics
-
-	if loader == nil {
-		pluginCtx, closer, err := newPluginContext()
-		if err != nil {
-			return "", diags, err
-		}
-		defer closer()
-		loader = schema.NewPluginLoader(pluginCtx)
-	}
 
 	pkgLoader := pulumiyaml.NewPackageLoaderFromSchemaLoader(loader)
 	// nil runner passed in since template is not executed and we can use pkgLoader

--- a/pkg/pulumiyaml/codegen/eject.go
+++ b/pkg/pulumiyaml/codegen/eject.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -30,9 +31,7 @@ func Eject(dir string, loader schema.ReferenceLoader) (*workspace.Project, *pcl.
 	// To avoid panics (see https://github.com/pulumi/pulumi/issues/10875), we make it the
 	// caller's responsibility to cleanup the loader used. This prevents us from providing
 	// a default loader, since there would be no way to clean it up correctly.
-	if loader == nil {
-		panic("must provide a non-nil loader")
-	}
+	contract.Assertf(loader != nil, "must provide a non-nil loader")
 	proj, template, diags, err := LoadTemplate(dir)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
`newPluginContext` was called exclusively by `ConvertTemplateIL` to construct a loader when no loader is passed in. `newPluginContext` is only called by `ConvertTemplateIL`, which in turn is only called by `EjectProgram`, which is only called by `Eject`, which has always asserted it has a non-nil loader.

That means we can safely delete `newPluginContext` without effecting runtime behavior of `pulumi-yaml` at all.