### PR TITLE
Drop the pulumi/pulumi submodule

### DIFF
--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ref: ${{ inputs.commit-ref }}
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "pulumi"]
-	path = pulumi
-	url = https://github.com/pulumi/pulumi
-	branch = v3.250.0
-

--- a/scripts/get_schemas.sh
+++ b/scripts/get_schemas.sh
@@ -4,15 +4,11 @@ LIST_ONLY=${LIST_ONLY:-false}
 
 default_url_template='https://raw.githubusercontent.com/pulumi/pulumi-_NAME_/v_VERSION_/provider/cmd/pulumi-resource-_NAME_/schema.json'
 awsx_url='https://raw.githubusercontent.com/pulumi/pulumi-awsx/v_VERSION_/awsx/schema.json'
-function pulumi_schema { echo "$1@$2@pulumi/tests/testdata/codegen/$1-$2.json"; }
 schemas=(
   "awsx@1.0.0-beta.5@${awsx_url}"
   "random@4.11.2"
   "kubernetes@3.7.0"
   "aws@5.4.0"
-  $(pulumi_schema other 0.1.0)
-  $(pulumi_schema std 1.0.0) # there's no pulumi-std 1.0.0
-  $(pulumi_schema using-dashes 1.0.0)
 )
 
 for s in "${schemas[@]}"; do
@@ -43,17 +39,8 @@ for s in "${schemas[@]}"; do
       fi
   fi
   if [ ! -f "${FILEPATH}" ]; then
-    if [[ "${URL}" == http* ]]; then
-      echo "Downloading ${FILEPATH} from ${URL}"
-      curl "${URL}" \
-        | jq ".version = \"${VERSION}\"" > "${FILEPATH}"
-    else
-      if [ ! -f "${URL}" ]; then
-        echo "Missing ${URL}; run 'git submodule update --init' to fetch it" >&2
-        exit 1
-      fi
-      echo "Copying ${FILEPATH} from ${URL}"
-      jq ".version = \"${VERSION}\"" "${URL}" > "${FILEPATH}"
-    fi
+    echo "Downloading ${FILEPATH} from ${URL}"
+    curl "${URL}" \
+      | jq ".version = \"${VERSION}\"" > "${FILEPATH}"
   fi
 done


### PR DESCRIPTION
## Summary

Removes the `pulumi/pulumi` submodule, which was only used to source the synthetic test schemas (`other`, `std`, `using-dashes`) for the codegen and transpile tests.

Those schemas are now embedded in `github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils` (see pulumi/pulumi#23738), so the schema-only plugin host resolves them through the Go module. The host still falls back to the on-disk testdata directory for the real-provider schemas (`aws`, `awsx`, `kubernetes`) that `get_schemas.sh` downloads from provider releases.

## Changes

- Drop the submodule (`.gitmodules` + gitlink).
- Bump `pkg/v3` / `sdk/v3` to the embed-test-schemas build of pulumi/pulumi.
- `get_schemas.sh` no longer fetches the synthetic schemas via the submodule.
- Register the codegen test providers explicitly, since `utils.NewContext`'s
  defaults no longer include `aws`/`awsx`/`kubernetes`.
- Drop the now-unused `submodules: recursive` checkout from CI.