### PR TITLE
convert: allow empty files to be parsed

### DIFF
--- a/pkg/pulumiyaml/codegen/convert.go
+++ b/pkg/pulumiyaml/codegen/convert.go
@@ -101,6 +101,9 @@ func parseSnippetExpr(filename string, source []byte) (ast.Expr, syntax.Diagnost
 		diags.Extend(syntax.Error(nil, err.Error(), ""))
 		return nil, diags
 	}
+	if yamlNode.Kind == 0 {
+		return nil, diags
+	}
 	// yaml.Unmarshal wraps the parsed value in a document node; unwrap so UnmarshalYAML sees the
 	// real content.
 	if yamlNode.Kind == yaml.DocumentNode {
@@ -141,6 +144,9 @@ func ImportSnippet(
 	diags.Extend(pdiags...)
 	if pdiags.HasErrors() {
 		return nil, diags, nil
+	}
+	if expr == nil {
+		return &model.Body{}, diags, nil
 	}
 	obj, ok := expr.(*ast.ObjectExpr)
 	if !ok {

--- a/pkg/pulumiyaml/codegen/convert_test.go
+++ b/pkg/pulumiyaml/codegen/convert_test.go
@@ -187,6 +187,20 @@ extra = "hello"
 `,
 		},
 		{
+			name:     "empty source",
+			token:    "snippet:index:Bucket",
+			filename: "inputs.yaml",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "comments-only source",
+			token:    "pulumi:providers:snippet",
+			filename: "provider.yaml",
+			input:    "# no config\n",
+			expected: "",
+		},
+		{
 			name:     "fn::length builtin",
 			token:    "snippet:index:Bucket",
 			filename: "inputs.yaml",


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/23948, `pulumi do` can send empty files to the converter.  Yaml currently errors out on that, even though it can be a valid state for `pulumi do` to be in (e.g. if only flags are passed for provider configuration, but no file):

```
    error: parse provider file: <no provider file>:0,0-0: unexpected node kind 0;
```

Fix this by not erroring out just because we try to convert an empty file.